### PR TITLE
Update wasm target

### DIFF
--- a/.changeset/new-news-smile.md
+++ b/.changeset/new-news-smile.md
@@ -1,0 +1,5 @@
+---
+"yak-swc": patch
+---
+
+Update wasm target to wasm-wasip1

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -42,8 +42,8 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Add wasm32-wasi target
-        run: rustup target add wasm32-wasi
+      - name: Add wasm32-wasip1 target
+        run: rustup target add wasm32-wasip1
 
       - name: Enable caching
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,8 +50,8 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Add wasm32-wasi target
-        run: rustup target add wasm32-wasi
+      - name: Add wasm32-wasip1 target
+        run: rustup target add wasm32-wasip1
 
       - name: Enable caching
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -44,8 +44,8 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
-      - name: Add wasm32-wasi target
-        run: rustup target add wasm32-wasi
+      - name: Add wasm32-wasip1 target
+        run: rustup target add wasm32-wasip1
       - name: Enable caching
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -41,8 +41,8 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
-      - name: Add wasm32-wasi target
-        run: rustup target add wasm32-wasi
+      - name: Add wasm32-wasip1 target
+        run: rustup target add wasm32-wasip1
       - name: Enable caching
         uses: Swatinem/rust-cache@v2
         with:

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -31,7 +31,7 @@ Before you begin
   Install Rust from [rust-lang.org](https://www.rust-lang.org/tools/install), following the official instructions for your platform
 - Add the Rust WebAssembly target, execute
   ```bash
-  rustup target add wasm32-wasi
+  rustup target add wasm32-wasip1
   ```
 
 ### Initial setup
@@ -183,7 +183,7 @@ export default withYak({
 ### Rust setup issues
 
 - **Permission problems with Rust**: Make sure to install Rust from [rust-lang.org](https://www.rust-lang.org/tools/install) and not through package managers
-- **Missing wasm32-wasi target**: Run `rustup target add wasm32-wasi`
+- **Missing wasm32-wasip1 target**: Run `rustup target add wasm32-wasip1`
 - **Cargo build failures**: Ensure you have the latest stable Rust toolchain with `rustup update stable`
 
 ### Build issues

--- a/packages/docs/app/api/transform/route.ts
+++ b/packages/docs/app/api/transform/route.ts
@@ -1,17 +1,17 @@
-import { NextRequest, NextResponse } from "next/server";
-import { type Compilation } from "webpack";
 import * as swc from "@swc/core";
+import { NextRequest, NextResponse } from "next/server";
+import path from "path";
+import { type Compilation } from "webpack";
 // had to update package exports
 // @ts-ignore
 import cssLoader = require("next-yak/loaders/css-loader");
-import path from "path";
 
 export const maxDuration = 60;
 
 const wasmPath = path.resolve(
   process.cwd(),
   "./node_modules",
-  "yak-swc/target/wasm32-wasi/release/yak_swc.wasm",
+  "yak-swc/target/wasm32-wasip1/release/yak_swc.wasm",
 );
 
 export async function POST(request: NextRequest) {

--- a/packages/docs/next.config.mjs
+++ b/packages/docs/next.config.mjs
@@ -1,5 +1,5 @@
 import { createMDX } from "fumadocs-mdx/next";
-import {withYak} from "next-yak/withYak";
+import { withYak } from "next-yak/withYak";
 
 const withMDX = createMDX();
 
@@ -16,11 +16,11 @@ const config = {
   },
   outputFileTracingIncludes: {
     // add yak-swc as a dependency for the /api/transform route
-    '/api/transform': ['./node_modules/yak-swc/*'],
-    '/api/transform': ['./node_modules/yak-swc/target/wasm32-wasi/release/*'],
+    "/api/transform": ["./node_modules/yak-swc/*"],
+    "/api/transform": ["./node_modules/yak-swc/target/wasm32-wasip1/release/*"],
   },
   outputFileTracingExcludes: {
-    '/api/transform': ['../../node_modules/yak-swc/**/*'],
+    "/api/transform": ["../../node_modules/yak-swc/**/*"],
   },
   // use the raw-loader for .d.ts files (used by the playground)
   webpack: (config) => {

--- a/packages/yak-swc/package.json
+++ b/packages/yak-swc/package.json
@@ -18,9 +18,9 @@
     "react",
     "typescript"
   ],
-  "main": "target/wasm32-wasi/release/yak_swc.wasm",
+  "main": "target/wasm32-wasip1/release/yak_swc.wasm",
   "scripts": {
-    "build": "cargo build --release --target=wasm32-wasi",
+    "build": "cargo build --release --target=wasm32-wasip1",
     "prepublishOnly": "node ../../scripts/check-pnpm.js && npm run build",
     "prettier": "cargo fmt --all",
     "test": "cargo test",

--- a/packages/yak-swc/yak_swc/.cargo/config
+++ b/packages/yak-swc/yak_swc/.cargo/config
@@ -1,5 +1,5 @@
 # These command aliases are not final, may change
 [alias]
 # Alias to build actual plugin binary for the specified target.
-build-wasi = "build --target wasm32-wasi"
+build-wasip1 = "build --target wasm32-wasip1"
 build-wasm32 = "build --target wasm32-unknown-unknown"


### PR DESCRIPTION
Update deprecated `wasm-wasi` target to `wasm-wasip1`

> warning: the `wasm32-wasi` target is being renamed to `wasm32-wasip1` and the `wasm32-wasi` target will be removed from nightly in October 2024 and removed from stable Rust in January 2025