### PR TITLE
Improve css-loader cache to avoid failing build with nextjs and webpack

### DIFF
--- a/.changeset/gentle-dragons-count.md
+++ b/.changeset/gentle-dragons-count.md
@@ -1,0 +1,5 @@
+---
+"next-yak": patch
+---
+
+Improve css-loader cache to avoid failing build with nextjs and webpack.

--- a/packages/next-yak/loaders/css-loader.ts
+++ b/packages/next-yak/loaders/css-loader.ts
@@ -12,7 +12,7 @@ import { resolveCrossFileConstant } from "./lib/resolveCrossFileSelectors.js";
 export default async function cssExtractLoader(
   this: LoaderContext<YakConfigOptions>,
   // Instead of the source code, we receive the extracted css
-  // from the ts-loader transformation
+  // from the yak-swc transformation
   _code: string,
   sourceMap: string | undefined,
 ): Promise<string | void> {

--- a/packages/next-yak/package.json
+++ b/packages/next-yak/package.json
@@ -60,9 +60,7 @@
       "require": "./dist/jsx-dev-runtime.cjs",
       "import": "./dist/jsx-dev-runtime.js"
     },
-    "./loaders/css-loader": {
-      "require": "./dist/loaders/css-loader.cjs"
-    }
+    "./loaders/css-loader":  "./dist/loaders/css-loader.js"
   },
   "scripts": {
     "prepublishOnly": "node ../../scripts/check-pnpm.js && npm run build && npm run test && npm run test:types:code && npm run test:types:test",

--- a/packages/next-yak/tsup.config.ts
+++ b/packages/next-yak/tsup.config.ts
@@ -95,10 +95,9 @@ export default defineConfig([
   // loaders
   {
     entryPoints: [
-      "loaders/ts-loader.ts",
       "loaders/css-loader.ts",
     ],
-    format: ["cjs"],
+    format: ["esm"],
     minify: false,
     sourcemap: true,
     clean: false,

--- a/packages/next-yak/withYak/index.ts
+++ b/packages/next-yak/withYak/index.ts
@@ -52,7 +52,7 @@ const addYak = (yakOptions: YakConfigOptions, nextConfig: NextConfig) => {
 
     webpackConfig.module.rules.push({
       test: /\.yak\.module\.css$/,
-      loader: path.join(currentDir, "../loaders/css-loader.cjs"),
+      loader: path.join(currentDir, "../loaders/css-loader.js"),
       options: yakOptions,
     });
 


### PR DESCRIPTION
After migrating more and more styled-components usages to next-yak, we started to experience failed nextjs builds (next build). The build ended without any error message and with a success status code, which is quite strange. After some time analyzing the issue, we were able to relate the issue to the parsed files cache within the css-loader.

Initially, the cache stored the promise resolving and parsing a module and its dependencies. A parallel request resolving the same module would, therefore, await the same promise and not load the module again. This likely led to a deadlock, or it has just exceeded the maximum number of concurrent loader executions.

Removing the cache solved the issue but slowed the build down quite a bit. With this PR, we change the cache to only cache the final result with the compromise of having the same module resolved more than once if requested simultaneously. Our performance test showed the exact same build time but without any failing builds.