### PR TITLE
Add css prop to all components that can receive className

### DIFF
--- a/.changeset/fluffy-otters-brush.md
+++ b/.changeset/fluffy-otters-brush.md
@@ -1,0 +1,5 @@
+---
+"next-yak": patch
+---
+
+Automatically add the css prop to all components that can receive `className`

--- a/packages/docs/content/docs/features.mdx
+++ b/packages/docs/content/docs/features.mdx
@@ -552,6 +552,8 @@ const Component = () => {
 
 It's meant for simple styling requirements, where you don't have to think about a name for a specialized component.
 
+The `css` prop is allowed on any element that can accept `className` and `style`.
+
 ### TypeScript
 
 To use it with the correct types just add the following line to the top of the file

--- a/packages/next-yak/runtime/__tests__/cssPropTest.tsx
+++ b/packages/next-yak/runtime/__tests__/cssPropTest.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource next-yak */
 // this is only a type check file and should not be executed
 
-import { css, CSSProp, styled } from "next-yak";
+import { css, styled } from "next-yak";
 import { CSSProperties } from "react";
 
 declare module "next-yak" {
@@ -28,10 +28,31 @@ const NestedComponentWithCssProp = () => (
   </div>
 );
 
-const ComponentThatTakesCssProp = (p: CSSProp) => <div {...p}>anything</div>;
+const ComponentThatTakesCssProp = (p: { className?: string }) => (
+  <div {...p}>anything</div>
+);
+
+const ComponentThatTakesCssProp2 = (p: { className?: string | string[] }) => (
+  <div {...(p as any)}>anything</div>
+);
+
+const ComponentThatTakesCssProp3 = (p: { className: string }) => (
+  <div {...p}>anything</div>
+);
+
+const ComponentThatTakesCssProp4 = (p: { className?: unknown }) => (
+  <div {...(p as any)}>anything</div>
+);
 
 const ComponentWithCssPropAsProp = () => {
-  return <ComponentThatTakesCssProp css={css``} />;
+  return (
+    <>
+      <ComponentThatTakesCssProp css={css``} />
+      <ComponentThatTakesCssProp2 css={css``} />
+      <ComponentThatTakesCssProp3 css={css``} className="" />
+      <ComponentThatTakesCssProp4 css={css``} />
+    </>
+  );
 };
 
 const ObjectWithComponent = {

--- a/packages/next-yak/runtime/cssLiteral.tsx
+++ b/packages/next-yak/runtime/cssLiteral.tsx
@@ -1,31 +1,9 @@
-import { CSSProperties } from "react";
 import type { YakTheme } from "./index.d.ts";
 
 export const yakComponentSymbol = Symbol("yak");
 
 export type ComponentStyles<TProps> = (props: TProps) => {
   className: string;
-  style?: {
-    [key: string]: string;
-  };
-};
-
-/**
- * Convenience type to specify the CSS prop type.
- * This type is used to allow the css prop on components.
- *
- * @example
- * ```tsx
- * const ComponentThatTakesCssProp = (p: CSSProp) =>
- *   <div {...p}>anything</div>;
- * ```
- */
-export type CSSProp = {
-  /** This prop is transformed during compilation and doesn't exist at runtime. */
-  css?: ComponentStyles<Record<keyof any, never>>;
-  /** The css prop will return the name of the class and automatically merged with an existing class */
-  className?: string;
-  /** The css prop will return the style object and automatically merged with an existing style */
   style?: {
     [key: string]: string;
   };

--- a/packages/next-yak/runtime/index.ts
+++ b/packages/next-yak/runtime/index.ts
@@ -28,6 +28,6 @@ export { useTheme, YakThemeProvider } from "next-yak/context";
 export type { YakTheme } from "./context/index.d.ts";
 
 export { atoms } from "./atoms.js";
-export { css, type CSSProp } from "./mocks/cssLiteral.js";
+export { css } from "./mocks/cssLiteral.js";
 export { keyframes } from "./mocks/keyframes.js";
 export { styled } from "./mocks/styled.js";

--- a/packages/next-yak/runtime/jsx-runtime.ts
+++ b/packages/next-yak/runtime/jsx-runtime.ts
@@ -1,6 +1,12 @@
 import ReactJSXRuntime from "react/jsx-runtime";
 import type { ComponentStyles } from "./mocks/cssLiteral.js";
 
+type WithConditionalCSSProp<P> = "className" extends keyof P
+  ? string extends P["className" & keyof P]
+    ? { css?: ComponentStyles<Record<keyof any, never>> }
+    : {}
+  : {};
+
 const Fragment = ReactJSXRuntime.Fragment;
 const jsx = ReactJSXRuntime.jsx;
 const jsxs = ReactJSXRuntime.jsxs;
@@ -11,11 +17,15 @@ export declare namespace YakJSX {
   export type ElementClass = React.JSX.ElementClass;
   export type ElementAttributesProperty = React.JSX.ElementAttributesProperty;
   export type ElementChildrenAttribute = React.JSX.ElementChildrenAttribute;
-  export type LibraryManagedAttributes<C, P> =
-    React.JSX.LibraryManagedAttributes<C, P>;
+
+  export type LibraryManagedAttributes<C, P> = P extends unknown
+    ? WithConditionalCSSProp<P> & React.JSX.LibraryManagedAttributes<C, P>
+    : never;
+
   export type IntrinsicAttributes = React.JSX.IntrinsicAttributes;
   export type IntrinsicClassAttributes<T> =
     React.JSX.IntrinsicClassAttributes<T>;
+
   export type IntrinsicElements = {
     [K in keyof React.JSX.IntrinsicElements]: React.JSX.IntrinsicElements[K] & {
       css?: ComponentStyles<Record<keyof any, never>>;

--- a/packages/next-yak/runtime/mocks/cssLiteral.ts
+++ b/packages/next-yak/runtime/mocks/cssLiteral.ts
@@ -1,10 +1,6 @@
 import type { css as cssInternal, PropsToClassNameFn } from "../cssLiteral.js";
 
-export type {
-  ComponentStyles,
-  CSSInterpolation,
-  CSSProp,
-} from "../cssLiteral.js";
+export type { ComponentStyles, CSSInterpolation } from "../cssLiteral.js";
 
 /**
  * Allows to use CSS styles in a styled or css block


### PR DESCRIPTION
This PR improves the types.

The `css` prop is automatically added to all components that can receive a `className`. This ensures the correct API and type safety guarantees before and after the transpilation.

Huge thanks to `emotion`, where I saw how genius this solution is.