### PR TITLE
Mark __yak_unitPostFix as pure

### DIFF
--- a/.changeset/giant-bobcats-sleep.md
+++ b/.changeset/giant-bobcats-sleep.md
@@ -1,0 +1,5 @@
+---
+"yak-swc": patch
+---
+
+Mark `__yak_unitPostFix` as pure (generated code)

--- a/packages/yak-swc/yak_swc/src/utils/add_suffix_to_expr.rs
+++ b/packages/yak-swc/yak_swc/src/utils/add_suffix_to_expr.rs
@@ -1,5 +1,5 @@
 use swc_core::{
-  common::{SyntaxContext, DUMMY_SP},
+  common::{source_map::PURE_SP, SyntaxContext, DUMMY_SP},
   ecma::ast::*,
 };
 
@@ -8,7 +8,7 @@ use swc_core::{
 pub fn add_suffix_to_expr(expr: Expr, helper: Ident, suffix: impl AsRef<str>) -> Expr {
   // Otherwise, replace the expression with a call to the utility function
   Expr::Call(CallExpr {
-    span: DUMMY_SP,
+    span: PURE_SP,
     ctxt: SyntaxContext::empty(),
     callee: Callee::Expr(helper.into()),
     args: vec![

--- a/packages/yak-swc/yak_swc/tests/fixture/css-mixin-nested/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-mixin-nested/output.dev.tsx
@@ -3,11 +3,11 @@ import * as __yak from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
 const buttonStyles = /*#__PURE__*/ css(({ $active })=>$active && /*#__PURE__*/ css(__styleYak.buttonStyles__$active, {
         "style": {
-            "--buttonStyles__max-width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--buttonStyles__max-width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), {
     "style": {
-        "--buttonStyles__width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--buttonStyles__width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });
 export const ThemedButton = /*YAK Extracted CSS:
@@ -28,11 +28,11 @@ export const ThemedButton = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active, {
         "style": {
-            "--ThemedButton__max-width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--ThemedButton__max-width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), {
     "style": {
-        "--ThemedButton__width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--ThemedButton__width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });
 export const CustomThemedButton = /*YAK Extracted CSS:
@@ -60,10 +60,10 @@ export const CustomThemedButton = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.CustomThemedButton__$active, {
         "style": {
-            "--CustomThemedButton__max-width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--CustomThemedButton__max-width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), {
     "style": {
-        "--CustomThemedButton__width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--CustomThemedButton__width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/css-mixin-nested/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-mixin-nested/output.prod.tsx
@@ -3,11 +3,11 @@ import * as __yak from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
 const buttonStyles = /*#__PURE__*/ css(({ $active })=>$active && /*#__PURE__*/ css(__styleYak.buttonStyles__$active, {
         "style": {
-            "--ym7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--ym7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), {
     "style": {
-        "--ym7uBBu1": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--ym7uBBu1": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });
 export const ThemedButton = /*YAK Extracted CSS:
@@ -28,11 +28,11 @@ export const ThemedButton = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active, {
         "style": {
-            "--ym7uBBu2": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--ym7uBBu2": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), {
     "style": {
-        "--ym7uBBu3": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--ym7uBBu3": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });
 export const CustomThemedButton = /*YAK Extracted CSS:
@@ -60,10 +60,10 @@ export const CustomThemedButton = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.CustomThemedButton__$active, {
         "style": {
-            "--ym7uBBu4": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--ym7uBBu4": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), {
     "style": {
-        "--ym7uBBu5": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--ym7uBBu5": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/css-mixin/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-mixin/output.dev.tsx
@@ -3,13 +3,13 @@ import * as __yak from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
 const buttonStyles = /*#__PURE__*/ css(({ $active })=>$active && /*#__PURE__*/ css(__styleYak.buttonStyles__$active, {
         "style": {
-            "--buttonStyles__max-width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--buttonStyles__max-width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), function({ $letters }) {
     return $letters > 5 && /*#__PURE__*/ css(__styleYak.buttonStyles__);
 }, {
     "style": {
-        "--buttonStyles__width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--buttonStyles__width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });
 export const ThemedButton = /*YAK Extracted CSS:
@@ -31,13 +31,13 @@ export const ThemedButton = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active, {
         "style": {
-            "--ThemedButton__max-width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--ThemedButton__max-width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), function({ $letters }) {
     return $letters > 5 && /*#__PURE__*/ css(__styleYak.ThemedButton__);
 }, {
     "style": {
-        "--ThemedButton__width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--ThemedButton__width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });
 export const CustomThemedButton = /*YAK Extracted CSS:
@@ -60,12 +60,12 @@ export const CustomThemedButton = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.CustomThemedButton__$active, {
         "style": {
-            "--CustomThemedButton__max-width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--CustomThemedButton__max-width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), function({ $letters }) {
     return $letters > 5 && /*#__PURE__*/ css(__styleYak.CustomThemedButton__);
 }, {
     "style": {
-        "--CustomThemedButton__width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--CustomThemedButton__width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/css-mixin/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-mixin/output.prod.tsx
@@ -3,13 +3,13 @@ import * as __yak from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
 const buttonStyles = /*#__PURE__*/ css(({ $active })=>$active && /*#__PURE__*/ css(__styleYak.buttonStyles__$active, {
         "style": {
-            "--ym7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--ym7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), function({ $letters }) {
     return $letters > 5 && /*#__PURE__*/ css(__styleYak.buttonStyles__);
 }, {
     "style": {
-        "--ym7uBBu1": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--ym7uBBu1": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });
 export const ThemedButton = /*YAK Extracted CSS:
@@ -31,13 +31,13 @@ export const ThemedButton = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active, {
         "style": {
-            "--ym7uBBu2": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--ym7uBBu2": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), function({ $letters }) {
     return $letters > 5 && /*#__PURE__*/ css(__styleYak.ThemedButton__);
 }, {
     "style": {
-        "--ym7uBBu3": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--ym7uBBu3": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });
 export const CustomThemedButton = /*YAK Extracted CSS:
@@ -60,12 +60,12 @@ export const CustomThemedButton = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.CustomThemedButton__$active, {
         "style": {
-            "--ym7uBBu4": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--ym7uBBu4": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), function({ $letters }) {
     return $letters > 5 && /*#__PURE__*/ css(__styleYak.CustomThemedButton__);
 }, {
     "style": {
-        "--ym7uBBu5": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--ym7uBBu5": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/output.dev.tsx
@@ -9,7 +9,7 @@ export const FlexContainer = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ __yak.__yak_div(__styleYak.FlexContainer, {
     "style": {
-        "--FlexContainer__margin-bottom_m7uBBu": __yak_unitPostFix(spacing[40].toString(), "px"),
+        "--FlexContainer__margin-bottom_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(spacing[40].toString(), "px"),
         "--FlexContainer__z-index_m7uBBu": getZIndex()
     }
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/output.prod.tsx
@@ -10,6 +10,6 @@ export const FlexContainer = /*YAK Extracted CSS:
 */ /*#__PURE__*/ __yak.__yak_div(__styleYak.FlexContainer, {
     "style": {
         "--ym7uBBu": getZIndex(),
-        "--ym7uBBu1": __yak_unitPostFix(spacing[40].toString(), "px")
+        "--ym7uBBu1": /*#__PURE__*/ __yak_unitPostFix(spacing[40].toString(), "px")
     }
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/nested-dynamic-mixin/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/nested-dynamic-mixin/output.dev.tsx
@@ -21,6 +21,6 @@ const ContainerFluid = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ __yak.__yak_div(__styleYak.ContainerFluid, ({ $isApp, $pageHeaderHeight })=>$isApp ? /*#__PURE__*/ css(__styleYak.ContainerFluid__$isApp) : /*#__PURE__*/ css(__styleYak.ContainerFluid__not_$isApp), {
     "style": {
-        "--ContainerFluid__margin-top_m7uBBu": __yak_unitPostFix(({ $pageHeaderHeight })=>$pageHeaderHeight, "px")
+        "--ContainerFluid__margin-top_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $pageHeaderHeight })=>$pageHeaderHeight, "px")
     }
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/nested-dynamic-mixin/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/nested-dynamic-mixin/output.prod.tsx
@@ -21,6 +21,6 @@ const ContainerFluid = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ __yak.__yak_div(__styleYak.ContainerFluid, ({ $isApp, $pageHeaderHeight })=>$isApp ? /*#__PURE__*/ css(__styleYak.ContainerFluid__$isApp) : /*#__PURE__*/ css(__styleYak.ContainerFluid__not_$isApp), {
     "style": {
-        "--ym7uBBu": __yak_unitPostFix(({ $pageHeaderHeight })=>$pageHeaderHeight, "px")
+        "--ym7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $pageHeaderHeight })=>$pageHeaderHeight, "px")
     }
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/parens/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/parens/output.dev.tsx
@@ -14,7 +14,7 @@ translate(0, -88px) rotate(var(--Card__transform_m7uBBu-01));
 }
 */ /*#__PURE__*/ __yak.__yak_div(__styleYak.Card, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.Card__$active), {
     "style": {
-        "--Card__transform_m7uBBu": __yak_unitPostFix(({ index })=>index * 30, "deg"),
-        "--Card__transform_m7uBBu-01": __yak_unitPostFix(({ index })=>-index * 30, "deg")
+        "--Card__transform_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ index })=>index * 30, "deg"),
+        "--Card__transform_m7uBBu-01": /*#__PURE__*/ __yak_unitPostFix(({ index })=>-index * 30, "deg")
     }
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/parens/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/parens/output.prod.tsx
@@ -14,7 +14,7 @@ translate(0, -88px) rotate(var(--ym7uBBu1));
 }
 */ /*#__PURE__*/ __yak.__yak_div(__styleYak.Card, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.Card__$active), {
     "style": {
-        "--ym7uBBu": __yak_unitPostFix(({ index })=>index * 30, "deg"),
-        "--ym7uBBu1": __yak_unitPostFix(({ index })=>-index * 30, "deg")
+        "--ym7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ index })=>index * 30, "deg"),
+        "--ym7uBBu1": /*#__PURE__*/ __yak_unitPostFix(({ index })=>-index * 30, "deg")
     }
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.dev.tsx
@@ -17,14 +17,14 @@ export const FlexContainer = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ __yak.__yak_div(__styleYak.FlexContainer, ({ $bottom })=>/*#__PURE__*/ css(__styleYak.FlexContainer__, {
         "style": {
-            "--FlexContainer__bottom_m7uBBu": __yak_unitPostFix($bottom * 20, "%")
+            "--FlexContainer__bottom_m7uBBu": /*#__PURE__*/ __yak_unitPostFix($bottom * 20, "%")
         }
     }), {
     "style": {
         "--FlexContainer__align-items_m7uBBu": ({ $align })=>$align || 'stretch',
         "--FlexContainer__flex-direction_m7uBBu": ({ $direction })=>$direction || 'row',
         "--FlexContainer__justify-content_m7uBBu": ({ $justify })=>$justify || 'flex-start',
-        "--FlexContainer__margin-bottom_m7uBBu": __yak_unitPostFix(({ $marginBottom })=>$marginBottom || '0', "px"),
-        "--FlexContainer__top_m7uBBu": __yak_unitPostFix(({ $top })=>$top * 20, "%")
+        "--FlexContainer__margin-bottom_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $marginBottom })=>$marginBottom || '0', "px"),
+        "--FlexContainer__top_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $top })=>$top * 20, "%")
     }
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.prod.tsx
@@ -17,14 +17,14 @@ export const FlexContainer = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ __yak.__yak_div(__styleYak.FlexContainer, ({ $bottom })=>/*#__PURE__*/ css(__styleYak.FlexContainer__, {
         "style": {
-            "--ym7uBBu5": __yak_unitPostFix($bottom * 20, "%")
+            "--ym7uBBu5": /*#__PURE__*/ __yak_unitPostFix($bottom * 20, "%")
         }
     }), {
     "style": {
         "--ym7uBBu": ({ $align })=>$align || 'stretch',
         "--ym7uBBu1": ({ $direction })=>$direction || 'row',
         "--ym7uBBu2": ({ $justify })=>$justify || 'flex-start',
-        "--ym7uBBu3": __yak_unitPostFix(({ $marginBottom })=>$marginBottom || '0', "px"),
-        "--ym7uBBu4": __yak_unitPostFix(({ $top })=>$top * 20, "%")
+        "--ym7uBBu3": /*#__PURE__*/ __yak_unitPostFix(({ $marginBottom })=>$marginBottom || '0', "px"),
+        "--ym7uBBu4": /*#__PURE__*/ __yak_unitPostFix(({ $top })=>$top * 20, "%")
     }
 });


### PR DESCRIPTION
Uses the magic [PURE_SP](https://docs.rs/swc_common/latest/swc_common/source_map/constant.PURE_SP.html) span to mark the call to `__yak_unitPostFix` as
pure. Swc code-gen will inject a `/* #__PURE__ */` comment when it sees the byte offset of that span.

That way, more code for unused components can be
removed by the usual dead code analysis.

Fixes #228