### PR TITLE
Add `experiments.displayNames` option

### DIFF
--- a/.changeset/three-readers-smoke.md
+++ b/.changeset/three-readers-smoke.md
@@ -1,0 +1,6 @@
+---
+"next-yak": minor
+"yak-swc": minor
+---
+
+Add `experiments.displayNames` setting

--- a/.changeset/three-readers-smoke.md
+++ b/.changeset/three-readers-smoke.md
@@ -3,4 +3,4 @@
 "yak-swc": minor
 ---
 
-Add `experiments.displayNames` setting
+Improved React DevTools support - Styled components created with next-yak now show up with their actual variable names in React DevTools instead of a generic yak label

--- a/packages/cross-file-tests/__tests__/fixtures/constant/output/index.tsx
+++ b/packages/cross-file-tests/__tests__/fixtures/constant/output/index.tsx
@@ -14,7 +14,9 @@ export var Button = /*YAK Extracted CSS:
   color: --yak-css-import: url("./constants:colors:secondary",mixin);
   background-color: --yak-css-import: url("./constants:colors:primary",mixin);
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button, function(param) {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button, function(param) {
     var $variant = param.$variant;
     return $variant === "secondary" && /*#__PURE__*/ css(__styleYak.Button__);
+}), {
+    "displayName": "Button"
 });

--- a/packages/cross-file-tests/__tests__/fixtures/namespaceConstant/output/index.tsx
+++ b/packages/cross-file-tests/__tests__/fixtures/namespaceConstant/output/index.tsx
@@ -7,4 +7,6 @@ export var Button = /*YAK Extracted CSS:
   color: --yak-css-import: url("./constants:colors:primary",mixin);
   background-color: --yak-css-import: url("./constants:colors:secondary",mixin);
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button);
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+    "displayName": "Button"
+});

--- a/packages/cross-file-tests/__tests__/fixtures/nestedMixin/output/icon.tsx
+++ b/packages/cross-file-tests/__tests__/fixtures/nestedMixin/output/icon.tsx
@@ -7,4 +7,6 @@ export var Icon = /*YAK Extracted CSS:
   width: 20px;
   height: 20px;
 }
-*/ /*#__PURE__*/ __yak.__yak_span(__styleYak.Icon);
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_span(__styleYak.Icon), {
+    "displayName": "Icon"
+});

--- a/packages/cross-file-tests/__tests__/fixtures/nestedMixin/output/index.tsx
+++ b/packages/cross-file-tests/__tests__/fixtures/nestedMixin/output/index.tsx
@@ -7,9 +7,13 @@ export var Button = /*YAK Extracted CSS:
 .Button {
   --yak-css-import: url("./mixin:buttonMixin",mixin);
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button);
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+    "displayName": "Button"
+});
 export var PrimaryButton = /*YAK Extracted CSS:
 .PrimaryButton {
   --yak-css-import: url("./helper/anotherMixin:primaryButtonMixin",mixin);
 }
-*/ /*#__PURE__*/ styled(Button)(__styleYak.PrimaryButton);
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(Button)(__styleYak.PrimaryButton), {
+    "displayName": "PrimaryButton"
+});

--- a/packages/cross-file-tests/__tests__/fixtures/sameFileMixin/output/index.tsx
+++ b/packages/cross-file-tests/__tests__/fixtures/sameFileMixin/output/index.tsx
@@ -18,7 +18,7 @@ var Button = /*YAK Extracted CSS:
 .Button__$disabled-01 {
   color: gray;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button, function(param) {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button, function(param) {
     var $disabled = param.$disabled;
     return $disabled && /*#__PURE__*/ css(__styleYak.Button__$disabled);
 }, function(param) {
@@ -27,5 +27,7 @@ var Button = /*YAK Extracted CSS:
 }, function(param) {
     var $disabled = param.$disabled;
     return $disabled && /*#__PURE__*/ css(__styleYak["Button__$disabled-01"]);
+}), {
+    "displayName": "Button"
 });
 export default Button;

--- a/packages/cross-file-tests/__tests__/fixtures/selector/output/icon.tsx
+++ b/packages/cross-file-tests/__tests__/fixtures/selector/output/icon.tsx
@@ -1,5 +1,9 @@
 import { styled } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
 import __styleYak from "./icon.yak.module.css!=!./icon?./icon.yak.module.css";
-export var Icon = /*#__PURE__*/ __yak.__yak_svg();
-export var AnyIcon = /*#__PURE__*/ __yak.__yak_svg();
+export var Icon = /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_svg(), {
+    "displayName": "Icon"
+});
+export var AnyIcon = /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_svg(), {
+    "displayName": "AnyIcon"
+});

--- a/packages/cross-file-tests/__tests__/fixtures/selector/output/index.tsx
+++ b/packages/cross-file-tests/__tests__/fixtures/selector/output/index.tsx
@@ -11,4 +11,6 @@ export var Button = /*YAK Extracted CSS:
     margin-right: 15px;
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button);
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+    "displayName": "Button"
+});

--- a/packages/cross-file-tests/__tests__/fixtures/staticMixin/output/index.tsx
+++ b/packages/cross-file-tests/__tests__/fixtures/staticMixin/output/index.tsx
@@ -9,5 +9,7 @@ var ListItem = /*YAK Extracted CSS:
     --yak-css-import: url("./mixin:lastChildMixin",mixin);
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_li(__styleYak.ListItem);
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_li(__styleYak.ListItem), {
+    "displayName": "ListItem"
+});
 export default ListItem;

--- a/packages/cross-file-tests/__tests__/fixtures/yak-file/output/index.tsx
+++ b/packages/cross-file-tests/__tests__/fixtures/yak-file/output/index.tsx
@@ -7,4 +7,6 @@ export var Button = /*YAK Extracted CSS:
   color: red;
   height: --yak-css-import: url("./constants.yak:siteMaxWidth",mixin)px;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button);
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+    "displayName": "Button"
+});

--- a/packages/cross-file-tests/__tests__/fixtures/yakFileMixin/output/index.tsx
+++ b/packages/cross-file-tests/__tests__/fixtures/yakFileMixin/output/index.tsx
@@ -7,10 +7,14 @@ export var Headline = /*YAK Extracted CSS:
   color: red;
   --yak-css-import: url("./typography.yak:typography:h1",mixin);
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Headline);
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Headline), {
+    "displayName": "Headline"
+});
 export var Button = /*YAK Extracted CSS:
 .Button {
   color: red;
   --yak-css-import: url("./typography.yak:typography:h3",mixin);
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button);
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+    "displayName": "Button"
+});

--- a/packages/example/next.config.mjs
+++ b/packages/example/next.config.mjs
@@ -13,4 +13,8 @@ const nextConfig = {
   // },
 };
 
-export default withYak(nextConfig);
+export default withYak({
+  experiments: {
+    displayNames: true,
+  }
+}, nextConfig);

--- a/packages/example/next.config.mjs
+++ b/packages/example/next.config.mjs
@@ -13,8 +13,4 @@ const nextConfig = {
   // },
 };
 
-export default withYak({
-  experiments: {
-    displayNames: true,
-  }
-}, nextConfig);
+export default withYak(nextConfig);

--- a/packages/next-yak/withYak/index.ts
+++ b/packages/next-yak/withYak/index.ts
@@ -28,6 +28,12 @@ export type YakConfigOptions = {
           filter?: (path: string) => boolean;
           type: "all" | "ts" | "css" | "css resolved";
         };
+
+    /**
+     * Assign `displayName` to components for a better developer experience
+     * when using React Developer Tools. Default: false
+     */
+    displayNames?: boolean;
   };
 };
 
@@ -42,6 +48,9 @@ const addYak = (yakOptions: YakConfigOptions, nextConfig: NextConfig) => {
       devMode: process.env.NODE_ENV !== "production",
       basePath: currentDir,
       prefix: yakOptions.prefix,
+      experiments: {
+        displayNames: yakOptions.experiments?.displayNames,
+      },
     },
   ]);
 

--- a/packages/next-yak/withYak/index.ts
+++ b/packages/next-yak/withYak/index.ts
@@ -22,8 +22,10 @@ export type YakConfigOptions = {
    */
   prefix?: string;
   /**
-   * Assign `displayName` to components for a better developer experience
-   * when using React Developer Tools. Default: match `devMode`
+   * Adds `displayName` to each components for better React DevTools debugging
+   * - Enabled by default in development mode
+   * - Disabled by default in production
+   * - Increases bundle size slightly when enabled
    */
   displayNames?: boolean;
   experiments?: {

--- a/packages/next-yak/withYak/index.ts
+++ b/packages/next-yak/withYak/index.ts
@@ -21,6 +21,11 @@ export type YakConfigOptions = {
    * or to add organization-specific prefixes.
    */
   prefix?: string;
+  /**
+   * Assign `displayName` to components for a better developer experience
+   * when using React Developer Tools. Default: match `devMode`
+   */
+  displayNames?: boolean;
   experiments?: {
     debug?:
       | boolean
@@ -28,29 +33,22 @@ export type YakConfigOptions = {
           filter?: (path: string) => boolean;
           type: "all" | "ts" | "css" | "css resolved";
         };
-
-    /**
-     * Assign `displayName` to components for a better developer experience
-     * when using React Developer Tools. Default: false
-     */
-    displayNames?: boolean;
   };
 };
 
 const addYak = (yakOptions: YakConfigOptions, nextConfig: NextConfig) => {
   const previousConfig = nextConfig.webpack;
+  const devMode = process.env.NODE_ENV !== "production";
 
   nextConfig.experimental ||= {};
   nextConfig.experimental.swcPlugins ||= [];
   nextConfig.experimental.swcPlugins.push([
     resolve("yak-swc"),
     {
-      devMode: process.env.NODE_ENV !== "production",
+      devMode,
       basePath: currentDir,
       prefix: yakOptions.prefix,
-      experiments: {
-        displayNames: yakOptions.experiments?.displayNames,
-      },
+      displayNames: yakOptions.displayNames ?? devMode,
     },
   ]);
 

--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -118,7 +118,8 @@ where
   css_module_identifier: Option<Ident>,
   /// Flag to check if we are inside a css attribute
   inside_element_with_css_attribute: bool,
-  /// Indicates whether `displayName` should be assigned on the component wrappers.
+  /// If true, additional code will be injected to provide readable `displayName` values
+  /// in React DevTools and stack traces for every yak component
   display_names: bool,
 }
 
@@ -148,7 +149,7 @@ where
       inside_element_with_css_attribute: false,
       filename: filename.as_ref().into(),
       comments,
-      display_names: dev_mode && display_names,
+      display_names: display_names,
     }
   }
 

--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -1099,32 +1099,6 @@ mod tests {
     )
   }
 
-  #[testing::fixture("tests/fixture/**/input.tsx")]
-  fn fixture_prod_display_names_ignored(input: PathBuf) {
-    test_fixture(
-      Syntax::Typescript(TsSyntax {
-        tsx: true,
-        ..Default::default()
-      }),
-      &|tester| {
-        visit_mut_pass(TransformVisitor::new(
-          Some(tester.comments.clone()),
-          "path/input.tsx",
-          false,
-          None,
-          true,
-        ))
-      },
-      &input,
-      &input.with_file_name("output.prod.tsx"),
-      FixtureTestConfig {
-        module: None,
-        sourcemap: false,
-        allow_error: true,
-      },
-    )
-  }
-
   #[testing::fixture("tests/fixture/**/input.yak.tsx")]
   fn fixture_yak(input: PathBuf) {
     test_fixture(

--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -60,15 +60,6 @@ pub struct Config {
   pub base_path: String,
   /// Prefix for the generated css identifier
   pub prefix: Option<String>,
-  /// Experimental configuration settings
-  pub experiments: Option<Experiments>,
-}
-
-/// Experimental plugin configuration settings
-#[derive(Default, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[serde(deny_unknown_fields)]
-pub struct Experiments {
   /// Improves react DevTools experience by setting displayName
   /// on the component to match the original component name.
   /// Disabled by default.
@@ -1018,9 +1009,7 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
     deterministic_path,
     config.dev_mode,
     config.prefix,
-    config
-      .experiments
-      .map_or(Default::default(), |e| e.display_names),
+    config.display_names,
   )))
 }
 

--- a/packages/yak-swc/yak_swc/src/variable_visitor.rs
+++ b/packages/yak-swc/yak_swc/src/variable_visitor.rs
@@ -46,6 +46,11 @@ impl ScopedVariableReference {
       .collect::<Vec<&str>>()
       .join(".")
   }
+
+  pub fn last_part(&self) -> &Atom {
+    // `parts` should never be empty
+    self.parts.last().unwrap_or(&self.id.0)
+  }
 }
 
 impl VariableVisitor {

--- a/packages/yak-swc/yak_swc/src/variable_visitor.rs
+++ b/packages/yak-swc/yak_swc/src/variable_visitor.rs
@@ -48,7 +48,7 @@ impl ScopedVariableReference {
   }
 
   pub fn last_part(&self) -> &Atom {
-    // `parts` should never be empty
+    // We don't expect `parts` to be empty in normal code
     self.parts.last().unwrap_or(&self.id.0)
   }
 }
@@ -268,5 +268,21 @@ mod tests {
     ));
     let array_value = get_expr_value(array_elem.as_ref().unwrap());
     assert_eq!(array_value, Some("2".to_string()));
+  }
+
+  #[test]
+  fn test_last_part_normal() {
+    let i = ScopedVariableReference::new(
+      Id::from((Atom::from("f"), SyntaxContext::empty())),
+      vec![atom!("g"), atom!("h")],
+    );
+    assert_eq!(i.last_part(), &atom!("h"));
+  }
+
+  #[test]
+  fn test_last_part_zero_parts() {
+    let i =
+      ScopedVariableReference::new(Id::from((Atom::from("f"), SyntaxContext::empty())), vec![]);
+    assert_eq!(i.last_part(), &atom!("f"));
   }
 }

--- a/packages/yak-swc/yak_swc/src/yak_transforms.rs
+++ b/packages/yak-swc/yak_swc/src/yak_transforms.rs
@@ -287,24 +287,17 @@ impl TransformStyled {
   }
 
   /// Wraps the supplied expression in
-  /// `globalThis.Object.assign(expr, { displayName: "declaration_name" })`. This improves the
+  /// `Object.assign(expr, { displayName: "declaration_name" })`. This improves the
   /// display of components in React DevTools.
   fn assign_display_name(&mut self, mut expr: Box<Expr>) -> Box<Expr> {
-    // `globalThis.Object.assign`
-    let global_this_object_assign = Callee::Expr(Box::new(Expr::Member(MemberExpr {
+    // `Object.assign`
+    let object_assign = Callee::Expr(Box::new(Expr::Member(MemberExpr {
       span: DUMMY_SP,
-      obj: Box::new(Expr::Member(MemberExpr {
+      obj: Box::new(Expr::Ident(Ident {
         span: DUMMY_SP,
-        obj: Box::new(Expr::Ident(Ident {
-          span: DUMMY_SP,
-          ctxt: SyntaxContext::empty(),
-          sym: "globalThis".into(),
-          optional: false,
-        })),
-        prop: MemberProp::Ident(IdentName {
-          span: DUMMY_SP,
-          sym: "Object".into(),
-        }),
+        ctxt: SyntaxContext::empty(),
+        sym: "Object".into(),
+        optional: false,
       })),
       prop: MemberProp::Ident(IdentName {
         span: DUMMY_SP,
@@ -335,11 +328,11 @@ impl TransformStyled {
     let original_span = expr.span();
     expr.set_span(PURE_SP);
 
-    // `globalThis.Object.assign(/*#__PURE__*/(expr), { displayName: "declaration_name" })`
+    // `Object.assign(/*#__PURE__*/(expr), { displayName: "declaration_name" })`
     Box::new(Expr::Call(CallExpr {
       span: original_span,
       ctxt: SyntaxContext::empty(),
-      callee: global_this_object_assign,
+      callee: object_assign,
       args: vec![
         ExprOrSpread::from(expr),
         ExprOrSpread::from(display_name_props),

--- a/packages/yak-swc/yak_swc/src/yak_transforms.rs
+++ b/packages/yak-swc/yak_swc/src/yak_transforms.rs
@@ -32,12 +32,7 @@ pub trait YakTransform {
   /// Create a CSS Scope\
   /// This CSS Scope will surround the entire CSS for this literal\
   /// e.g. const myMixin = css`...` -> .myMixin { ... }
-  fn create_css_state(
-    &mut self,
-    naming_convention: &mut NamingConvention,
-    declaration_name: &ScopedVariableReference,
-    previous_parser_state: Option<ParserState>,
-  ) -> ParserState;
+  fn create_css_state(&self, previous_parser_state: Option<ParserState>) -> ParserState;
   /// Transform the expression\
   /// This is where the TypeScript AST for the expression is finally transformed
   fn transform_expression(
@@ -58,40 +53,34 @@ pub trait YakTransform {
 /// Transform for nested css mixins
 /// e.g. const Button = `${({$active}) => $active && css`...`}`
 pub struct TransformNestedCss {
-  /// Current condition which is used to determine if the mixin should be applied
-  pub condition: Vec<String>,
   /// ClassName of the mixin
-  class_name: Option<String>,
+  class_name: String,
 }
 
 impl TransformNestedCss {
-  pub fn new(condition: Vec<String>) -> TransformNestedCss {
-    TransformNestedCss {
-      condition,
-      class_name: None,
-    }
+  /// `condition` is the condition which is used to determine if the mixin should be applied
+  pub fn new(
+    naming_convention: &mut NamingConvention,
+    declaration_name: &ScopedVariableReference,
+    condition: Vec<String>,
+  ) -> TransformNestedCss {
+    let condition_concatenated = condition.as_slice().join("-and-");
+    let class_name = naming_convention.generate_unique_name(&format!(
+      "{}__{}",
+      declaration_name.to_readable_string(),
+      condition_concatenated
+    ));
+    TransformNestedCss { class_name }
   }
 }
 
 impl YakTransform for TransformNestedCss {
-  fn create_css_state(
-    &mut self,
-    naming_convention: &mut NamingConvention,
-    declaration_name: &ScopedVariableReference,
-    previous_parser_state: Option<ParserState>,
-  ) -> ParserState {
-    let condition = self.condition.join("-and-");
-    let css_identifier = naming_convention.generate_unique_name(&format!(
-      "{}__{}",
-      declaration_name.to_readable_string(),
-      condition
-    ));
-    self.class_name = Some(css_identifier.clone());
+  fn create_css_state(&self, previous_parser_state: Option<ParserState>) -> ParserState {
     // It is safe to unwrap here because the previous_parser_state is always set for a nested css
     let mut parser_state = previous_parser_state.clone().unwrap();
     // The first scope is the class name which gets attached to the element
     parser_state.current_scopes[0] = CssScope {
-      name: format!(".{}", css_identifier),
+      name: format!(".{}", self.class_name),
       scope_type: ScopeType::Selector,
     };
     parser_state
@@ -112,7 +101,7 @@ impl YakTransform for TransformNestedCss {
         Expr::Member(MemberExpr {
           span: DUMMY_SP,
           obj: Box::new(Expr::Ident(css_module_identifier.clone())),
-          prop: create_member_prop_from_string(self.class_name.clone().unwrap()),
+          prop: create_member_prop_from_string(&self.class_name),
         })
         .into(),
       );
@@ -150,40 +139,38 @@ impl YakTransform for TransformNestedCss {
 /// e.g. const myMixin = css`...`
 pub struct TransformCssMixin {
   /// ClassName of the mixin
-  export_name: Option<ScopedVariableReference>,
+  export_name: ScopedVariableReference,
   is_exported: bool,
   is_within_jsx_attribute: bool,
-  generated_class_name: Option<String>,
+  generated_class_name: String,
 }
 
 impl TransformCssMixin {
-  pub fn new(is_exported: bool, is_within_jsx_attribute: bool) -> TransformCssMixin {
+  pub fn new(
+    naming_convention: &mut NamingConvention,
+    declaration_name: ScopedVariableReference,
+    is_exported: bool,
+    is_within_jsx_attribute: bool,
+  ) -> TransformCssMixin {
+    let generated_class_name =
+      naming_convention.generate_unique_name_for_variable(&declaration_name);
     TransformCssMixin {
-      export_name: None,
+      export_name: declaration_name,
       is_exported,
       is_within_jsx_attribute,
-      generated_class_name: None,
+      generated_class_name,
     }
   }
 }
 
 impl YakTransform for TransformCssMixin {
-  fn create_css_state(
-    &mut self,
-    naming_convention: &mut NamingConvention,
-    declaration_name: &ScopedVariableReference,
-    _previous_parser_state: Option<ParserState>,
-  ) -> ParserState {
-    self.export_name = Some(declaration_name.clone());
+  fn create_css_state(&self, _previous_parser_state: Option<ParserState>) -> ParserState {
     let mut parser_state = ParserState::new();
-    let generated_class_name =
-      naming_convention.generate_unique_name_for_variable(declaration_name);
     // TODO: Remove the unused scope once nested mixins work again
     parser_state.current_scopes = vec![CssScope {
-      name: format!(".{}", generated_class_name),
+      name: format!(".{}", self.generated_class_name),
       scope_type: ScopeType::AtRule,
     }];
-    self.generated_class_name = Some(generated_class_name);
     parser_state
   }
 
@@ -228,7 +215,7 @@ impl YakTransform for TransformCssMixin {
         Expr::Member(MemberExpr {
           span: DUMMY_SP,
           obj: Box::new(Expr::Ident(css_module_identifier.clone())),
-          prop: create_member_prop_from_string(self.generated_class_name.clone().unwrap()),
+          prop: create_member_prop_from_string(&self.generated_class_name),
         })
         .into(),
       );
@@ -238,8 +225,6 @@ impl YakTransform for TransformCssMixin {
         "YAK EXPORTED MIXIN:{}",
         self
           .export_name
-          .as_ref()
-          .unwrap()
           .parts
           .iter()
           .map(|atom| encode_percent(atom.as_str()))
@@ -272,7 +257,7 @@ impl YakTransform for TransformCssMixin {
 
   fn get_css_reference_name(&self) -> Option<String> {
     if self.is_within_jsx_attribute {
-      return Some(self.generated_class_name.clone().unwrap());
+      return Some(self.generated_class_name.clone());
     }
     None
   }
@@ -282,12 +267,14 @@ impl YakTransform for TransformCssMixin {
 /// e.g. const Wrapper = styled.div`...`
 pub struct TransformStyled {
   /// root class name of the styled component
-  class_name: Option<String>,
+  class_name: String,
+  declaration_name: ScopedVariableReference,
 }
 
 impl TransformStyled {
-  pub fn new() -> TransformStyled {
-    TransformStyled { class_name: None }
+  pub fn new(naming_convention: &mut NamingConvention, declaration_name: ScopedVariableReference) -> TransformStyled {
+    let class_name = naming_convention.generate_unique_name_for_variable(&declaration_name);
+    TransformStyled { class_name, declaration_name }
   }
 }
 
@@ -359,17 +346,10 @@ fn transform_styled_usages(expression: Box<Expr>, yak_imports: &mut YakImports) 
 }
 
 impl YakTransform for TransformStyled {
-  fn create_css_state(
-    &mut self,
-    naming_convention: &mut NamingConvention,
-    declaration_name: &ScopedVariableReference,
-    _previous_parser_state: Option<ParserState>,
-  ) -> ParserState {
-    let css_identifier = naming_convention.generate_unique_name_for_variable(declaration_name);
-    self.class_name = Some(css_identifier.clone());
+  fn create_css_state(&self, _previous_parser_state: Option<ParserState>) -> ParserState {
     let mut parser_state = ParserState::new();
     parser_state.current_scopes = vec![CssScope {
-      name: format!(".{}", css_identifier),
+      name: format!(".{}", self.class_name),
       scope_type: ScopeType::AtRule,
     }];
     parser_state
@@ -390,7 +370,7 @@ impl YakTransform for TransformStyled {
         Expr::Member(MemberExpr {
           span: DUMMY_SP,
           obj: Box::new(Expr::Ident(css_module_identifier.clone())),
-          prop: create_member_prop_from_string(self.class_name.clone().unwrap()),
+          prop: create_member_prop_from_string(&self.class_name),
         })
         .into(),
       );
@@ -423,7 +403,7 @@ impl YakTransform for TransformStyled {
 
   /// Get the selector for the specific styled component to be used in other expressions
   fn get_css_reference_name(&self) -> Option<String> {
-    Some(format!(".{}", self.class_name.clone().unwrap()))
+    Some(format!(".{}", self.class_name))
   }
 }
 
@@ -431,34 +411,20 @@ impl YakTransform for TransformStyled {
 /// e.g. const fadeIn = keyframes`...`
 pub struct TransformKeyframes {
   /// Animation Name
-  animation_name: Option<String>,
+  animation_name: String,
 }
 
 impl TransformKeyframes {
-  pub fn new(animation_name: String) -> TransformKeyframes {
-    TransformKeyframes {
-      animation_name: Some(animation_name),
-    }
+  pub fn with_animation_name(animation_name: String) -> TransformKeyframes {
+    TransformKeyframes { animation_name }
   }
 }
 
 impl YakTransform for TransformKeyframes {
-  fn create_css_state(
-    &mut self,
-    naming_convention: &mut NamingConvention,
-    declaration_name: &ScopedVariableReference,
-    _previous_parser_state: Option<ParserState>,
-  ) -> ParserState {
-    let css_identifier = if self.animation_name.is_none() {
-      let new_identifier = naming_convention.generate_unique_name_for_variable(declaration_name);
-      self.animation_name = Some(new_identifier.clone());
-      new_identifier
-    } else {
-      self.animation_name.clone().unwrap()
-    };
+  fn create_css_state(&self, _previous_parser_state: Option<ParserState>) -> ParserState {
     let mut parser_state = ParserState::new();
     parser_state.current_scopes = vec![CssScope {
-      name: format!("@keyframes {}", css_identifier),
+      name: format!("@keyframes {}", self.animation_name),
       scope_type: ScopeType::AtRule,
     }];
     parser_state
@@ -479,7 +445,7 @@ impl YakTransform for TransformKeyframes {
         Expr::Member(MemberExpr {
           span: DUMMY_SP,
           obj: Box::new(Expr::Ident(css_module_identifier.clone())),
-          prop: create_member_prop_from_string(self.animation_name.clone().unwrap()),
+          prop: create_member_prop_from_string(&self.animation_name),
         })
         .into(),
       );
@@ -510,6 +476,6 @@ impl YakTransform for TransformKeyframes {
 
   /// Get the selector for the keyframe to be used in other expressions
   fn get_css_reference_name(&self) -> Option<String> {
-    Some(self.animation_name.clone().unwrap())
+    Some(self.animation_name.clone())
   }
 }

--- a/packages/yak-swc/yak_swc/tests/fixture/attrs-on-function-component/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/attrs-on-function-component/output.dev.tsx
@@ -4,6 +4,8 @@ export const Button = /*YAK Extracted CSS:
 .Button {
   background-color: #007bff;
 }
-*/ /*#__PURE__*/ styled("button").attrs({
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled("button").attrs({
     type: "button"
-})(__styleYak.Button);
+})(__styleYak.Button), {
+    "displayName": "Button"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/attrs-on-function-component/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/attrs-on-function-component/output.dev.tsx
@@ -4,7 +4,7 @@ export const Button = /*YAK Extracted CSS:
 .Button {
   background-color: #007bff;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled("button").attrs({
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled("button").attrs({
     type: "button"
 })(__styleYak.Button), {
     "displayName": "Button"

--- a/packages/yak-swc/yak_swc/tests/fixture/attrs/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/attrs/output.dev.tsx
@@ -15,7 +15,7 @@ export const Button = /*YAK Extracted CSS:
     background-color: #0056b3;
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button.attrs({
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button.attrs({
     type: "button"
 })(__styleYak.Button), {
     "displayName": "Button"

--- a/packages/yak-swc/yak_swc/tests/fixture/attrs/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/attrs/output.dev.tsx
@@ -15,6 +15,8 @@ export const Button = /*YAK Extracted CSS:
     background-color: #0056b3;
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_button.attrs({
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button.attrs({
     type: "button"
-})(__styleYak.Button);
+})(__styleYak.Button), {
+    "displayName": "Button"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/basic-styled-component/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/basic-styled-component/output.dev.tsx
@@ -15,4 +15,6 @@ export const Button = /*YAK Extracted CSS:
     background-color: #0056b3;
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+    "displayName": "Button"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/basic-styled-component/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/basic-styled-component/output.dev.tsx
@@ -15,6 +15,6 @@ export const Button = /*YAK Extracted CSS:
     background-color: #0056b3;
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
     "displayName": "Button"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/comments/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/comments/output.dev.tsx
@@ -7,6 +7,6 @@ export const Button = /*YAK Extracted CSS:
   color: green;
   background: red;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
     "displayName": "Button"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/comments/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/comments/output.dev.tsx
@@ -7,4 +7,6 @@ export const Button = /*YAK Extracted CSS:
   color: green;
   background: red;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+    "displayName": "Button"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/complex-nested-structure/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/complex-nested-structure/output.dev.tsx
@@ -53,6 +53,6 @@ export const ArticleCard = /*YAK Extracted CSS:
     }
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_article(__styleYak.ArticleCard), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_article(__styleYak.ArticleCard), {
     "displayName": "ArticleCard"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/complex-nested-structure/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/complex-nested-structure/output.dev.tsx
@@ -53,4 +53,6 @@ export const ArticleCard = /*YAK Extracted CSS:
     }
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_article(__styleYak.ArticleCard);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_article(__styleYak.ArticleCard), {
+    "displayName": "ArticleCard"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/constants/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/constants/output.dev.tsx
@@ -29,4 +29,6 @@ export const Button = /*YAK Extracted CSS:
     background-color: #343a40;
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+    "displayName": "Button"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/constants/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/constants/output.dev.tsx
@@ -29,6 +29,6 @@ export const Button = /*YAK Extracted CSS:
     background-color: #343a40;
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
     "displayName": "Button"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-constants/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-constants/output.dev.tsx
@@ -15,6 +15,6 @@ export const Button = /*YAK Extracted CSS:
   background-color: --yak-css-import: url("./colorDefinitions:colors:light:full%20opacity",mixin);
   height: --yak-css-import: url("./sizeDefinitions:sizes:0",mixin);
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
     "displayName": "Button"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-constants/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-constants/output.dev.tsx
@@ -15,4 +15,6 @@ export const Button = /*YAK Extracted CSS:
   background-color: --yak-css-import: url("./colorDefinitions:colors:light:full%20opacity",mixin);
   height: --yak-css-import: url("./sizeDefinitions:sizes:0",mixin);
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+    "displayName": "Button"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-dynamic-export/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-dynamic-export/output.dev.tsx
@@ -52,6 +52,6 @@ export const Button = /*YAK Extracted CSS:
     color: red;
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button, ({ $isSet })=>$isSet && true && true && true && /*#__PURE__*/ css(__styleYak.Button__, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak["Button__-and-$active"])), ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.Button__$active), ({ $active })=>$active && /*#__PURE__*/ css(__styleYak["Button__$active-01"])), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button, ({ $isSet })=>$isSet && true && true && true && /*#__PURE__*/ css(__styleYak.Button__, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak["Button__-and-$active"])), ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.Button__$active), ({ $active })=>$active && /*#__PURE__*/ css(__styleYak["Button__$active-01"])), {
     "displayName": "Button"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-dynamic-export/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-dynamic-export/output.dev.tsx
@@ -52,4 +52,6 @@ export const Button = /*YAK Extracted CSS:
     color: red;
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button, ({ $isSet })=>$isSet && true && true && true && /*#__PURE__*/ css(__styleYak.Button__, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak["Button__-and-$active"])), ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.Button__$active), ({ $active })=>$active && /*#__PURE__*/ css(__styleYak["Button__$active-01"]));
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button, ({ $isSet })=>$isSet && true && true && true && /*#__PURE__*/ css(__styleYak.Button__, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak["Button__-and-$active"])), ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.Button__$active), ({ $active })=>$active && /*#__PURE__*/ css(__styleYak["Button__$active-01"])), {
+    "displayName": "Button"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-export/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-export/output.dev.tsx
@@ -34,7 +34,7 @@ export const Button = /*YAK Extracted CSS:
     color: black;
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button, ({ $isSet })=>$isSet && true && true && true && /*#__PURE__*/ css(__styleYak.Button__)), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button, ({ $isSet })=>$isSet && true && true && true && /*#__PURE__*/ css(__styleYak.Button__)), {
     "displayName": "Button"
 });
 export const aspectRatios = {

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-export/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-export/output.dev.tsx
@@ -34,7 +34,9 @@ export const Button = /*YAK Extracted CSS:
     color: black;
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button, ({ $isSet })=>$isSet && true && true && true && /*#__PURE__*/ css(__styleYak.Button__));
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button, ({ $isSet })=>$isSet && true && true && true && /*#__PURE__*/ css(__styleYak.Button__)), {
+    "displayName": "Button"
+});
 export const aspectRatios = {
     base: /*YAK EXPORTED MIXIN:aspectRatios:base
 padding-top: 100%;

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-import/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-import/output.dev.tsx
@@ -11,14 +11,14 @@ export const Button = /*YAK Extracted CSS:
 .Button {
   --yak-css-import: url("./fonts:fonts:h1",mixin);
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
     "displayName": "Button"
 });
 export const Button2 = /*YAK Extracted CSS:
 .Button2 {
   --yak-css-import: url("./fonts:fonts:h1",mixin);
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button2), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button2), {
     "displayName": "Button2"
 });
 export const Button3 = /*YAK Extracted CSS:
@@ -26,7 +26,7 @@ export const Button3 = /*YAK Extracted CSS:
   --yak-css-import: url("./fonts:fonts:h1",mixin);
   color: green;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button3), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button3), {
     "displayName": "Button3"
 });
 export const Button4 = /*YAK Extracted CSS:
@@ -35,7 +35,7 @@ export const Button4 = /*YAK Extracted CSS:
 --yak-css-import: url("./fonts:fonts:underline",mixin);
   color: green;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button4), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button4), {
     "displayName": "Button4"
 });
 export const Button5 = /*YAK Extracted CSS:
@@ -44,7 +44,7 @@ export const Button5 = /*YAK Extracted CSS:
   --yak-css-import: url("./fancy:fancy:mixins:specialEffect",mixin);
   color: green;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button5), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button5), {
     "displayName": "Button5"
 });
 export const Button6 = /*YAK Extracted CSS:
@@ -56,7 +56,7 @@ export const Button6 = /*YAK Extracted CSS:
 ;
   color: green;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button6), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button6), {
     "displayName": "Button6"
 });
 export const Button7 = /*YAK Extracted CSS:
@@ -68,6 +68,6 @@ export const Button7 = /*YAK Extracted CSS:
 ;
   color: green;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button7), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button7), {
     "displayName": "Button7"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-import/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-import/output.dev.tsx
@@ -11,32 +11,42 @@ export const Button = /*YAK Extracted CSS:
 .Button {
   --yak-css-import: url("./fonts:fonts:h1",mixin);
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+    "displayName": "Button"
+});
 export const Button2 = /*YAK Extracted CSS:
 .Button2 {
   --yak-css-import: url("./fonts:fonts:h1",mixin);
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button2);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button2), {
+    "displayName": "Button2"
+});
 export const Button3 = /*YAK Extracted CSS:
 .Button3 {
   --yak-css-import: url("./fonts:fonts:h1",mixin);
   color: green;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button3);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button3), {
+    "displayName": "Button3"
+});
 export const Button4 = /*YAK Extracted CSS:
 .Button4 {
   --yak-css-import: url("./fonts:fonts:h1",mixin)
 --yak-css-import: url("./fonts:fonts:underline",mixin);
   color: green;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button4);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button4), {
+    "displayName": "Button4"
+});
 export const Button5 = /*YAK Extracted CSS:
 .Button5 {
   --yak-css-import: url("./fonts:fonts:h1",mixin);
   --yak-css-import: url("./fancy:fancy:mixins:specialEffect",mixin);
   color: green;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button5);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button5), {
+    "displayName": "Button5"
+});
 export const Button6 = /*YAK Extracted CSS:
 .Button6 {
   &:hover {
@@ -46,7 +56,9 @@ export const Button6 = /*YAK Extracted CSS:
 ;
   color: green;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button6);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button6), {
+    "displayName": "Button6"
+});
 export const Button7 = /*YAK Extracted CSS:
 .Button7 {
   &:hover {
@@ -56,4 +68,6 @@ export const Button7 = /*YAK Extracted CSS:
 ;
   color: green;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button7);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button7), {
+    "displayName": "Button7"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-selectors/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-selectors/output.dev.tsx
@@ -15,4 +15,6 @@ export const Button = /*YAK Extracted CSS:
     color: blue;
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+    "displayName": "Button"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-selectors/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-selectors/output.dev.tsx
@@ -15,6 +15,6 @@ export const Button = /*YAK Extracted CSS:
     color: blue;
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
     "displayName": "Button"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/css-grid-layout/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-grid-layout/output.dev.tsx
@@ -57,6 +57,6 @@ export const GridLayout = /*YAK Extracted CSS:
     text-align: center;
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.GridLayout), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.GridLayout), {
     "displayName": "GridLayout"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/css-grid-layout/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-grid-layout/output.dev.tsx
@@ -57,4 +57,6 @@ export const GridLayout = /*YAK Extracted CSS:
     text-align: center;
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_div(__styleYak.GridLayout);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.GridLayout), {
+    "displayName": "GridLayout"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/css-import-order/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-import-order/output.dev.tsx
@@ -11,6 +11,6 @@ export const FancyIconButton = /*YAK Extracted CSS:
     color: #f0f;
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled(IconButton)(__styleYak.FancyIconButton), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(IconButton)(__styleYak.FancyIconButton), {
     "displayName": "FancyIconButton"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/css-import-order/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-import-order/output.dev.tsx
@@ -11,4 +11,6 @@ export const FancyIconButton = /*YAK Extracted CSS:
     color: #f0f;
   }
 }
-*/ /*#__PURE__*/ styled(IconButton)(__styleYak.FancyIconButton);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled(IconButton)(__styleYak.FancyIconButton), {
+    "displayName": "FancyIconButton"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/css-mixin-inline/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-mixin-inline/output.dev.tsx
@@ -12,4 +12,6 @@ export const ThemedButton = /*YAK Extracted CSS:
     color: red;
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active));
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active)), {
+    "displayName": "ThemedButton"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/css-mixin-inline/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-mixin-inline/output.dev.tsx
@@ -12,6 +12,6 @@ export const ThemedButton = /*YAK Extracted CSS:
     color: red;
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active)), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active)), {
     "displayName": "ThemedButton"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/css-mixin-nested/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-mixin-nested/output.dev.tsx
@@ -26,7 +26,7 @@ export const ThemedButton = /*YAK Extracted CSS:
 .ThemedButton {
   width: var(--ThemedButton__width_m7uBBu);
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active, {
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active, {
         "style": {
             "--ThemedButton__max-width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
@@ -34,6 +34,8 @@ export const ThemedButton = /*YAK Extracted CSS:
     "style": {
         "--ThemedButton__width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
+}), {
+    "displayName": "ThemedButton"
 });
 export const CustomThemedButton = /*YAK Extracted CSS:
 .CustomThemedButton {
@@ -58,7 +60,7 @@ export const CustomThemedButton = /*YAK Extracted CSS:
     width: var(--CustomThemedButton__width_m7uBBu);
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.CustomThemedButton__$active, {
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.CustomThemedButton__$active, {
         "style": {
             "--CustomThemedButton__max-width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
@@ -66,4 +68,6 @@ export const CustomThemedButton = /*YAK Extracted CSS:
     "style": {
         "--CustomThemedButton__width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
+}), {
+    "displayName": "CustomThemedButton"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/css-mixin-nested/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-mixin-nested/output.dev.tsx
@@ -26,7 +26,7 @@ export const ThemedButton = /*YAK Extracted CSS:
 .ThemedButton {
   width: var(--ThemedButton__width_m7uBBu);
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active, {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active, {
         "style": {
             "--ThemedButton__max-width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
@@ -60,7 +60,7 @@ export const CustomThemedButton = /*YAK Extracted CSS:
     width: var(--CustomThemedButton__width_m7uBBu);
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.CustomThemedButton__$active, {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.CustomThemedButton__$active, {
         "style": {
             "--CustomThemedButton__max-width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }

--- a/packages/yak-swc/yak_swc/tests/fixture/css-mixin/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-mixin/output.dev.tsx
@@ -29,7 +29,7 @@ export const ThemedButton = /*YAK Extracted CSS:
 .ThemedButton__ {
   color: red;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active, {
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active, {
         "style": {
             "--ThemedButton__max-width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
@@ -39,6 +39,8 @@ export const ThemedButton = /*YAK Extracted CSS:
     "style": {
         "--ThemedButton__width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
+}), {
+    "displayName": "ThemedButton"
 });
 export const CustomThemedButton = /*YAK Extracted CSS:
 .CustomThemedButton {
@@ -58,7 +60,7 @@ export const CustomThemedButton = /*YAK Extracted CSS:
 .CustomThemedButton__ {
   color: red;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.CustomThemedButton__$active, {
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.CustomThemedButton__$active, {
         "style": {
             "--CustomThemedButton__max-width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
@@ -68,4 +70,6 @@ export const CustomThemedButton = /*YAK Extracted CSS:
     "style": {
         "--CustomThemedButton__width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
+}), {
+    "displayName": "CustomThemedButton"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/css-mixin/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-mixin/output.dev.tsx
@@ -29,7 +29,7 @@ export const ThemedButton = /*YAK Extracted CSS:
 .ThemedButton__ {
   color: red;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active, {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active, {
         "style": {
             "--ThemedButton__max-width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
@@ -60,7 +60,7 @@ export const CustomThemedButton = /*YAK Extracted CSS:
 .CustomThemedButton__ {
   color: red;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.CustomThemedButton__$active, {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.CustomThemedButton__$active, {
         "style": {
             "--CustomThemedButton__max-width_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.dev.tsx
@@ -55,7 +55,9 @@ const Text = /*YAK Extracted CSS:
 .Text {
   font-size: 20px;
 }
-*/ /*#__PURE__*/ __yak.__yak_p(__styleYak.Text);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_p(__styleYak.Text), {
+    "displayName": "Text"
+});
 const StyledComponentWithCSSProp = ()=><Text {.../*YAK Extracted CSS:
 .StyledComponentWithCSSProp {
   color: red;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.dev.tsx
@@ -55,7 +55,7 @@ const Text = /*YAK Extracted CSS:
 .Text {
   font-size: 20px;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_p(__styleYak.Text), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_p(__styleYak.Text), {
     "displayName": "Text"
 });
 const StyledComponentWithCSSProp = ()=><Text {.../*YAK Extracted CSS:

--- a/packages/yak-swc/yak_swc/tests/fixture/css-variables/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-variables/output.dev.tsx
@@ -14,11 +14,15 @@ export const ThemedButton = /*YAK Extracted CSS:
     background-color: var(--secondary-color);
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton), {
+    "displayName": "ThemedButton"
+});
 export const ThemeProvider = /*YAK Extracted CSS:
 .ThemeProvider {
   --primary-color: #007bff;
   --secondary-color: #6c757d;
   --font-size-base: 16px;
 }
-*/ /*#__PURE__*/ __yak.__yak_div(__styleYak.ThemeProvider);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.ThemeProvider), {
+    "displayName": "ThemeProvider"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/css-variables/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-variables/output.dev.tsx
@@ -14,7 +14,7 @@ export const ThemedButton = /*YAK Extracted CSS:
     background-color: var(--secondary-color);
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.ThemedButton), {
     "displayName": "ThemedButton"
 });
 export const ThemeProvider = /*YAK Extracted CSS:
@@ -23,6 +23,6 @@ export const ThemeProvider = /*YAK Extracted CSS:
   --secondary-color: #6c757d;
   --font-size-base: 16px;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.ThemeProvider), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.ThemeProvider), {
     "displayName": "ThemeProvider"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/output.dev.tsx
@@ -7,9 +7,11 @@ export const FlexContainer = /*YAK Extracted CSS:
   z-index: var(--FlexContainer__z-index_m7uBBu);
   margin-bottom: var(--FlexContainer__margin-bottom_m7uBBu);
 }
-*/ /*#__PURE__*/ __yak.__yak_div(__styleYak.FlexContainer, {
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.FlexContainer, {
     "style": {
         "--FlexContainer__margin-bottom_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(spacing[40].toString(), "px"),
         "--FlexContainer__z-index_m7uBBu": getZIndex()
     }
+}), {
+    "displayName": "FlexContainer"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/output.dev.tsx
@@ -7,7 +7,7 @@ export const FlexContainer = /*YAK Extracted CSS:
   z-index: var(--FlexContainer__z-index_m7uBBu);
   margin-bottom: var(--FlexContainer__margin-bottom_m7uBBu);
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.FlexContainer, {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.FlexContainer, {
     "style": {
         "--FlexContainer__margin-bottom_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(spacing[40].toString(), "px"),
         "--FlexContainer__z-index_m7uBBu": getZIndex()

--- a/packages/yak-swc/yak_swc/tests/fixture/encoded/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/encoded/output.dev.tsx
@@ -12,4 +12,6 @@ export const Button = /*YAK Extracted CSS:
     content: "\2022";
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+    "displayName": "Button"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/encoded/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/encoded/output.dev.tsx
@@ -12,6 +12,6 @@ export const Button = /*YAK Extracted CSS:
     content: "\2022";
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
     "displayName": "Button"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/extending-styles/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/extending-styles/output.dev.tsx
@@ -9,7 +9,9 @@ const BaseButton = /*YAK Extracted CSS:
   font-size: 16px;
   cursor: pointer;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.BaseButton);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.BaseButton), {
+    "displayName": "BaseButton"
+});
 export const PrimaryButton = /*YAK Extracted CSS:
 .PrimaryButton {
   background-color: #007bff;
@@ -18,7 +20,9 @@ export const PrimaryButton = /*YAK Extracted CSS:
     background-color: #0056b3;
   }
 }
-*/ /*#__PURE__*/ styled(BaseButton)(__styleYak.PrimaryButton);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled(BaseButton)(__styleYak.PrimaryButton), {
+    "displayName": "PrimaryButton"
+});
 export const SecondaryButton = /*YAK Extracted CSS:
 .SecondaryButton {
   background-color: #6c757d;
@@ -27,4 +31,6 @@ export const SecondaryButton = /*YAK Extracted CSS:
     background-color: #545b62;
   }
 }
-*/ /*#__PURE__*/ styled(BaseButton)(__styleYak.SecondaryButton);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled(BaseButton)(__styleYak.SecondaryButton), {
+    "displayName": "SecondaryButton"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/extending-styles/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/extending-styles/output.dev.tsx
@@ -9,7 +9,7 @@ const BaseButton = /*YAK Extracted CSS:
   font-size: 16px;
   cursor: pointer;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.BaseButton), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.BaseButton), {
     "displayName": "BaseButton"
 });
 export const PrimaryButton = /*YAK Extracted CSS:
@@ -20,7 +20,7 @@ export const PrimaryButton = /*YAK Extracted CSS:
     background-color: #0056b3;
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled(BaseButton)(__styleYak.PrimaryButton), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(BaseButton)(__styleYak.PrimaryButton), {
     "displayName": "PrimaryButton"
 });
 export const SecondaryButton = /*YAK Extracted CSS:
@@ -31,6 +31,6 @@ export const SecondaryButton = /*YAK Extracted CSS:
     background-color: #545b62;
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled(BaseButton)(__styleYak.SecondaryButton), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(BaseButton)(__styleYak.SecondaryButton), {
     "displayName": "SecondaryButton"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/function-on-component/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/function-on-component/output.dev.tsx
@@ -5,7 +5,7 @@ export const Button = /*YAK Extracted CSS:
 .Button {
   background-color: #007bff;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button.functionName({
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button.functionName({
     arg: "something"
 })(__styleYak.Button), {
     "displayName": "Button"

--- a/packages/yak-swc/yak_swc/tests/fixture/function-on-component/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/function-on-component/output.dev.tsx
@@ -5,6 +5,8 @@ export const Button = /*YAK Extracted CSS:
 .Button {
   background-color: #007bff;
 }
-*/ /*#__PURE__*/ __yak.__yak_button.functionName({
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button.functionName({
     arg: "something"
-})(__styleYak.Button);
+})(__styleYak.Button), {
+    "displayName": "Button"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.dev.tsx
@@ -12,7 +12,7 @@ export const FadeInText = /*YAK Extracted CSS:
   font-size: 18px;
   color: #333;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_p(__styleYak.FadeInText, ({ $reverse })=>$reverse ? /*#__PURE__*/ css(__styleYak.FadeInText__$reverse) : /*#__PURE__*/ css(__styleYak.FadeInText__not_$reverse)), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_p(__styleYak.FadeInText, ({ $reverse })=>$reverse ? /*#__PURE__*/ css(__styleYak.FadeInText__$reverse) : /*#__PURE__*/ css(__styleYak.FadeInText__not_$reverse)), {
     "displayName": "FadeInText"
 });
 const fadeIn = /*YAK Extracted CSS:

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.dev.tsx
@@ -12,7 +12,9 @@ export const FadeInText = /*YAK Extracted CSS:
   font-size: 18px;
   color: #333;
 }
-*/ /*#__PURE__*/ __yak.__yak_p(__styleYak.FadeInText, ({ $reverse })=>$reverse ? /*#__PURE__*/ css(__styleYak.FadeInText__$reverse) : /*#__PURE__*/ css(__styleYak.FadeInText__not_$reverse));
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_p(__styleYak.FadeInText, ({ $reverse })=>$reverse ? /*#__PURE__*/ css(__styleYak.FadeInText__$reverse) : /*#__PURE__*/ css(__styleYak.FadeInText__not_$reverse)), {
+    "displayName": "FadeInText"
+});
 const fadeIn = /*YAK Extracted CSS:
 @keyframes fadeIn {
   from {

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.dev.tsx
@@ -12,7 +12,7 @@ export const FadeInText = /*YAK Extracted CSS:
   font-size: 18px;
   color: #333;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_p(__styleYak.FadeInText, ({ $reverse })=>$reverse ? /*#__PURE__*/ css(__styleYak.FadeInText__$reverse) : /*#__PURE__*/ css(__styleYak.FadeInText__not_$reverse)), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_p(__styleYak.FadeInText, ({ $reverse })=>$reverse ? /*#__PURE__*/ css(__styleYak.FadeInText__$reverse) : /*#__PURE__*/ css(__styleYak.FadeInText__not_$reverse)), {
     "displayName": "FadeInText"
 });
 const animations = {
@@ -64,6 +64,6 @@ export const FancyButton = /*YAK Extracted CSS:
     animation: slides_200 1s ease-in-out, animations_fadeOut 1s ease-in;
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.FancyButton), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.FancyButton), {
     "displayName": "FancyButton"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.dev.tsx
@@ -12,7 +12,9 @@ export const FadeInText = /*YAK Extracted CSS:
   font-size: 18px;
   color: #333;
 }
-*/ /*#__PURE__*/ __yak.__yak_p(__styleYak.FadeInText, ({ $reverse })=>$reverse ? /*#__PURE__*/ css(__styleYak.FadeInText__$reverse) : /*#__PURE__*/ css(__styleYak.FadeInText__not_$reverse));
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_p(__styleYak.FadeInText, ({ $reverse })=>$reverse ? /*#__PURE__*/ css(__styleYak.FadeInText__$reverse) : /*#__PURE__*/ css(__styleYak.FadeInText__not_$reverse)), {
+    "displayName": "FadeInText"
+});
 const animations = {
     fadeIn: /*YAK Extracted CSS:
 @keyframes animations_fadeIn {
@@ -62,4 +64,6 @@ export const FancyButton = /*YAK Extracted CSS:
     animation: slides_200 1s ease-in-out, animations_fadeOut 1s ease-in;
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.FancyButton);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.FancyButton), {
+    "displayName": "FancyButton"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations/output.dev.tsx
@@ -17,6 +17,6 @@ export const FadeInText = /*YAK Extracted CSS:
   font-size: 18px;
   color: #333;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_p(__styleYak.FadeInText), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_p(__styleYak.FadeInText), {
     "displayName": "FadeInText"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations/output.dev.tsx
@@ -17,4 +17,6 @@ export const FadeInText = /*YAK Extracted CSS:
   font-size: 18px;
   color: #333;
 }
-*/ /*#__PURE__*/ __yak.__yak_p(__styleYak.FadeInText);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_p(__styleYak.FadeInText), {
+    "displayName": "FadeInText"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframes-nested-error/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframes-nested-error/output.dev.tsx
@@ -1,4 +1,6 @@
 import { styled, keyframes } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
-export const Button = /*#__PURE__*/ __yak.__yak_button();
+export const Button = /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(), {
+    "displayName": "Button"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframes-nested-error/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframes-nested-error/output.dev.tsx
@@ -1,6 +1,6 @@
 import { styled, keyframes } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
-export const Button = /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(), {
+export const Button = /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(), {
     "displayName": "Button"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/media-queries/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/media-queries/output.dev.tsx
@@ -14,6 +14,6 @@ export const ResponsiveGrid = /*YAK Extracted CSS:
     grid-template-columns: repeat(3, 1fr);
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.ResponsiveGrid), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.ResponsiveGrid), {
     "displayName": "ResponsiveGrid"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/media-queries/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/media-queries/output.dev.tsx
@@ -14,4 +14,6 @@ export const ResponsiveGrid = /*YAK Extracted CSS:
     grid-template-columns: repeat(3, 1fr);
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_div(__styleYak.ResponsiveGrid);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.ResponsiveGrid), {
+    "displayName": "ResponsiveGrid"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/mixing-with-tailwind-error/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/mixing-with-tailwind-error/output.dev.tsx
@@ -1,6 +1,6 @@
 import { styled, atoms } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
-export const TailwindButton = /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(atoms("bg-blue-500 text-white font-bold py-2 px-4 rounded"), atoms("bg-blue-700")), {
+export const TailwindButton = /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(atoms("bg-blue-500 text-white font-bold py-2 px-4 rounded"), atoms("bg-blue-700")), {
     "displayName": "TailwindButton"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/mixing-with-tailwind-error/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/mixing-with-tailwind-error/output.dev.tsx
@@ -1,4 +1,6 @@
 import { styled, atoms } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
-export const TailwindButton = /*#__PURE__*/ __yak.__yak_button(atoms("bg-blue-500 text-white font-bold py-2 px-4 rounded"), atoms("bg-blue-700"));
+export const TailwindButton = /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(atoms("bg-blue-500 text-white font-bold py-2 px-4 rounded"), atoms("bg-blue-700")), {
+    "displayName": "TailwindButton"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/mixing-with-tailwind/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/mixing-with-tailwind/output.dev.tsx
@@ -1,6 +1,6 @@
 import { styled, atoms } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
-export const TailwindButton = /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(atoms("bg-blue-500 text-white font-bold py-2 px-4 rounded")), {
+export const TailwindButton = /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(atoms("bg-blue-500 text-white font-bold py-2 px-4 rounded")), {
     "displayName": "TailwindButton"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/mixing-with-tailwind/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/mixing-with-tailwind/output.dev.tsx
@@ -1,4 +1,6 @@
 import { styled, atoms } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
-export const TailwindButton = /*#__PURE__*/ __yak.__yak_button(atoms("bg-blue-500 text-white font-bold py-2 px-4 rounded"));
+export const TailwindButton = /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(atoms("bg-blue-500 text-white font-bold py-2 px-4 rounded")), {
+    "displayName": "TailwindButton"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/multiple-styled-components/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/multiple-styled-components/output.dev.tsx
@@ -5,27 +5,27 @@ export const Button = /*YAK Extracted CSS:
 .Button {
   background-color: #007bff;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
     "displayName": "Button"
 });
 export const Button2 = /*YAK Extracted CSS:
 .Button2 {
   background-color: #11c817;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button2), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button2), {
     "displayName": "Button2"
 });
 export const FancyButton = /*YAK Extracted CSS:
 .FancyButton {
   margin-bottom: 23px;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled(Button)(__styleYak.FancyButton), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(Button)(__styleYak.FancyButton), {
     "displayName": "FancyButton"
 });
 export const FancyButton2 = /*YAK Extracted CSS:
 .FancyButton2 {
   margin-bottom: 17px;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled(Button2)(__styleYak.FancyButton2), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(Button2)(__styleYak.FancyButton2), {
     "displayName": "FancyButton2"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/multiple-styled-components/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/multiple-styled-components/output.dev.tsx
@@ -5,19 +5,27 @@ export const Button = /*YAK Extracted CSS:
 .Button {
   background-color: #007bff;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+    "displayName": "Button"
+});
 export const Button2 = /*YAK Extracted CSS:
 .Button2 {
   background-color: #11c817;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button2);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button2), {
+    "displayName": "Button2"
+});
 export const FancyButton = /*YAK Extracted CSS:
 .FancyButton {
   margin-bottom: 23px;
 }
-*/ /*#__PURE__*/ styled(Button)(__styleYak.FancyButton);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled(Button)(__styleYak.FancyButton), {
+    "displayName": "FancyButton"
+});
 export const FancyButton2 = /*YAK Extracted CSS:
 .FancyButton2 {
   margin-bottom: 17px;
 }
-*/ /*#__PURE__*/ styled(Button2)(__styleYak.FancyButton2);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled(Button2)(__styleYak.FancyButton2), {
+    "displayName": "FancyButton2"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/nested-dynamic-mixin/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/nested-dynamic-mixin/output.dev.tsx
@@ -19,8 +19,10 @@ const ContainerFluid = /*YAK Extracted CSS:
 .ContainerFluid {
   margin-top: var(--ContainerFluid__margin-top_m7uBBu);
 }
-*/ /*#__PURE__*/ __yak.__yak_div(__styleYak.ContainerFluid, ({ $isApp, $pageHeaderHeight })=>$isApp ? /*#__PURE__*/ css(__styleYak.ContainerFluid__$isApp) : /*#__PURE__*/ css(__styleYak.ContainerFluid__not_$isApp), {
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.ContainerFluid, ({ $isApp, $pageHeaderHeight })=>$isApp ? /*#__PURE__*/ css(__styleYak.ContainerFluid__$isApp) : /*#__PURE__*/ css(__styleYak.ContainerFluid__not_$isApp), {
     "style": {
         "--ContainerFluid__margin-top_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $pageHeaderHeight })=>$pageHeaderHeight, "px")
     }
+}), {
+    "displayName": "ContainerFluid"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/nested-dynamic-mixin/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/nested-dynamic-mixin/output.dev.tsx
@@ -19,7 +19,7 @@ const ContainerFluid = /*YAK Extracted CSS:
 .ContainerFluid {
   margin-top: var(--ContainerFluid__margin-top_m7uBBu);
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.ContainerFluid, ({ $isApp, $pageHeaderHeight })=>$isApp ? /*#__PURE__*/ css(__styleYak.ContainerFluid__$isApp) : /*#__PURE__*/ css(__styleYak.ContainerFluid__not_$isApp), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.ContainerFluid, ({ $isApp, $pageHeaderHeight })=>$isApp ? /*#__PURE__*/ css(__styleYak.ContainerFluid__$isApp) : /*#__PURE__*/ css(__styleYak.ContainerFluid__not_$isApp), {
     "style": {
         "--ContainerFluid__margin-top_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $pageHeaderHeight })=>$pageHeaderHeight, "px")
     }

--- a/packages/yak-swc/yak_swc/tests/fixture/nested-selectors/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/nested-selectors/output.dev.tsx
@@ -30,4 +30,6 @@ export const Card = /*YAK Extracted CSS:
     }
   }
 }
-*/ /*#__PURE__*/ __yak.__yak_div(__styleYak.Card);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.Card), {
+    "displayName": "Card"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/nested-selectors/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/nested-selectors/output.dev.tsx
@@ -30,6 +30,6 @@ export const Card = /*YAK Extracted CSS:
     }
   }
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.Card), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.Card), {
     "displayName": "Card"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/parens/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/parens/output.dev.tsx
@@ -12,9 +12,11 @@ export const Card = /*YAK Extracted CSS:
   transform: translate(-50%, -50%) rotate(var(--Card__transform_m7uBBu))
 translate(0, -88px) rotate(var(--Card__transform_m7uBBu-01));
 }
-*/ /*#__PURE__*/ __yak.__yak_div(__styleYak.Card, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.Card__$active), {
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.Card, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.Card__$active), {
     "style": {
         "--Card__transform_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ index })=>index * 30, "deg"),
         "--Card__transform_m7uBBu-01": /*#__PURE__*/ __yak_unitPostFix(({ index })=>-index * 30, "deg")
     }
+}), {
+    "displayName": "Card"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/parens/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/parens/output.dev.tsx
@@ -12,7 +12,7 @@ export const Card = /*YAK Extracted CSS:
   transform: translate(-50%, -50%) rotate(var(--Card__transform_m7uBBu))
 translate(0, -88px) rotate(var(--Card__transform_m7uBBu-01));
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.Card, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.Card__$active), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.Card, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.Card__$active), {
     "style": {
         "--Card__transform_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ index })=>index * 30, "deg"),
         "--Card__transform_m7uBBu-01": /*#__PURE__*/ __yak_unitPostFix(({ index })=>-index * 30, "deg")

--- a/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.dev.tsx
@@ -15,7 +15,7 @@ export const FlexContainer = /*YAK Extracted CSS:
 .FlexContainer__ {
   bottom: var(--FlexContainer__bottom_m7uBBu);
 }
-*/ /*#__PURE__*/ __yak.__yak_div(__styleYak.FlexContainer, ({ $bottom })=>/*#__PURE__*/ css(__styleYak.FlexContainer__, {
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.FlexContainer, ({ $bottom })=>/*#__PURE__*/ css(__styleYak.FlexContainer__, {
         "style": {
             "--FlexContainer__bottom_m7uBBu": /*#__PURE__*/ __yak_unitPostFix($bottom * 20, "%")
         }
@@ -27,4 +27,6 @@ export const FlexContainer = /*YAK Extracted CSS:
         "--FlexContainer__margin-bottom_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $marginBottom })=>$marginBottom || '0', "px"),
         "--FlexContainer__top_m7uBBu": /*#__PURE__*/ __yak_unitPostFix(({ $top })=>$top * 20, "%")
     }
+}), {
+    "displayName": "FlexContainer"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.dev.tsx
@@ -15,7 +15,7 @@ export const FlexContainer = /*YAK Extracted CSS:
 .FlexContainer__ {
   bottom: var(--FlexContainer__bottom_m7uBBu);
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.FlexContainer, ({ $bottom })=>/*#__PURE__*/ css(__styleYak.FlexContainer__, {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.FlexContainer, ({ $bottom })=>/*#__PURE__*/ css(__styleYak.FlexContainer__, {
         "style": {
             "--FlexContainer__bottom_m7uBBu": /*#__PURE__*/ __yak_unitPostFix($bottom * 20, "%")
         }

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-componets/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-componets/output.dev.tsx
@@ -9,7 +9,7 @@ export const CustomThemedButton = /*YAK Extracted CSS:
 .CustomThemedButton {
   color: blue;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton), {
     "displayName": "CustomThemedButton"
 });
 // Should not be transformed as it is NOT yak

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-componets/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-componets/output.dev.tsx
@@ -9,7 +9,9 @@ export const CustomThemedButton = /*YAK Extracted CSS:
 .CustomThemedButton {
   color: blue;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.CustomThemedButton), {
+    "displayName": "CustomThemedButton"
+});
 // Should not be transformed as it is NOT yak
 export const StyledComponent = styled.button`
   color: ${textColor};

--- a/packages/yak-swc/yak_swc/tests/fixture/theming-with-context/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/theming-with-context/output.dev.tsx
@@ -9,7 +9,7 @@ const ThemedComponent = /*YAK Extracted CSS:
   padding: 20px;
   border-radius: 8px;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.ThemedComponent, {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.ThemedComponent, {
     "style": {
         "--ThemedComponent__background-color_m7uBBu": (props)=>props.theme.background,
         "--ThemedComponent__color_m7uBBu": (props)=>props.theme.text

--- a/packages/yak-swc/yak_swc/tests/fixture/theming-with-context/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/theming-with-context/output.dev.tsx
@@ -9,9 +9,11 @@ const ThemedComponent = /*YAK Extracted CSS:
   padding: 20px;
   border-radius: 8px;
 }
-*/ /*#__PURE__*/ __yak.__yak_div(__styleYak.ThemedComponent, {
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_div(__styleYak.ThemedComponent, {
     "style": {
         "--ThemedComponent__background-color_m7uBBu": (props)=>props.theme.background,
         "--ThemedComponent__color_m7uBBu": (props)=>props.theme.text
     }
+}), {
+    "displayName": "ThemedComponent"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/transform-only-known-elements/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/transform-only-known-elements/output.dev.tsx
@@ -5,14 +5,20 @@ export const Button = /*YAK Extracted CSS:
 .Button {
   background-color: #007bff;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+    "displayName": "Button"
+});
 export const CustomElement = /*YAK Extracted CSS:
 .CustomElement {
   margin-bottom: 23px;
 }
-*/ /*#__PURE__*/ styled("unknown")(__styleYak.CustomElement);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled("unknown")(__styleYak.CustomElement), {
+    "displayName": "CustomElement"
+});
 export const SomeThingElse = /*YAK Extracted CSS:
 .SomeThingElse {
   margin-bottom: 15px;
 }
-*/ /*#__PURE__*/ styled("something-else")(__styleYak.SomeThingElse);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled("something-else")(__styleYak.SomeThingElse), {
+    "displayName": "SomeThingElse"
+});

--- a/packages/yak-swc/yak_swc/tests/fixture/transform-only-known-elements/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/transform-only-known-elements/output.dev.tsx
@@ -5,20 +5,20 @@ export const Button = /*YAK Extracted CSS:
 .Button {
   background-color: #007bff;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
     "displayName": "Button"
 });
 export const CustomElement = /*YAK Extracted CSS:
 .CustomElement {
   margin-bottom: 23px;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled("unknown")(__styleYak.CustomElement), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled("unknown")(__styleYak.CustomElement), {
     "displayName": "CustomElement"
 });
 export const SomeThingElse = /*YAK Extracted CSS:
 .SomeThingElse {
   margin-bottom: 15px;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled("something-else")(__styleYak.SomeThingElse), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled("something-else")(__styleYak.SomeThingElse), {
     "displayName": "SomeThingElse"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/two-styled-components/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/two-styled-components/output.dev.tsx
@@ -5,27 +5,27 @@ export const Button = /*YAK Extracted CSS:
 .Button {
   background-color: #007bff;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
     "displayName": "Button"
 });
 export const FancyButton = /*YAK Extracted CSS:
 .FancyButton {
   margin-bottom: 23px;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled(Button)(__styleYak.FancyButton), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(Button)(__styleYak.FancyButton), {
     "displayName": "FancyButton"
 });
 export const Button2 = /*YAK Extracted CSS:
 .Button2 {
   background-color: #007bfb;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button2), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button2), {
     "displayName": "Button2"
 });
 export const Button3 = /*YAK Extracted CSS:
 .Button3 {
   background-color: #007bfb;
 }
-*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled("button")(__styleYak.Button3), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled("button")(__styleYak.Button3), {
     "displayName": "Button3"
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/two-styled-components/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/two-styled-components/output.dev.tsx
@@ -5,19 +5,27 @@ export const Button = /*YAK Extracted CSS:
 .Button {
   background-color: #007bff;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button), {
+    "displayName": "Button"
+});
 export const FancyButton = /*YAK Extracted CSS:
 .FancyButton {
   margin-bottom: 23px;
 }
-*/ /*#__PURE__*/ styled(Button)(__styleYak.FancyButton);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled(Button)(__styleYak.FancyButton), {
+    "displayName": "FancyButton"
+});
 export const Button2 = /*YAK Extracted CSS:
 .Button2 {
   background-color: #007bfb;
 }
-*/ /*#__PURE__*/ __yak.__yak_button(__styleYak.Button2);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button2), {
+    "displayName": "Button2"
+});
 export const Button3 = /*YAK Extracted CSS:
 .Button3 {
   background-color: #007bfb;
 }
-*/ /*#__PURE__*/ styled("button")(__styleYak.Button3);
+*/ /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ styled("button")(__styleYak.Button3), {
+    "displayName": "Button3"
+});


### PR DESCRIPTION
When enabled, assigns a `displayName` matching the component name to each yak-styled component. This improves the developer experience when using React Developer Tools.

The setting is disabled by default and only has an effect in dev mode.

For example:
```ts
 /*#__PURE__*/ globalThis.Object.assign(/*#__PURE__*/ __yak.__yak_button(__styleYak.Button2), {
    "displayName": "Button2"
});
```

Applied to the example app:
![image](https://github.com/user-attachments/assets/d3f664cb-ba5d-4bda-9a49-1b292a24e70d)

resolves #292
