### PR TITLE
Support `atoms` in CSS prop

### DIFF
--- a/.changeset/ninety-tips-attack.md
+++ b/.changeset/ninety-tips-attack.md
@@ -1,0 +1,6 @@
+---
+"next-yak": patch
+"yak-swc": patch
+---
+
+Added support for using the atoms function directly in the css prop

--- a/packages/docs/content/docs/features.mdx
+++ b/packages/docs/content/docs/features.mdx
@@ -554,6 +554,25 @@ It's meant for simple styling requirements, where you don't have to think about 
 
 The `css` prop is allowed on any element that can accept `className` and `style`.
 
+### Using atoms with the css prop
+
+The `css` prop also fully supports the `atoms` function, allowing you to use utility classes directly and conditionally:
+
+```jsx title="my-component-with-atoms.tsx"
+import { atoms } from 'next-yak';
+
+const Component = () => {
+  const isDefault = true;
+  return <div css={atoms("flex p-4 bg-blue-500",
+      isDefault ? "text-white" : "text-gray-500",
+      "rounded")}>
+    Hello there!
+  </div>
+}
+```
+
+Both `css` template literals and `atoms` can be used interchangeably in the css prop, as they're designed to be compatible with each other.
+
 ### TypeScript
 
 To use it with the correct types just add the following line to the top of the file

--- a/packages/example/app/globals.css
+++ b/packages/example/app/globals.css
@@ -1,6 +1,5 @@
 @layer global, base;
 @layer global {
-
   * {
     box-sizing: border-box;
     padding: 0;
@@ -28,4 +27,10 @@
     }
   }
 
+  .salmon {
+    color: salmon;
+  }
+  .indigo {
+    color: indigo;
+  }
 }

--- a/packages/example/app/page.tsx
+++ b/packages/example/app/page.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource next-yak */
-import { YakThemeProvider, css, styled } from "next-yak";
+import { YakThemeProvider, atoms, css, styled } from "next-yak";
 import styles from "./page.module.css";
 import { queries, colors } from "@/theme/constants.yak";
 import { Clock } from "./Clock";
@@ -211,6 +211,16 @@ export default function Home() {
           >
             and this is teal
           </span>
+        </p>
+        <p css={atoms("salmon")}>
+          Atoms in css props work if this is <span>salmon</span>
+          <span
+            css={atoms("salmon", true && "indigo", false && "indigo")}
+            className="test"
+          >
+            {" "}
+            and this is indigo
+          </span>{" "}
         </p>
         <Inputs />
       </main>

--- a/packages/next-yak/runtime/__tests__/cssPropTest.tsx
+++ b/packages/next-yak/runtime/__tests__/cssPropTest.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource next-yak */
 // this is only a type check file and should not be executed
 
-import { css, styled } from "next-yak";
+import { atoms, css, styled } from "next-yak";
 import { ComponentProps, CSSProperties } from "react";
 
 declare module "next-yak" {
@@ -32,6 +32,10 @@ const ComponentThatTakesCssProp = (p: {
   className?: string;
   style?: ComponentProps<"div">["style"];
 }) => <div {...p}>anything</div>;
+
+const ComponentWithCssPropAsPropThatUsesAtoms = () => {
+  return <ComponentThatTakesCssProp css={atoms("")} />;
+};
 
 const ComponentThatTakesCssProp2 = (p: {
   className?: string | string[];
@@ -208,4 +212,16 @@ const ComponentWithCSSThatUsesDynamicMixinShouldGenerateTypeError = () => {
       `}
     />
   );
+};
+
+const BothCSSAndAtomsShouldBeHandledTheSame = () => {
+  const customAtoms = atoms("");
+  const mixin = css``;
+
+  // type test if they're compatible
+  type t = typeof customAtoms extends typeof mixin ? true : false;
+  const _: true = {} as t;
+
+  <div css={customAtoms} />;
+  <div css={mixin} />;
 };

--- a/packages/next-yak/runtime/atoms.tsx
+++ b/packages/next-yak/runtime/atoms.tsx
@@ -1,3 +1,5 @@
+import { combineProps, ComponentStyles } from "./cssLiteral.js";
+
 /**
  * Allows to use atomic CSS classes in a styled or css block
  *
@@ -12,7 +14,10 @@
  * `;
  * ```
  */
-export const atoms = (...atoms: string[]) => {
-  const className = atoms.join(" ");
-  return () => ({ className });
+export const atoms = (...atoms: string[]): ComponentStyles<unknown> => {
+  return (props: any) => {
+    return combineProps(props, {
+      className: atoms.filter(Boolean).join(" "),
+    });
+  };
 };

--- a/packages/yak-swc/yak_swc/src/utils/css_prop.rs
+++ b/packages/yak-swc/yak_swc/src/utils/css_prop.rs
@@ -226,13 +226,13 @@ impl TransformError {
   fn message(&self) -> &'static str {
     match self {
             TransformError::InvalidCSSAttribute(_) =>
-                "Invalid CSS attribute. The 'css' prop should contain a valid CSS-in-JS expression. \
-                Example: css={css`color: red;`}",
+            "Invalid CSS attribute. The 'css' prop should contain a valid CSS-in-JS expression or atoms function call. \
+              Example: css={css`color: red;`} or css={atoms(\"m-8 p-6\",\"flex\")}",
 
             TransformError::UnsupportedSpreadElement(_) =>
                 "Spread elements are not supported in the 'css' prop. \
-                    Instead, use a css template literals for your styles. \
-                    Example: css={css`color: red;`}",
+                    Instead, use a css template literals or atoms function for your styles. \
+                    Example: css={css`color: red;`} or css={atoms(\"m-8 p-6\")}",
 
             TransformError::InvalidJSXAttribute(_) =>
                 "Invalid JSX attribute detected. Ensure all attributes have valid names and values. \

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-atoms/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-atoms/input.tsx
@@ -1,0 +1,43 @@
+import { styled, atoms } from "next-yak";
+
+const Elem = () => <div css={atoms("mb-8 flex flex-col")} />;
+
+const Elem2 = () => (
+  <div css={atoms("mb-8 flex flex-col")} className="test-class" />
+);
+
+const Elem3 = () => (
+  <div style={{ padding: "5px" }} css={atoms("mb-8 flex flex-col")} />
+);
+
+const Elem4 = (props: any) => (
+  <div css={atoms("mb-8 flex flex-col")} {...props} />
+);
+
+const Elem5 = (props: any) => (
+  <div css={atoms("mb-8 flex flex-col")} {...props.a} {...props.b} />
+);
+
+const Elem6 = () => (
+  <div
+    css={atoms("mb-8 flex flex-col")}
+    className="main"
+    style={{ fontWeight: "bold" }}
+  />
+);
+
+const Elem7 = () => <div className="no-css" />;
+
+const Elem8 = () => <div css={atoms("")} className="empty-css" />;
+
+const Elem9 = (isSomething: boolean) => (
+  <div css={atoms("flex gap-4", isSomething ? "basis-8/12" : "w-full")} />
+);
+
+const Text = styled.p`
+  font-size: 20px;
+`;
+
+const StyledComponentWithCSSProp = () => (
+  <Text css={atoms("mb-8 flex flex-col")}>test</Text>
+);

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-atoms/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-atoms/output.dev.tsx
@@ -1,0 +1,38 @@
+import { styled, atoms } from "next-yak/internal";
+import * as __yak from "next-yak/internal";
+import "./input.yak.module.css!=!./input?./input.yak.module.css";
+const Elem = ()=><div {...atoms("mb-8 flex flex-col")({})}/>;
+const Elem2 = ()=><div {...atoms("mb-8 flex flex-col")({
+        className: "test-class"
+    })}/>;
+const Elem3 = ()=><div {...atoms("mb-8 flex flex-col")({
+        style: {
+            padding: "5px"
+        }
+    })}/>;
+const Elem4 = (props: any)=><div {...atoms("mb-8 flex flex-col")({
+        ...props
+    })}/>;
+const Elem5 = (props: any)=><div {...atoms("mb-8 flex flex-col")({
+        ...props.a,
+        ...props.b
+    })}/>;
+const Elem6 = ()=><div {...atoms("mb-8 flex flex-col")({
+        className: "main",
+        style: {
+            fontWeight: "bold"
+        }
+    })}/>;
+const Elem7 = ()=><div className="no-css"/>;
+const Elem8 = ()=><div {...atoms("")({
+        className: "empty-css"
+    })}/>;
+const Elem9 = (isSomething: boolean)=><div {...atoms("flex gap-4", isSomething ? "basis-8/12" : "w-full")({})}/>;
+const Text = /*YAK Extracted CSS:
+:global(.input_Text_m7uBBu) {
+  font-size: 20px;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_p("input_Text_m7uBBu"), {
+    "displayName": "Text"
+});
+const StyledComponentWithCSSProp = ()=><Text {...atoms("mb-8 flex flex-col")({})}>test</Text>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-atoms/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-atoms/output.prod.tsx
@@ -1,0 +1,36 @@
+import { styled, atoms } from "next-yak/internal";
+import * as __yak from "next-yak/internal";
+import "./input.yak.module.css!=!./input?./input.yak.module.css";
+const Elem = ()=><div {...atoms("mb-8 flex flex-col")({})}/>;
+const Elem2 = ()=><div {...atoms("mb-8 flex flex-col")({
+        className: "test-class"
+    })}/>;
+const Elem3 = ()=><div {...atoms("mb-8 flex flex-col")({
+        style: {
+            padding: "5px"
+        }
+    })}/>;
+const Elem4 = (props: any)=><div {...atoms("mb-8 flex flex-col")({
+        ...props
+    })}/>;
+const Elem5 = (props: any)=><div {...atoms("mb-8 flex flex-col")({
+        ...props.a,
+        ...props.b
+    })}/>;
+const Elem6 = ()=><div {...atoms("mb-8 flex flex-col")({
+        className: "main",
+        style: {
+            fontWeight: "bold"
+        }
+    })}/>;
+const Elem7 = ()=><div className="no-css"/>;
+const Elem8 = ()=><div {...atoms("")({
+        className: "empty-css"
+    })}/>;
+const Elem9 = (isSomething: boolean)=><div {...atoms("flex gap-4", isSomething ? "basis-8/12" : "w-full")({})}/>;
+const Text = /*YAK Extracted CSS:
+:global(.ym7uBBu) {
+  font-size: 20px;
+}
+*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBu");
+const StyledComponentWithCSSProp = ()=><Text {...atoms("mb-8 flex flex-col")({})}>test</Text>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.dev.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.dev.stderr
@@ -1,4 +1,4 @@
-  x Invalid CSS attribute. The 'css' prop should contain a valid CSS-in-JS expression. Example: css={css`color: red;`}
+  x Invalid CSS attribute. The 'css' prop should contain a valid CSS-in-JS expression or atoms function call. Example: css={css`color: red;`} or css={atoms("m-8 p-6","flex")}
    ,-[input.js:3:1]
  2 | 
  3 | const Elem = () => <div css="invalid" />;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.prod.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.prod.stderr
@@ -1,4 +1,4 @@
-  x Invalid CSS attribute. The 'css' prop should contain a valid CSS-in-JS expression. Example: css={css`color: red;`}
+  x Invalid CSS attribute. The 'css' prop should contain a valid CSS-in-JS expression or atoms function call. Example: css={css`color: red;`} or css={atoms("m-8 p-6","flex")}
    ,-[input.js:3:1]
  2 | 
  3 | const Elem = () => <div css="invalid" />;


### PR DESCRIPTION
This supersedes #291 

> Completing this PR will add the possibility to use atoms directly in the css prop. E.g.
```jsx
<div
  css={atoms('flex gap-4', isSomething ? 'basis-8/12' : 'w-full')}
/>
```

Based on #307 the change to add the atoms functionality is trivial, as the transpilation step can stay the same and only the runtime API of the `atoms` function has to be changed.