### PR TITLE
fix-class-name-escaping

### DIFF
--- a/.changeset/thirty-badgers-wait.md
+++ b/.changeset/thirty-badgers-wait.md
@@ -1,0 +1,6 @@
+---
+"yak-swc": patch
+"next-yak": patch
+---
+
+fix class name escaping in dev mode

--- a/packages/cross-file-tests/__tests__/fixtures/sameFileMixin/output/index.tsx
+++ b/packages/cross-file-tests/__tests__/fixtures/sameFileMixin/output/index.tsx
@@ -9,13 +9,13 @@ var Button = /*YAK Extracted CSS:
 :global(.index_Button_xEUJ1U) {
   color: black;
 }
-:global(.index_Button__$disabled_xEUJ1U) {
+:global(.index_Button__\$disabled_xEUJ1U) {
   opacity: 0.5;
 }
-:global(.index_Button__$hasIcon_xEUJ1U) {
+:global(.index_Button__\$hasIcon_xEUJ1U) {
   padding-left: 30px;
 }
-:global(.index_Button__$disabled_xEUJ1U-01) {
+:global(.index_Button__\$disabled_xEUJ1U-01) {
   color: gray;
 }
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button("index_Button_xEUJ1U", function(param) {

--- a/packages/cross-file-tests/__tests__/fixtures/sameFileMixin/output/index.yak.module.css
+++ b/packages/cross-file-tests/__tests__/fixtures/sameFileMixin/output/index.yak.module.css
@@ -2,12 +2,12 @@
 :global(.index_Button_xEUJ1U) {
   color: black;
 }
-:global(.index_Button__$disabled_xEUJ1U) {
+:global(.index_Button__\$disabled_xEUJ1U) {
   opacity: 0.5;
 }
-:global(.index_Button__$hasIcon_xEUJ1U) {
+:global(.index_Button__\$hasIcon_xEUJ1U) {
   padding-left: 30px;
 }
-:global(.index_Button__$disabled_xEUJ1U-01) {
+:global(.index_Button__\$disabled_xEUJ1U-01) {
   color: gray;
 }

--- a/packages/yak-swc/yak_swc/src/yak_transforms.rs
+++ b/packages/yak-swc/yak_swc/src/yak_transforms.rs
@@ -12,7 +12,7 @@ use swc_core::common::{source_map::PURE_SP, Span, Spanned, SyntaxContext, DUMMY_
 use swc_core::ecma::ast::*;
 use swc_core::plugin::errors::HANDLER;
 
-use crate::naming_convention::NamingConvention;
+use crate::naming_convention::{get_css_modules_class_name, NamingConvention};
 
 /// Represents a CSS result after the transformation
 #[derive(Debug)]
@@ -79,7 +79,7 @@ impl YakTransform for TransformNestedCss {
     let mut parser_state = previous_parser_state.clone().unwrap();
     // The first scope is the class name which gets attached to the element
     parser_state.current_scopes[0] = CssScope {
-      name: format!(":global(.{})", self.class_name),
+      name: get_css_modules_class_name(&self.class_name),
       scope_type: ScopeType::Selector,
     };
     parser_state
@@ -166,7 +166,7 @@ impl YakTransform for TransformCssMixin {
   fn create_css_state(&self, _previous_parser_state: Option<ParserState>) -> ParserState {
     let mut parser_state = ParserState::new();
     parser_state.current_scopes = vec![CssScope {
-      name: format!(":global(.{})", self.class_name),
+      name: get_css_modules_class_name(&self.class_name),
       scope_type: ScopeType::AtRule,
     }];
     parser_state
@@ -412,7 +412,7 @@ impl YakTransform for TransformStyled {
   fn create_css_state(&self, _previous_parser_state: Option<ParserState>) -> ParserState {
     let mut parser_state = ParserState::new();
     parser_state.current_scopes = vec![CssScope {
-      name: format!(":global(.{})", self.class_name),
+      name: get_css_modules_class_name(&self.class_name),
       scope_type: ScopeType::AtRule,
     }];
     parser_state
@@ -474,7 +474,7 @@ impl YakTransform for TransformStyled {
 
   /// Get the selector for the specific styled component to be used in other expressions
   fn get_css_reference_name(&self) -> Option<String> {
-    Some(format!(":global(.{})", self.class_name))
+    Some(get_css_modules_class_name(&self.class_name))
   }
 }
 

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-dynamic-export/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-dynamic-export/output.dev.tsx
@@ -25,7 +25,7 @@ export const Button = /*YAK Extracted CSS:
     color: black;
   }
 }
-:global(.input_Button__-and-$active_m7uBBu) {
+:global(.input_Button__-and-\$active_m7uBBu) {
   &:hover {
     color: red;
   }
@@ -36,7 +36,7 @@ export const Button = /*YAK Extracted CSS:
     color: black;
   }
 }
-:global(.input_Button__$active_m7uBBu) {
+:global(.input_Button__\$active_m7uBBu) {
   &:focus {
     color: red;
   }
@@ -47,7 +47,7 @@ export const Button = /*YAK Extracted CSS:
     color: black;
   }
 }
-:global(.input_Button__$active_m7uBBu-01) {
+:global(.input_Button__\$active_m7uBBu-01) {
   &:focus {
     color: red;
   }

--- a/packages/yak-swc/yak_swc/tests/fixture/css-mixin-inline/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-mixin-inline/output.dev.tsx
@@ -7,7 +7,7 @@ export const ThemedButton = /*YAK Extracted CSS:
     color: black;
   }
 }
-:global(.input_ThemedButton__$active_m7uBBu) {
+:global(.input_ThemedButton__\$active_m7uBBu) {
   &:hover {
     color: red;
   }

--- a/packages/yak-swc/yak_swc/tests/fixture/css-mixin-nested/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-mixin-nested/output.dev.tsx
@@ -17,7 +17,7 @@ export const ThemedButton = /*YAK Extracted CSS:
   border-radius: 5px;
   cursor: pointer;
 }
-:global(.input_ThemedButton__$active_m7uBBu) {
+:global(.input_ThemedButton__\$active_m7uBBu) {
   @media (max-width: 600px) {
     background-color: #f0f0f0;
     max-width: var(--input_ThemedButton__max-width_m7uBBu);
@@ -47,7 +47,7 @@ export const CustomThemedButton = /*YAK Extracted CSS:
     cursor: pointer;
   }
 }
-:global(.input_CustomThemedButton__$active_m7uBBu) {
+:global(.input_CustomThemedButton__\$active_m7uBBu) {
   &:not([disabled]) {
     @media (max-width: 600px) {
       background-color: #f0f0f0;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-mixin/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-mixin/output.dev.tsx
@@ -19,7 +19,7 @@ export const ThemedButton = /*YAK Extracted CSS:
   border-radius: 5px;
   cursor: pointer;
 }
-:global(.input_ThemedButton__$active_m7uBBu) {
+:global(.input_ThemedButton__\$active_m7uBBu) {
   background-color: #f0f0f0;
   max-width: var(--input_ThemedButton__max-width_m7uBBu);
 }
@@ -50,7 +50,7 @@ export const CustomThemedButton = /*YAK Extracted CSS:
   border-radius: 5px;
   cursor: pointer;
 }
-:global(.input_CustomThemedButton__$active_m7uBBu) {
+:global(.input_CustomThemedButton__\$active_m7uBBu) {
   background-color: #f0f0f0;
   max-width: var(--input_CustomThemedButton__max-width_m7uBBu);
 }

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.dev.tsx
@@ -2,10 +2,10 @@ import { styled, css, keyframes } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
 import "./input.yak.module.css!=!./input?./input.yak.module.css";
 export const FadeInText = /*YAK Extracted CSS:
-:global(.input_FadeInText__$reverse_m7uBBu) {
+:global(.input_FadeInText__\$reverse_m7uBBu) {
   animation: fadeOut_m7uBBu 1s ease-in;
 }
-:global(.input_FadeInText__not_$reverse_m7uBBu) {
+:global(.input_FadeInText__not_\$reverse_m7uBBu) {
   animation: fadeIn_m7uBBu 1s ease-in;
 }
 :global(.input_FadeInText_m7uBBu) {

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.dev.tsx
@@ -2,10 +2,10 @@ import { styled, css, keyframes } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
 import "./input.yak.module.css!=!./input?./input.yak.module.css";
 export const FadeInText = /*YAK Extracted CSS:
-:global(.input_FadeInText__$reverse_m7uBBu) {
+:global(.input_FadeInText__\$reverse_m7uBBu) {
   animation: animations_fadeOut_m7uBBu 1s ease-in;
 }
-:global(.input_FadeInText__not_$reverse_m7uBBu) {
+:global(.input_FadeInText__not_\$reverse_m7uBBu) {
   animation: animations_fadeIn_m7uBBu 1s ease-in;
 }
 :global(.input_FadeInText_m7uBBu) {

--- a/packages/yak-swc/yak_swc/tests/fixture/nested-dynamic-mixin/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/nested-dynamic-mixin/output.dev.tsx
@@ -10,10 +10,10 @@ const ContainerFluid = /*YAK Extracted CSS:
   padding-top: 20px;
   max-width: 100%;
 }
-:global(.input_ContainerFluid__$isApp_m7uBBu) {
+:global(.input_ContainerFluid__\$isApp_m7uBBu) {
   margin-top: unset;
 }
-:global(.input_ContainerFluid__not_$isApp_m7uBBu) {
+:global(.input_ContainerFluid__not_\$isApp_m7uBBu) {
   margin-top: px;
 }
 :global(.input_ContainerFluid_m7uBBu) {

--- a/packages/yak-swc/yak_swc/tests/fixture/parens/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/parens/output.dev.tsx
@@ -5,7 +5,7 @@ export const Card = /*YAK Extracted CSS:
 :global(.input_Card_m7uBBu) {
   background: url("/card-bg.jpg") no-repeat;
 }
-:global(.input_Card__$active_m7uBBu) {
+:global(.input_Card__\$active_m7uBBu) {
   backgorund: url(/card-bg-active.jpg) no-repeat;
 }
 :global(.input_Card_m7uBBu) {


### PR DESCRIPTION
This PR addresses CSS class name escaping issues that caused rendering problems in development mode. 

The implementation now correctly handles special characters like `$`, `[`, `]` and emoji by preserving them in HTML class attributes while properly escaping them in CSS selectors