### PR TITLE
Fix keyframe animation references when used before declaration 

### DIFF
--- a/.changeset/fair-shoes-hope.md
+++ b/.changeset/fair-shoes-hope.md
@@ -1,0 +1,6 @@
+---
+"yak-swc": patch
+"next-yak": patch
+---
+
+Fix reference of animations

--- a/.changeset/fair-shoes-hope.md
+++ b/.changeset/fair-shoes-hope.md
@@ -3,4 +3,4 @@
 "next-yak": patch
 ---
 
-Fix reference of animations
+Fix keyframe animation references when used before declaration

--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -332,7 +332,7 @@ where
                 self
                   .variable_name_selector_mapping
                   .insert(scoped_name.clone(), keyframe_name.clone());
-                let (new_state, _) = parse_css(keyframe_name.as_str(), css_state);
+                let (new_state, _) = parse_css(&format!(":global({})", keyframe_name), css_state);
                 css_state = Some(new_state);
               } else {
                 HANDLER.with(|handler| {

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.dev.tsx
@@ -3,10 +3,10 @@ import * as __yak from "next-yak/internal";
 import "./input.yak.module.css!=!./input?./input.yak.module.css";
 export const FadeInText = /*YAK EXPORTED STYLED:FadeInText:input_FadeInText_m7uBBu*//*YAK Extracted CSS:
 :global(.input_FadeInText__\$reverse_m7uBBu) {
-  animation: fadeOut_m7uBBu 1s ease-in;
+  animation: :global(fadeOut_m7uBBu) 1s ease-in;
 }
 :global(.input_FadeInText__not_\$reverse_m7uBBu) {
-  animation: fadeIn_m7uBBu 1s ease-in;
+  animation: :global(fadeIn_m7uBBu) 1s ease-in;
 }
 :global(.input_FadeInText_m7uBBu) {
   font-size: 18px;

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.prod.tsx
@@ -3,10 +3,10 @@ import * as __yak from "next-yak/internal";
 import "./input.yak.module.css!=!./input?./input.yak.module.css";
 export const FadeInText = /*YAK EXPORTED STYLED:FadeInText:ym7uBBu*//*YAK Extracted CSS:
 :global(.ym7uBBu1) {
-  animation: ym7uBBu2 1s ease-in;
+  animation: :global(ym7uBBu2) 1s ease-in;
 }
 :global(.ym7uBBu3) {
-  animation: ym7uBBu4 1s ease-in;
+  animation: :global(ym7uBBu4) 1s ease-in;
 }
 :global(.ym7uBBu) {
   font-size: 18px;

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.dev.tsx
@@ -3,10 +3,10 @@ import * as __yak from "next-yak/internal";
 import "./input.yak.module.css!=!./input?./input.yak.module.css";
 export const FadeInText = /*YAK EXPORTED STYLED:FadeInText:input_FadeInText_m7uBBu*//*YAK Extracted CSS:
 :global(.input_FadeInText__\$reverse_m7uBBu) {
-  animation: animations_fadeOut_m7uBBu 1s ease-in;
+  animation: :global(animations_fadeOut_m7uBBu) 1s ease-in;
 }
 :global(.input_FadeInText__not_\$reverse_m7uBBu) {
-  animation: animations_fadeIn_m7uBBu 1s ease-in;
+  animation: :global(animations_fadeIn_m7uBBu) 1s ease-in;
 }
 :global(.input_FadeInText_m7uBBu) {
   font-size: 18px;

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.prod.tsx
@@ -3,10 +3,10 @@ import * as __yak from "next-yak/internal";
 import "./input.yak.module.css!=!./input?./input.yak.module.css";
 export const FadeInText = /*YAK EXPORTED STYLED:FadeInText:ym7uBBu*//*YAK Extracted CSS:
 :global(.ym7uBBu1) {
-  animation: ym7uBBu2 1s ease-in;
+  animation: :global(ym7uBBu2) 1s ease-in;
 }
 :global(.ym7uBBu3) {
-  animation: ym7uBBu4 1s ease-in;
+  animation: :global(ym7uBBu4) 1s ease-in;
 }
 :global(.ym7uBBu) {
   font-size: 18px;


### PR DESCRIPTION
This PR addresses an issue where keyframe animations would not work properly when referenced in an animation property before the keyframe was declared in the code. 
When keyframes were referenced before their declaration, the animation reference in the CSS wasn't properly wrapped with `:global()`, causing CSS modules to generate different names for the animation reference and the keyframe declaration. This resulted in broken animations in the compiled output.

For example:
```css
/* What was happening */
.Component {
  animation: animationName_i9blVg 1s ease; /* Missing :global() wrapper */
}

@keyframes :global(animationName_i9blVg) {
  from { opacity: 0; }
  to { opacity: 1; }
}
```

This pr modified the Rust code to ensure that keyframe references are properly wrapped with `:global()` even when the keyframe itself hasn't been parsed yet. This ensures consistent naming across both animation references and keyframe declarations.

Closes #320 
 