### PR TITLE
Use global instead of :global in animation references

### DIFF
--- a/.changeset/chilled-cows-peel.md
+++ b/.changeset/chilled-cows-peel.md
@@ -1,0 +1,6 @@
+---
+"yak-swc": patch
+"next-yak": patch
+---
+
+Fix animation references by using "global()" instead of ":global()"

--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -332,7 +332,7 @@ where
                 self
                   .variable_name_selector_mapping
                   .insert(scoped_name.clone(), keyframe_name.clone());
-                let (new_state, _) = parse_css(&format!(":global({})", keyframe_name), css_state);
+                let (new_state, _) = parse_css(&format!("global({})", keyframe_name), css_state);
                 css_state = Some(new_state);
               } else {
                 HANDLER.with(|handler| {

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.dev.tsx
@@ -3,10 +3,10 @@ import * as __yak from "next-yak/internal";
 import "./input.yak.module.css!=!./input?./input.yak.module.css";
 export const FadeInText = /*YAK EXPORTED STYLED:FadeInText:input_FadeInText_m7uBBu*//*YAK Extracted CSS:
 :global(.input_FadeInText__\$reverse_m7uBBu) {
-  animation: :global(fadeOut_m7uBBu) 1s ease-in;
+  animation: global(fadeOut_m7uBBu) 1s ease-in;
 }
 :global(.input_FadeInText__not_\$reverse_m7uBBu) {
-  animation: :global(fadeIn_m7uBBu) 1s ease-in;
+  animation: global(fadeIn_m7uBBu) 1s ease-in;
 }
 :global(.input_FadeInText_m7uBBu) {
   font-size: 18px;

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.prod.tsx
@@ -3,10 +3,10 @@ import * as __yak from "next-yak/internal";
 import "./input.yak.module.css!=!./input?./input.yak.module.css";
 export const FadeInText = /*YAK EXPORTED STYLED:FadeInText:ym7uBBu*//*YAK Extracted CSS:
 :global(.ym7uBBu1) {
-  animation: :global(ym7uBBu2) 1s ease-in;
+  animation: global(ym7uBBu2) 1s ease-in;
 }
 :global(.ym7uBBu3) {
-  animation: :global(ym7uBBu4) 1s ease-in;
+  animation: global(ym7uBBu4) 1s ease-in;
 }
 :global(.ym7uBBu) {
   font-size: 18px;

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.dev.tsx
@@ -3,10 +3,10 @@ import * as __yak from "next-yak/internal";
 import "./input.yak.module.css!=!./input?./input.yak.module.css";
 export const FadeInText = /*YAK EXPORTED STYLED:FadeInText:input_FadeInText_m7uBBu*//*YAK Extracted CSS:
 :global(.input_FadeInText__\$reverse_m7uBBu) {
-  animation: :global(animations_fadeOut_m7uBBu) 1s ease-in;
+  animation: global(animations_fadeOut_m7uBBu) 1s ease-in;
 }
 :global(.input_FadeInText__not_\$reverse_m7uBBu) {
-  animation: :global(animations_fadeIn_m7uBBu) 1s ease-in;
+  animation: global(animations_fadeIn_m7uBBu) 1s ease-in;
 }
 :global(.input_FadeInText_m7uBBu) {
   font-size: 18px;

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.prod.tsx
@@ -3,10 +3,10 @@ import * as __yak from "next-yak/internal";
 import "./input.yak.module.css!=!./input?./input.yak.module.css";
 export const FadeInText = /*YAK EXPORTED STYLED:FadeInText:ym7uBBu*//*YAK Extracted CSS:
 :global(.ym7uBBu1) {
-  animation: :global(ym7uBBu2) 1s ease-in;
+  animation: global(ym7uBBu2) 1s ease-in;
 }
 :global(.ym7uBBu3) {
-  animation: :global(ym7uBBu4) 1s ease-in;
+  animation: global(ym7uBBu4) 1s ease-in;
 }
 :global(.ym7uBBu) {
   font-size: 18px;


### PR DESCRIPTION
With #321 I broke the references for animations. This PR should fix the issue and correct the syntax using `global()` instead of `:global()` for animation references.