### PR TITLE
prevent turbopack panic by adding support for relative filepaths

### DIFF
--- a/.changeset/bright-kiwis-taste.md
+++ b/.changeset/bright-kiwis-taste.md
@@ -1,0 +1,6 @@
+---
+"yak-swc": patch
+"next-yak": patch
+---
+
+Add support for turbopacks relative filepaths

--- a/packages/yak-swc/relative_posix_path/src/lib.rs
+++ b/packages/yak-swc/relative_posix_path/src/lib.rs
@@ -9,8 +9,12 @@ extern crate lazy_static;
 /// - "/foo/", "/bar/baz.txt" -> "../bar/baz.txt"
 /// - "C:\foo\", "C:\foo\baz.txt" -> "../bar/baz.txt"
 ///
-/// The format of `base_path` and `filename` must match the current OS.
+/// Works with both absolute and relative paths
 pub fn relative_posix_path(base_path: &str, filename: &str) -> String {
+  if !is_absolute_path(filename) {
+    return convert_path_to_posix(filename);
+  }
+
   let normalized_base_path = convert_path_to_posix(base_path);
   let normalized_filename = convert_path_to_posix(filename);
   let relative_filename =
@@ -21,6 +25,15 @@ pub fn relative_posix_path(base_path: &str, filename: &str) -> String {
     .collect::<Vec<&str>>();
 
   path_parts.join("/")
+}
+
+/// Checks if the given path is an absolute path
+///
+/// For example:
+/// - "/foo/bar" -> true
+/// - "C:\foo\bar" -> true
+fn is_absolute_path(path: &str) -> bool {
+  path.starts_with('/') || path.starts_with('\\') || (path.len() > 2 && (&path[1..3] == ":\\" || &path[1..3] == ":/"))
 }
 
 /// Returns the path converted to a POSIX path (naive approach).
@@ -65,6 +78,19 @@ mod tests {
   }
 
   #[test]
+  fn test_relative_path_posix_relative_path() {
+    assert_eq!(relative_posix_path(r"/foo", "bar/file.tsx"), "bar/file.tsx");
+  }
+
+  #[test]
+  fn test_relative_path_windows_relative_path() {
+    assert_eq!(
+      relative_posix_path(r"E:\foo", "bar\\file.tsx"),
+      "bar/file.tsx"
+    );
+  }
+
+  #[test]
   fn test_convert_unix_path() {
     assert_eq!(convert_path_to_posix(r"/foo/bar"), "/foo/bar");
   }
@@ -72,5 +98,14 @@ mod tests {
   #[test]
   fn test_convert_windows_path() {
     assert_eq!(convert_path_to_posix(r"C:\foo\bar"), "C/foo/bar");
+  }
+
+  #[test]
+  fn test_is_absolute_path() {
+    assert!(is_absolute_path("/foo/bar"));
+    assert!(is_absolute_path("C:\\foo\\bar"));
+    assert!(!is_absolute_path("foo/bar"));
+    assert!(!is_absolute_path("C:foo\\bar"));
+    assert!(!is_absolute_path("f"));
   }
 }


### PR DESCRIPTION
This PR enhances the `relative_posix_path` utility to handle both absolute and relative paths, ensuring compatibility with Turbopack.

Following the fix in vercel/next.js#78637 by @kdy1, Turbopack now correctly provides filepath information to SWC plugins through `TransformPluginMetadataContextKind::Filename`. However, there's a key difference in behavior:

- Webpack provides absolute paths (e.g., `/full/path/to/app/layout.tsx`)
- Turbopack provides relative paths (e.g., `app/layout.tsx`)

Our code previously expected only absolute paths which still caused panics when run with Turbopack
The new absolute/relative path detection in this PR handles this for both cases correctly