### PR TITLE
Add error boundary for shiki-magic-move in safari

### DIFF
--- a/packages/docs/components/errorBoundary.tsx
+++ b/packages/docs/components/errorBoundary.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { Component, ReactNode } from "react";
+
+interface Props {
+  fallback?: ReactNode;
+  children?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: { hasError: boolean };
+
+  constructor(props: { fallback: ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  componentDidCatch() {}
+
+  render() {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/docs/components/landingPage.tsx
+++ b/packages/docs/components/landingPage.tsx
@@ -4,6 +4,7 @@ import { breakpoints, colors, theme } from "@/lib/utils/constants";
 import NextLink from "next/link";
 import NextImage from "next/image";
 import yakJumping from "@/public/img/yak-jumping.png";
+import { ErrorBoundary } from "./errorBoundary";
 
 export const LandingPage = () => {
   return (
@@ -123,7 +124,9 @@ export const LandingPage = () => {
           JavaScript.
         </li>
       </List>
-      <AnimatedCode />
+      <ErrorBoundary fallback={null}>
+        <AnimatedCode />
+      </ErrorBoundary>
     </Article>
   );
 };


### PR DESCRIPTION
This PR adds an `<ErrorBoundary>` for `shiki-magic-move` in safari:

<img width="1141" alt="image" src="https://github.com/user-attachments/assets/592339ce-2d6e-4a74-b180-4027410780ef" />
