### PR TITLE
Set regexp engine to forgiving for safari

### DIFF
--- a/packages/docs/lib/shiki.ts
+++ b/packages/docs/lib/shiki.ts
@@ -11,5 +11,6 @@ import styled from "./langs/styled";
 export const highlighterPromise = createHighlighterCore({
   themes: [vitesseLight, vitesseDark],
   langs: [tsx, ts, css, cssStyled, styled],
-  engine: createJavaScriptRegexEngine(),
+  // forgiving is set for safari, as the RegExp engine is not fully compatible with Safari's RegExp implementation
+  engine: createJavaScriptRegexEngine({ forgiving: true }),
 });


### PR DESCRIPTION
From the [shiki docs](https://shiki.style/guide/regex-engines#use-with-unsupported-languages):

> Unlike the Oniguruma engine, the JavaScript engine is strict by default. It will throw an error if it encounters an invalid Oniguruma pattern or a pattern that it cannot convert. If you want best-effort results for unsupported grammars, you can enable the forgiving option to suppress any conversion errors.

This enables `forgiving` mode for our highlighter to work in safari.

Preview: https://next-yak-docs-77rr3m2km-jan-nicklas-projects.vercel.app/