### PR TITLE
Support more access patterns for same file constant replacement

### DIFF
--- a/.changeset/fine-numbers-repair.md
+++ b/.changeset/fine-numbers-repair.md
@@ -1,0 +1,5 @@
+---
+"yak-swc": patch
+---
+
+Added support for constant string and number keys of object in the same file

--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -7,6 +7,7 @@ use std::vec;
 use swc_core::atoms::atom;
 use swc_core::atoms::Atom;
 
+
 use swc_core::common::comments::Comment;
 use swc_core::common::comments::Comments;
 use swc_core::common::errors::HANDLER;

--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -7,7 +7,6 @@ use std::vec;
 use swc_core::atoms::atom;
 use swc_core::atoms::Atom;
 
-
 use swc_core::common::comments::Comment;
 use swc_core::common::comments::Comments;
 use swc_core::common::errors::HANDLER;

--- a/packages/yak-swc/yak_swc/src/variable_visitor.rs
+++ b/packages/yak-swc/yak_swc/src/variable_visitor.rs
@@ -78,8 +78,11 @@ impl VariableVisitor {
             if let Some(prop) = obj.props.iter().find_map(|prop| match prop {
               PropOrSpread::Prop(prop) => match &**prop {
                 Prop::KeyValue(kv) => match &kv.key {
+                  // Regular identifiers like e.g. foo.bar
                   PropName::Ident(ident) if ident.sym == *part => Some(&kv.value),
+                  // String literals like e.g. foo["bar"]
                   PropName::Str(str_lit) if str_lit.value == *part => Some(&kv.value),
+                  // Numeric literals like e.g. foo[1]
                   PropName::Num(num_lit) if num_lit.value.to_string() == part.as_str() => {
                     Some(&kv.value)
                   }

--- a/packages/yak-swc/yak_swc/src/variable_visitor.rs
+++ b/packages/yak-swc/yak_swc/src/variable_visitor.rs
@@ -80,8 +80,10 @@ impl VariableVisitor {
                 Prop::KeyValue(kv) => match &kv.key {
                   PropName::Ident(ident) if ident.sym == *part => Some(&kv.value),
                   PropName::Str(str_lit) if str_lit.value == *part => Some(&kv.value),
-                  PropName::Num(num_lit) if num_lit.value.to_string() == part.as_str() => Some(&kv.value),
-                  _ => None
+                  PropName::Num(num_lit) if num_lit.value.to_string() == part.as_str() => {
+                    Some(&kv.value)
+                  }
+                  _ => None,
                 },
                 _ => None,
               },

--- a/packages/yak-swc/yak_swc/src/variable_visitor.rs
+++ b/packages/yak-swc/yak_swc/src/variable_visitor.rs
@@ -79,7 +79,9 @@ impl VariableVisitor {
               PropOrSpread::Prop(prop) => match &**prop {
                 Prop::KeyValue(kv) => match &kv.key {
                   PropName::Ident(ident) if ident.sym == *part => Some(&kv.value),
-                  _ => None,
+                  PropName::Str(str_lit) if str_lit.value == *part => Some(&kv.value),
+                  PropName::Num(num_lit) if num_lit.value.to_string() == part.as_str() => Some(&kv.value),
+                  _ => None
                 },
                 _ => None,
               },

--- a/packages/yak-swc/yak_swc/tests/fixture/constants/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/constants/input.tsx
@@ -9,6 +9,8 @@ const colors = {
   info: "#17a2b8",
   light: "#f8f9fa",
   dark: "#343a40",
+  "almost-black": "#212529",
+  1: "#000000",
 };
 
 const borderRadius = "4px";
@@ -27,5 +29,9 @@ export const Button = styled.button`
   font-weight: bold;
   &:hover {
     background-color: ${colors.dark};
+  }
+  &:active {
+    color: ${colors[1]};
+    background-color: ${colors["almost-black"]};
   }
 `;

--- a/packages/yak-swc/yak_swc/tests/fixture/constants/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/constants/output.dev.tsx
@@ -9,7 +9,9 @@ const colors = {
     warning: "#ffc107",
     info: "#17a2b8",
     light: "#f8f9fa",
-    dark: "#343a40"
+    dark: "#343a40",
+    "almost-black": "#212529",
+    1: "#000000"
 };
 const borderRadius = "4px";
 const stacking = 1;
@@ -27,6 +29,10 @@ export const Button = /*YAK EXPORTED STYLED:Button:input_Button_m7uBBu*//*YAK Ex
   font-weight: bold;
   &:hover {
     background-color: #343a40;
+  }
+  &:active {
+    color: #000000;
+    background-color: #212529;
   }
 }
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button("input_Button_m7uBBu"), {

--- a/packages/yak-swc/yak_swc/tests/fixture/constants/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/constants/output.prod.tsx
@@ -9,7 +9,9 @@ const colors = {
     warning: "#ffc107",
     info: "#17a2b8",
     light: "#f8f9fa",
-    dark: "#343a40"
+    dark: "#343a40",
+    "almost-black": "#212529",
+    1: "#000000"
 };
 const borderRadius = "4px";
 const stacking = 1;
@@ -27,6 +29,10 @@ export const Button = /*YAK EXPORTED STYLED:Button:ym7uBBu*//*YAK Extracted CSS:
   font-weight: bold;
   &:hover {
     background-color: #343a40;
+  }
+  &:active {
+    color: #000000;
+    background-color: #212529;
   }
 }
 */ /*#__PURE__*/ __yak.__yak_button("ym7uBBu");


### PR DESCRIPTION
This closes #368 

It adds support for more access patterns of constant objects like string and number literals.

Example:

```tsx
const styles = {
  small: "20px",
  "extra-small": "16px",
  1: "12px",
};

const Component = styled.div`
  margin: {styles.small}; // This works already
  padding: {styles['extra-small']}; // Support for this was added
  font-size: {styles[1]}; // Support for this was added
`;
```