### PR TITLE
Enter prerelease with 'next' tag

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -10,5 +10,8 @@
     "next-yak": "6.0.0",
     "yak-swc": "6.0.0"
   },
-  "changesets": []
+  "changesets": [
+    "dirty-masks-serve",
+    "proud-bananas-beam"
+  ]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,14 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "benchmarks": "0.1.0",
+    "cross-file-tests": "1.0.0",
+    "docs": "0.0.0",
+    "eslint-plugin-yak": "1.0.1",
+    "next-yak-example": "0.1.0",
+    "next-yak": "6.0.0",
+    "yak-swc": "6.0.0"
+  },
+  "changesets": []
+}

--- a/packages/next-yak/CHANGELOG.md
+++ b/packages/next-yak/CHANGELOG.md
@@ -1,5 +1,15 @@
 # next-yak
 
+## 6.1.0-next.0
+
+### Minor Changes
+
+- a5e730d: extract the cross-file resolution logic to make it reusable with different bundlers
+
+### Patch Changes
+
+- yak-swc@6.1.0-next.0
+
 ## 6.0.0
 
 ### Patch Changes

--- a/packages/next-yak/package.json
+++ b/packages/next-yak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-yak",
-  "version": "6.0.0",
+  "version": "6.1.0-next.0",
   "type": "module",
   "types": "./dist/",
   "sideEffects": false,
@@ -76,7 +76,7 @@
   "dependencies": {
     "@babel/parser": "catalog:core",
     "@babel/traverse": "catalog:core",
-    "yak-swc": "6.0.0"
+    "yak-swc": "6.1.0-next.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "catalog:dev",

--- a/packages/yak-swc/CHANGELOG.md
+++ b/packages/yak-swc/CHANGELOG.md
@@ -1,5 +1,7 @@
 # yak-swc
 
+## 6.1.0-next.0
+
 ## 6.0.0
 
 ### Major Changes

--- a/packages/yak-swc/package.json
+++ b/packages/yak-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yak-swc",
-  "version": "6.0.0",
+  "version": "6.1.0-next.0",
   "description": "next-yak rust based swc plugin to compile styled components at build time",
   "homepage": "https://yak.js.org/",
   "repository": {


### PR DESCRIPTION
This PR adds the ["prerelease" mode](https://changesets-docs.vercel.app/en/prereleases) into the main branch. This means that we can reuse our workflows for normal releases as the `next` tag lives on the main branch. The downside is that we can't release any non-prerelease version until we exit the mode again. 

Currently I think this is the simplest solution and we don't deploy that much so this would be sufficient to test out versions that could potentially have some downstream performance impact.