### PR TITLE
Fix initial benchmark setup

### DIFF
--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -9,7 +9,7 @@
     "build:yak": "pnpm run --dir ../.. build",
     "start": "next start",
     "prettier": "npx prettier --write \"./{app,letters,codspeed}/**/*.{ts,tsx,js,jsx}\"",
-    "generate:letters": "npx tsx ./letters/gen.js",
+    "generate:letters": "npx tsx ./letters/gen.ts",
     "generate:codspeed": "pnpm run generate:codspeed:pure-components && pnpm run generate:codspeed:attrs-components && pnpm run generate:codspeed:css-prop && pnpm run generate:codspeed:dynamic-props && pnpm run generate:codspeed:nested-components",
     "generate:codspeed:pure-components": "npx tsx ./codspeed/pure-components/gen.ts",
     "generate:codspeed:attrs-components": "npx tsx ./codspeed/attrs-components/gen.ts",


### PR DESCRIPTION
This fixes an issue with the initial benchmark setup and corrects the file extension used in the `generate:letters` command.

[This addresses this comment](https://github.com/DigitecGalaxus/next-yak/pull/422#issuecomment-3452898219)
