### PR TITLE
Fix path in workflows

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -6,14 +6,14 @@ on:
     paths:
       - "packages/next-yak/**"
       - "packages/yak-swc/**"
-      - "packages/benchmarks/**"
+      - "benchmarks/**"
       - ".github/workflows/codspeed.yml"
   pull_request:
     branches: ["main"]
     paths:
       - "packages/next-yak/**"
       - "packages/yak-swc/**"
-      - "packages/benchmarks/**"
+      - "benchmarks/**"
       - ".github/workflows/codspeed.yml"
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy packages/docs
+name: Build and Deploy docs
 env:
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy packages/example
+name: Build and Deploy examples/next-js
 
 env:
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,14 +7,14 @@ on:
       - "./package.json"
       - "packages/next-yak/**"
       - "packages/yak-swc/**"
-      - ".github/workflows/node.js.yml"
+      - ".github/workflows/tests.yml"
   pull_request:
     branches: ["main"]
     paths:
       - "./package.json"
       - "packages/next-yak/**"
       - "packages/yak-swc/**"
-      - ".github/workflows/node.js.yml"
+      - ".github/workflows/tests.yml"
   workflow_dispatch:
 
 permissions:

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -71,11 +71,12 @@ Rust packages under `./packages/yak-swc/`:
 - [./css_in_js_parser](./packages/yak-swc/css_in_js_parser) - Rust library for parsing CSS-in-JS syntax
 - [./relative_posix_path](./packages/yak-swc/relative_posix_path) - Rust utility for path handling
 
-Additional packages
+Additional directories
 
-- [benchmark](./packages/benchmark) - CI-benchmarking tool
-- [example](./packages/example) - Demo Next.js application, featuring various use cases
-- [docs](./packages/docs) - Documentation and playground, hosted at [yak.js.org](https://yak.js.org/)
+- [benchmarks](./benchmarks) - CI-benchmarking tool
+- [examples/next-js](./examples/next-js) - Demo Next.js application, featuring various use cases
+- [examples/vite](./examples/vite) - Demo Vite application
+- [docs](./docs) - Documentation and playground, hosted at [yak.js.org](https://yak.js.org/)
 
 ## Developing `next-yak` TypeScript/JavaScript
 
@@ -132,7 +133,7 @@ pnpm test:snapshots
 
 ### Running the example app
 
-The example app is a Next.js application that demonstrates the features of `next-yak`. The example app is located in the `./packages/example` directory.
+The example app is a Next.js application that demonstrates the features of `next-yak`. The example app is located in the `./examples/next-js` directory.
 
 Build everything and start the example app
 
@@ -166,7 +167,7 @@ pnpm example
 Debugging the SWC plugin in the example app, you can enable debug logging
 
 ```js
-// ./packages/example/next.config.mjs
+// ./examples/next-js/next.config.mjs
 export default withYak({
   experiments: {
     debug: true, // or { filter: 'component.tsx.css$' }

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -3,4 +3,4 @@
 # [swc](https://github.com/swc-project/swc)
 Licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
- - `packages/docs/playground-wasm/src/types.rs`
+ - `docs/playground-wasm/src/types.rs`


### PR DESCRIPTION
I've moved everything around in #434 which causes the `example` and `docs` build to fail.

@jantimon This should fix the build, but we need to update our paths in Vercel as well. Currently the build fails.