### PR TITLE
fix CSS HMR for Vite virtual modules

### DIFF
--- a/.changeset/mighty-banks-argue.md
+++ b/.changeset/mighty-banks-argue.md
@@ -1,0 +1,5 @@
+---
+"next-yak": patch
+---
+
+fix HMR for CSS in Vite


### PR DESCRIPTION
Vite's default HMR only invalidates the JS module when a source file changes. The extracted CSS lives in a separate virtual module (virtual:yak-css:...) that Vite doesn't know is derived from the source file. Add a hotUpdate hook that explicitly invalidates the virtual CSS module and includes it in the HMR update so the browser receives fresh styles.