### PR TITLE
test: add HMR refresh boundary e2e test and improve run.ts

### DIFF
--- a/e2e/cases/hmr-styled-refresh-boundary/App.tsx
+++ b/e2e/cases/hmr-styled-refresh-boundary/App.tsx
@@ -1,0 +1,27 @@
+import { useState } from "react";
+import { DividerForPage, PAGE_CONFIG } from "./pageUtils.ts";
+
+/**
+ * App imports a styled component through a chain of non-boundary modules:
+ *   Divider.tsx (.name="yak") -> barrel.ts (namespace export) -> pageUtils.ts (mixed exports)
+ *
+ * This function also exports getPageConfig (non-component), making this
+ * module NOT a refresh boundary either. The HMR update propagates all the
+ * way to the entry point -> abort -> full reload.
+ */
+export default function App() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div>
+      {PAGE_CONFIG.showDivider && <DividerForPage data-testid="divider" />}
+      <span data-testid="counter">{count}</span>
+      <button data-testid="increment" onClick={() => setCount((c) => c + 1)}>
+        +1
+      </button>
+    </div>
+  );
+}
+
+// Non-component export -> makes this module NOT a refresh boundary
+export const getPageConfig = () => PAGE_CONFIG;

--- a/e2e/cases/hmr-styled-refresh-boundary/Divider.tsx
+++ b/e2e/cases/hmr-styled-refresh-boundary/Divider.tsx
@@ -1,0 +1,18 @@
+/**
+ * Styled-only file -- the root cause of the HMR full reload.
+ *
+ * styled() returns a function with .name = "yak" (lowercase).
+ * React's isLikelyComponentType checks .name for uppercase -> returns false.
+ * Without $RefreshReg$, this module is NOT a React Fast Refresh boundary.
+ *
+ * When this file is edited, the HMR update propagates up through every
+ * parent module. If no parent is a boundary, it reaches the webpack entry
+ * point and aborts -> full page reload.
+ */
+import { styled } from "next-yak";
+
+export const Divider = styled.hr`
+  background-color: red;
+  height: 2px;
+  border: 0;
+`;

--- a/e2e/cases/hmr-styled-refresh-boundary/barrel.tsx
+++ b/e2e/cases/hmr-styled-refresh-boundary/barrel.tsx
@@ -1,0 +1,9 @@
+/**
+ * Barrel with namespace re-export.
+ *
+ * `export * as mixins` is a namespace object -- NOT a React component type.
+ * This makes isReactRefreshBoundary return false for this module.
+ * HMR updates from Divider.tsx propagate through without being accepted.
+ */
+export { Divider } from "./Divider.tsx";
+export * as mixins from "./mixins.ts";

--- a/e2e/cases/hmr-styled-refresh-boundary/mixins.ts
+++ b/e2e/cases/hmr-styled-refresh-boundary/mixins.ts
@@ -1,0 +1,2 @@
+/** Non-component constant for the namespace re-export in the barrel */
+export const DIVIDER_SPACING = "16px";

--- a/e2e/cases/hmr-styled-refresh-boundary/pageUtils.ts
+++ b/e2e/cases/hmr-styled-refresh-boundary/pageUtils.ts
@@ -1,0 +1,7 @@
+/**
+ * Mixed exports (component + constant) -- NOT a refresh boundary.
+ */
+import { Divider } from "./barrel.tsx";
+
+export const DividerForPage = Divider;
+export const PAGE_CONFIG = { showDivider: true };

--- a/e2e/cases/hmr-styled-refresh-boundary/test.ts
+++ b/e2e/cases/hmr-styled-refresh-boundary/test.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+import { withTestEnv } from "next-yak-e2e";
+
+test(
+  "HMR: editing styled-only file does not cause full reload when imported through non-boundary chain",
+  withTestEnv("hmr-styled-refresh-boundary", async (fsTmp, page) => {
+    await page.goto(fsTmp.url);
+
+    const divider = page.getByTestId("divider");
+    const counter = page.getByTestId("counter");
+    const increment = page.getByTestId("increment");
+
+    // Verify initial CSS
+    await expect(divider).toHaveCSS("background-color", "rgb(255, 0, 0)");
+    await expect(counter).toHaveText("0");
+
+    // Set state that would be lost on full reload
+    await increment.click();
+    await increment.click();
+    await expect(counter).toHaveText("2");
+
+    // Set marker to detect full page reloads
+    await page.evaluate(() => {
+      window.__hmr = true;
+    });
+
+    // Edit the styled-only file -- change CSS color.
+    // The import chain is: Divider.tsx -> barrel.ts -> pageUtils.ts -> App.tsx
+    // None of these modules are React Fast Refresh boundaries because:
+    //   - Divider.tsx: styled() function .name = "yak" (lowercase, not recognized)
+    //   - barrel.ts: has namespace export (not a component type)
+    //   - pageUtils.ts: mixed exports (component + constant)
+    //   - App.tsx: mixed exports (component + function)
+    // Without the fix, the update propagates to the entry point -> full reload.
+    const src = await fsTmp.readFile("Divider.tsx");
+    await fsTmp.writeFile(
+      "Divider.tsx",
+      src.replace("background-color: red", "background-color: blue"),
+    );
+
+    // Wait for HMR to apply the CSS change
+    await expect(divider).toHaveCSS("background-color", "rgb(0, 0, 255)", {
+      timeout: 30_000,
+    });
+
+    // Verify no full page reload occurred
+    expect(await page.evaluate(() => window.__hmr)).toBe(true);
+
+    // Verify React state was preserved (counter didn't reset)
+    await expect(counter).toHaveText("2");
+  }),
+);

--- a/e2e/run.ts
+++ b/e2e/run.ts
@@ -12,7 +12,7 @@
  * Usage: node run.ts [bundler] [case]
  */
 
-import { spawn, type ChildProcess } from "node:child_process";
+import { execSync, spawn, type ChildProcess } from "node:child_process";
 import {
   readdir,
   rm,
@@ -29,28 +29,45 @@ import { styleText } from "node:util";
 const e2eRoot = import.meta.dirname;
 
 // ---------------------------------------------------------------------------
-// Process cleanup — ensure all spawned children are killed on exit / abort
+// Process cleanup — recursive tree kill for reliable shutdown
 // ---------------------------------------------------------------------------
 
 const activeChildren = new Set<ChildProcess>();
 
+/** Recursively find all descendant PIDs of a process. */
+function getDescendants(pid: number): number[] {
+  try {
+    const output = execSync(`pgrep -P ${pid}`, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+    }).trim();
+    const children = output.split("\n").map(Number).filter(Boolean);
+    return [...children, ...children.flatMap(getDescendants)];
+  } catch {
+    return [];
+  }
+}
+
+/** SIGKILL a process and all its descendants (bottom-up). */
+function killTree(pid: number) {
+  if (process.platform === "win32") {
+    spawn("taskkill", ["/T", "/F", "/PID", String(pid)]);
+    return;
+  }
+  const pids = [...getDescendants(pid), pid];
+  for (const p of pids) {
+    try {
+      process.kill(p, "SIGKILL");
+    } catch {
+      // already exited
+    }
+  }
+}
+
 /** Kill all tracked child processes (and their process trees). */
 function killAllChildren() {
   for (const child of activeChildren) {
-    if (!child.pid) continue;
-    try {
-      if (process.platform === "win32") {
-        spawn("taskkill", ["/T", "/F", "/PID", String(child.pid)]);
-      } else {
-        process.kill(-child.pid, "SIGTERM");
-      }
-    } catch {
-      try {
-        child.kill("SIGTERM");
-      } catch {
-        // already exited
-      }
-    }
+    if (child.pid) killTree(child.pid);
   }
   activeChildren.clear();
 }
@@ -382,15 +399,7 @@ function killServer(child: ChildProcess): Promise<void> {
       return;
     }
 
-    if (process.platform === "win32") {
-      spawn("taskkill", ["/T", "/F", "/PID", String(child.pid)]);
-    } else {
-      try {
-        process.kill(-child.pid, "SIGTERM");
-      } catch {
-        child.kill("SIGTERM");
-      }
-    }
+    killTree(child.pid);
   });
 }
 


### PR DESCRIPTION
## Summary
- Add e2e test case for styled component HMR refresh boundaries
- Refactor `run.ts` for reliable process cleanup with recursive tree kill
- Move dev server management to `playwright.config.ts` webServer config
- Remove `[case-name]` template pattern in favor of direct file copies

## Test plan
- [ ] Run `pnpm e2e` to verify all e2e tests pass
- [ ] Verify dev server cleanup on Ctrl+C (no occupied ports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)