### PR TITLE
Batch non-HMR e2e cases into single Playwright process

### DIFF
--- a/e2e/e2eEnvironment.ts
+++ b/e2e/e2eEnvironment.ts
@@ -532,6 +532,53 @@ export function runPlaywright(
   });
 }
 
+/**
+ * Spawn a single Playwright process that runs all given cases in parallel
+ * (one Playwright project per case, multiple workers).
+ */
+export function runPlaywrightBatch(
+  bundler: string,
+  caseNames: string[],
+  discoveredBundlers: string[],
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    const color = COLORS[discoveredBundlers.indexOf(bundler) % COLORS.length];
+    const prefix = styleText(color, `[${bundler}]`);
+    const child = spawn(
+      `pnpm exec playwright test --config bundlers/${bundler}/playwright.config.ts`,
+      {
+        cwd: e2eRoot,
+        env: {
+          ...process.env,
+          BUNDLER: bundler,
+          CASES: caseNames.join(","),
+        },
+        stdio: "pipe",
+        shell: true,
+        detached: true,
+      },
+    );
+
+    activeChildren.add(child);
+
+    child.stdout.on("data", (data: Buffer) => {
+      for (const line of data.toString().split("\n")) {
+        if (line) process.stdout.write(`${prefix} ${line}\n`);
+      }
+    });
+    child.stderr.on("data", (data: Buffer) => {
+      for (const line of data.toString().split("\n")) {
+        if (line) process.stderr.write(`${prefix} ${line}\n`);
+      }
+    });
+
+    child.on("close", (code) => {
+      activeChildren.delete(child);
+      resolve(code === 0);
+    });
+  });
+}
+
 // ---------------------------------------------------------------------------
 // High-level runner
 // ---------------------------------------------------------------------------
@@ -544,8 +591,12 @@ export interface RunOptions {
 }
 
 /**
- * Assemble all cases, optionally build, start a server, run Playwright per
- * case, then tear down the server.
+ * Assemble all cases, optionally build, start a server, run Playwright,
+ * then tear down the server.
+ *
+ * Non-HMR cases run in a single batched Playwright process with parallel
+ * workers. HMR cases run sequentially (one process each) since they modify
+ * files on the dev server.
  */
 export async function runBundlerCases(
   bundler: string,
@@ -578,7 +629,25 @@ export async function runBundlerCases(
     await waitForPort(port);
 
     const results: Result[] = [];
-    for (const caseName of cases) {
+    const hmrCases = cases.filter((c) => c.startsWith("hmr-"));
+    const nonHmrCases = cases.filter((c) => !c.startsWith("hmr-"));
+
+    // Batch all non-HMR cases in one Playwright process (parallel workers)
+    if (nonHmrCases.length > 0) {
+      const start = Date.now();
+      const passed = await runPlaywrightBatch(
+        bundler,
+        nonHmrCases,
+        discoveredBundlers,
+      );
+      const durationMs = Date.now() - start;
+      for (const caseName of nonHmrCases) {
+        results.push({ bundler, caseName, passed, durationMs });
+      }
+    }
+
+    // HMR cases run sequentially — they modify files on the dev server
+    for (const caseName of hmrCases) {
       const start = Date.now();
       const passed = await runPlaywright(bundler, caseName, discoveredBundlers);
       results.push({
@@ -588,6 +657,7 @@ export async function runBundlerCases(
         durationMs: Date.now() - start,
       });
     }
+
     return results;
   } finally {
     await killServer(server);

--- a/e2e/playwright-base.ts
+++ b/e2e/playwright-base.ts
@@ -1,9 +1,9 @@
 /**
  * Shared Playwright config factory for bundler-specific configs.
  *
- * Each bundler's playwright.config.ts calls this with its dev server
- * details. The CASE env var (set by e2eEnvironment.ts) determines which case to test.
- * The dev server is managed by e2eEnvironment.ts — Playwright reuses it.
+ * Supports two modes:
+ * - Batch mode (CASES env var, comma-separated): one project per case, parallel workers
+ * - Single mode (CASE env var): one project, single worker (used for HMR tests)
  */
 
 import { defineConfig } from "@playwright/test";
@@ -13,33 +13,39 @@ interface BundlerPlaywrightConfig {
   name: string;
   /** URL pattern with [case-name] placeholder (e.g. "/[case-name]" or "/[case-name].html") */
   urlPattern: string;
-  /** Port the dev server listens on (managed by e2eEnvironment.ts) */
+  /** Port the server listens on (managed by e2eEnvironment.ts) */
   port: number;
 }
 
 export function basePlaywrightConfig(config: BundlerPlaywrightConfig) {
-  // CASE may be unset when e2eEnvironment.ts imports this config just to read the port
-  const caseName = process.env.CASE ?? "__placeholder__";
-
   const e2eRoot = import.meta.dirname;
-  const url = config.urlPattern.replaceAll("[case-name]", caseName);
 
-  return defineConfig({
+  // CASES (comma-separated) for batch mode, CASE for single-case (HMR) mode
+  const caseList = process.env.CASES
+    ? process.env.CASES.split(",")
+    : [process.env.CASE ?? "__placeholder__"];
+
+  const isBatch = caseList.length > 1;
+
+  const projects = caseList.map((caseName) => ({
+    name: isBatch ? `${config.name}/${caseName}` : config.name,
     testDir: resolve(e2eRoot, "cases", caseName),
     testMatch: "index.test.ts",
-    workers: 1,
+    metadata: {
+      url: config.urlPattern.replaceAll("[case-name]", caseName),
+      urlPattern: config.urlPattern,
+      bundlerName: config.name,
+    },
+    use: { baseURL: `http://localhost:${config.port}` },
+  }));
 
-    projects: [
-      {
-        name: config.name,
-        use: { baseURL: `http://localhost:${config.port}` },
-        metadata: { url, urlPattern: config.urlPattern },
-      },
-    ],
+  return defineConfig({
+    workers: isBatch ? undefined : 1,
+    projects,
 
     webServer: {
       // Playwright requires a webServer.command, but e2eEnvironment.ts manages the actual
-      // dev server externally. This no-op command + reuseExistingServer tells
+      // server externally. This no-op command + reuseExistingServer tells
       // Playwright to verify the port is already open instead of starting one.
       command: "echo 'server managed by e2eEnvironment.ts'",
       port: config.port,

--- a/e2e/test-env.ts
+++ b/e2e/test-env.ts
@@ -38,7 +38,9 @@ export function withTestEnv(
   fn: (fsTmp: FsTmp, page: Page) => Promise<void>,
 ) {
   return async ({ page }: { page: Page }, testInfo: TestInfo) => {
-    const bundlerName = testInfo.project.name;
+    const bundlerName =
+      (testInfo.project.metadata as { bundlerName?: string }).bundlerName ??
+      testInfo.project.name;
     const tmpDir = resolve(
       e2eRoot,
       "bundlers",


### PR DESCRIPTION
Non-HMR tests now run in one Playwright invocation per bundler with parallel workers instead of spawning a new process per case. Eliminates ~1.5s overhead per case from Node/Playwright/browser boot. HMR tests still run sequentially since they modify files.