### PR TITLE
Fix `eslint-plugin-yak` release artifact missing dist

### DIFF
--- a/.changeset/build-eslint-plugin-yak.md
+++ b/.changeset/build-eslint-plugin-yak.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-yak": patch
+---
+
+Build eslint-plugin-yak before publishing packages so its dist entrypoint is included in the npm artifact.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:e2e": "pnpm --filter=next-yak-e2e test",
     "test:e2e:build": "pnpm --filter=next-yak-e2e test:build",
     "watch": "pnpm run --filter=next-yak watch",
-    "release": "pnpm run --filter=yak-swc build && pnpm run --filter=next-yak build && pnpm run --filter=storybook-addon-yak build && npm_config_ignore_scripts=true changeset publish"
+    "release": "pnpm run --filter=yak-swc build && pnpm run --filter=next-yak build && pnpm run --filter=storybook-addon-yak build && pnpm run --filter=eslint-plugin-yak build && npm_config_ignore_scripts=true changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "catalog:dev",


### PR DESCRIPTION
Issue: https://github.com/DigitecGalaxus/next-yak/issues/555

What changed:

- Root release script now builds `eslint-plugin-yak` before changeset publish.
- Added a patch changeset for `eslint-plugin-yak`.

Validated:

- pnpm --filter=eslint-plugin-yak build
- npm pack --dry-run includes dist/index.js
- pnpm --filter=eslint-plugin-yak test -- --watch=false passes, 87 tests.