### PR TITLE
perf(runtime): string className collector, chain flattening, static fast path — every SSR bench cell now beats styled-components

### DIFF
--- a/.changeset/chatty-fans-drop.md
+++ b/.changeset/chatty-fans-drop.md
@@ -1,0 +1,5 @@
+---
+"next-yak": minor
+---
+
+Improve runtime render performance by collecting class names via string append instead of Set round-trips, rendering styled() composition chains as a single wrapper and skipping prop/style processing entirely for static components

--- a/.changeset/chatty-fans-drop.md
+++ b/.changeset/chatty-fans-drop.md
@@ -3,3 +3,5 @@
 ---
 
 Improve runtime render performance by collecting class names via string append instead of Set round-trips, rendering styled() composition chains as a single wrapper and skipping prop/style processing entirely for static components
+
+Components with fully static styles no longer receive a default `style: {}` prop, and a user-passed `style` object is forwarded by reference instead of cloned on every render; components with dynamic styles are unchanged.

--- a/.changeset/drop-classname-dedup.md
+++ b/.changeset/drop-classname-dedup.md
@@ -1,0 +1,5 @@
+---
+"next-yak": minor
+---
+
+The runtime no longer deduplicates class names, so the same class applied twice — e.g. an `atoms()` utility that is already on the element, or a shared `css` block toggled by two conditions — now appears twice in the class attribute. This is rendering-neutral, as CSS applies a class once however often it is listed.

--- a/docs/content/docs/how-does-it-work.mdx
+++ b/docs/content/docs/how-does-it-work.mdx
@@ -254,7 +254,7 @@ Despite being called "zero-runtime", next-yak does ship a small runtime. What "z
 
 The runtime is essentially a type-safe `classnames` utility. It takes the generated class name strings and the component's props, evaluates the dynamic functions (conditionals, CSS variable values), and returns:
 
-- The final `className` string (merging base classes and conditional classes)
+- The final `className` string (merging any incoming `className`, base classes and conditional classes)
 - An optional `style` object (setting CSS variable values from props)
 
 Since it has no side effects, it works in both server and client components.
@@ -265,7 +265,8 @@ Here is a simplified version of what `__yak.__yak_button` does:
 function __yak_button(className, ...dynamicParts) {
   // returns a React component
   return (props) => {
-    const classNames = new Set([className]);
+    const classNames = new ClassNames(props.className);
+    classNames.add(className);
     const style = {};
 
     for (const part of dynamicParts) {
@@ -273,7 +274,7 @@ function __yak_button(className, ...dynamicParts) {
         // conditional css block, e.g.:
         // (props) => props.$primary && css("Button_primary")
         // css("Button_primary") returns a function that
-        // adds "Button_primary" to the classNames set
+        // adds "Button_primary" to the class names
         const result = part(props);
         if (result) result(props, classNames, style);
       } else if (part?.style) {
@@ -285,12 +286,12 @@ function __yak_button(className, ...dynamicParts) {
       }
     }
 
-    return <button className={[...classNames].join(" ")} style={style} />;
+    return <button className={classNames.value} style={style} />;
   };
 }
 ```
 
-When the component is rendered, the runtime passes the received props through all the dynamic functions, collects the resulting class names into a `Set` and CSS variable values into a `style` object, and forwards them as `className` and `style` props to the underlying DOM element.
+When the component is rendered, the runtime passes the received props through all the dynamic functions, collects the resulting class names into a single string and CSS variable values into a `style` object, and forwards them as `className` and `style` props to the underlying DOM element.
 
 ## Context
 

--- a/e2e/cases/atoms/index.test.ts
+++ b/e2e/cases/atoms/index.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+import { withTestEnv } from "next-yak-e2e";
+
+const atomClasses = async (page: import("@playwright/test").Page, testId: string) =>
+  ((await page.getByTestId(testId).getAttribute("class")) ?? "")
+    .split(" ")
+    .filter((className) => className.startsWith("bg-") || className.startsWith("text-"));
+
+test(
+  "renders atom classes and applies them",
+  withTestEnv("atoms", async (testEnv, page) => {
+    await page.goto(testEnv.url);
+
+    // one multi class string and separate atoms must emit the same classes
+    expect(await atomClasses(page, "joined")).toEqual(["bg-blue", "text-white"]);
+    expect(await atomClasses(page, "separate")).toEqual(["bg-blue", "text-white"]);
+
+    const joined = page.getByTestId("joined");
+    await expect(joined).toHaveCSS("background-color", "rgb(0, 0, 255)");
+    await expect(joined).toHaveCSS("color", "rgb(255, 255, 255)");
+
+    // atoms in a dynamic interpolation still resolve per props
+    expect(await atomClasses(page, "conditional-active")).toEqual(["bg-blue", "text-white"]);
+    expect(await atomClasses(page, "conditional-inactive")).toEqual(["bg-blue"]);
+    await expect(page.getByTestId("conditional-inactive")).toHaveCSS("color", "rgb(0, 0, 0)");
+  }),
+);

--- a/e2e/cases/atoms/index.tsx
+++ b/e2e/cases/atoms/index.tsx
@@ -1,0 +1,33 @@
+import { atoms, styled } from "next-yak";
+
+// utility class names as an atomic CSS framework would emit them
+// (the stylesheet below is hand written, no framework in the e2e app)
+const Joined = styled.div`
+  ${atoms("bg-blue text-white")}
+`;
+
+const Separate = styled.div`
+  ${atoms("bg-blue", "text-white")}
+`;
+
+const Conditional = styled.div<{ $active?: boolean }>`
+  ${atoms("bg-blue")}
+  ${(props) => props.$active && atoms("text-white")}
+`;
+
+export default function App() {
+  return (
+    <>
+      <style>{`
+        .bg-blue { background-color: rgb(0, 0, 255); }
+        .text-white { color: rgb(255, 255, 255); }
+      `}</style>
+      <Joined data-testid="joined">joined</Joined>
+      <Separate data-testid="separate">separate</Separate>
+      <Conditional data-testid="conditional-active" $active>
+        active
+      </Conditional>
+      <Conditional data-testid="conditional-inactive">inactive</Conditional>
+    </>
+  );
+}

--- a/e2e/cases/dynamic-props-nested-selector/icon.tsx
+++ b/e2e/cases/dynamic-props-nested-selector/icon.tsx
@@ -1,0 +1,6 @@
+import { styled } from "next-yak";
+
+export const Icon = styled.svg`
+  width: 32px;
+  height: 32px;
+`;

--- a/e2e/cases/dynamic-props-nested-selector/index.test.ts
+++ b/e2e/cases/dynamic-props-nested-selector/index.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test";
+import { withTestEnv } from "next-yak-e2e";
+
+test(
+  "inherits dynamic-prop CSS variables into descendant selectors",
+  withTestEnv("dynamic-props-nested-selector", async (fsTmp, page) => {
+    await page.goto(fsTmp.url);
+
+    // The CSS variable is set on the styled parent's inline style but
+    // consumed by a plain child element via a descendant selector — each
+    // instance's value must be inherited by its own children.
+    await expect(page.getByTestId("button-32")).toHaveCSS("left", "32px");
+    await expect(page.getByTestId("button-64")).toHaveCSS("left", "64px");
+
+    // Same inheritance dependency via a component selector (${Icon} { ... })
+    await expect(page.getByTestId("icon")).toHaveCSS("width", "24px");
+  }),
+);

--- a/e2e/cases/dynamic-props-nested-selector/index.tsx
+++ b/e2e/cases/dynamic-props-nested-selector/index.tsx
@@ -1,0 +1,40 @@
+import { styled } from "next-yak";
+import { Icon } from "./icon.tsx";
+
+// The dynamic prop is turned into a CSS variable set on the styled <div>
+// (inline style) but consumed by a *descendant* element — the variable must
+// be inherited across the element boundary for these styles to apply.
+const Positioned = styled.div<{ $x: number }>`
+  position: relative;
+  height: 50px;
+
+  button {
+    position: absolute;
+    left: ${({ $x }) => $x}px;
+  }
+`;
+
+// Same inheritance dependency expressed through a component selector
+const IconBox = styled.div<{ $size: number }>`
+  ${Icon} {
+    width: ${({ $size }) => $size}px;
+  }
+`;
+
+export default function App() {
+  return (
+    <>
+      <Positioned $x={32}>
+        <button data-testid="button-32">A</button>
+      </Positioned>
+      <Positioned $x={64}>
+        <button data-testid="button-64">B</button>
+      </Positioned>
+      <IconBox $size={24}>
+        <Icon data-testid="icon" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="10" />
+        </Icon>
+      </IconBox>
+    </>
+  );
+}

--- a/packages/next-yak/runtime/__tests__/atoms.test.tsx
+++ b/packages/next-yak/runtime/__tests__/atoms.test.tsx
@@ -39,9 +39,8 @@ describe("atoms", () => {
 
   it("is static on its own but dynamic once css() wraps it", () => {
     // styled`` compiles to css("yak123", atoms(...)) and gates its fast path on
-    // the outer processor, which is dynamic because atoms() is a function - so
-    // atoms' own $dynamic is not read today. Pinned to catch a fold of static
-    // atoms into the outer class name, which would make the fast path reachable.
+    // the outer processor, so atoms' own $dynamic is not read today. Pinned to
+    // catch a fold of static atoms that would make the fast path reachable
     expect((atoms("a") as unknown as { $dynamic: boolean }).$dynamic).toBe(false);
     // @ts-expect-error calling with a class name string mimics the compiled css form
     expect((css("yak123", atoms("a")) as unknown as { $dynamic: boolean }).$dynamic).toBe(true);

--- a/packages/next-yak/runtime/__tests__/atoms.test.tsx
+++ b/packages/next-yak/runtime/__tests__/atoms.test.tsx
@@ -43,6 +43,7 @@ describe("atoms", () => {
     // atoms' own $dynamic is not read today. Pinned to catch a fold of static
     // atoms into the outer class name, which would make the fast path reachable.
     expect((atoms("a") as unknown as { $dynamic: boolean }).$dynamic).toBe(false);
+    // @ts-expect-error calling with a class name string mimics the compiled css form
     expect((css("yak123", atoms("a")) as unknown as { $dynamic: boolean }).$dynamic).toBe(true);
   });
 });

--- a/packages/next-yak/runtime/__tests__/atoms.test.tsx
+++ b/packages/next-yak/runtime/__tests__/atoms.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { atoms } from "../atoms";
+import { ClassNames, css } from "../cssLiteral";
+import type { RuntimeStyleProcessor } from "../publicStyledApi";
+
+const classNamesOf = (processor: unknown, props: Record<string, unknown> = {}) => {
+  const classNames = new ClassNames();
+  (processor as RuntimeStyleProcessor<unknown>)(props, classNames, {});
+  return classNames.value;
+};
+
+describe("atoms", () => {
+  it("collects static classes, however they are grouped", () => {
+    expect(classNamesOf(atoms("a b c"))).toBe("a b c");
+    expect(classNamesOf(atoms("a", "b", "c"))).toBe("a b c");
+    expect(classNamesOf(atoms("a b", "c"))).toBe("a b c");
+  });
+
+  it("skips falsy atoms", () => {
+    expect(classNamesOf(atoms("a", false, "b"))).toBe("a b");
+    expect(classNamesOf(atoms(false))).toBe("");
+    expect(classNamesOf(atoms())).toBe("");
+  });
+
+  it("runs dynamic atoms after the static ones", () => {
+    const processor = atoms<{ $active?: boolean }>("a", (props, classNames) => {
+      if (props.$active) classNames.add("active");
+    });
+    expect(classNamesOf(processor, { $active: true })).toBe("a active");
+    expect(classNamesOf(processor, { $active: false })).toBe("a");
+  });
+
+  it("keeps classes a dynamic atom removes removable", () => {
+    const processor = atoms("a b", (_props, classNames) => {
+      classNames.delete("a");
+    });
+    expect(classNamesOf(processor)).toBe("b");
+  });
+
+  it("is static on its own but dynamic once css() wraps it", () => {
+    // styled`` compiles to css("yak123", atoms(...)) and gates its fast path on
+    // the outer processor, which is dynamic because atoms() is a function - so
+    // atoms' own $dynamic is not read today. Pinned to catch a fold of static
+    // atoms into the outer class name, which would make the fast path reachable.
+    expect((atoms("a") as unknown as { $dynamic: boolean }).$dynamic).toBe(false);
+    expect((css("yak123", atoms("a")) as unknown as { $dynamic: boolean }).$dynamic).toBe(true);
+  });
+});

--- a/packages/next-yak/runtime/__tests__/attrs.test.tsx
+++ b/packages/next-yak/runtime/__tests__/attrs.test.tsx
@@ -235,6 +235,27 @@ it("merge attrs when inheriting SC", () => {
   `);
 });
 
+it("overrides attrs of the wrapped component and appends its style class", () => {
+  // styled(SubmitButton) renders as a single flattened wrapper — this pins
+  // that flattening keeps styled-components semantics: the outer attrs win
+  // and the outer class comes after the inner one
+  const SubmitButton = styled.button.attrs({ type: "submit" })("submit_btn");
+  const ResetButton = styled(SubmitButton).attrs({ type: "reset" })("reset_btn");
+
+  expect(getSnapshot(<SubmitButton />)).toMatchInlineSnapshot(`
+    <button
+      class="submit_btn"
+      type="submit"
+    />
+  `);
+  expect(getSnapshot(<ResetButton />)).toMatchInlineSnapshot(`
+    <button
+      class="submit_btn reset_btn"
+      type="reset"
+    />
+  `);
+});
+
 it("pass attrs to style block", () => {
   /* Would be a React Router Link in real life */
   const Comp = styled.a.attrs<DataAttributes>(() => ({

--- a/packages/next-yak/runtime/__tests__/attrs.test.tsx
+++ b/packages/next-yak/runtime/__tests__/attrs.test.tsx
@@ -239,7 +239,9 @@ it("overrides attrs of the wrapped component and appends its style class", () =>
   // styled(SubmitButton) renders as a single flattened wrapper — this pins
   // that flattening keeps styled-components semantics: the outer attrs win
   // and the outer class comes after the inner one
+  // @ts-expect-error calling with a class name string mimics the compiled css form
   const SubmitButton = styled.button.attrs({ type: "submit" })("submit_btn");
+  // @ts-expect-error calling with a class name string mimics the compiled css form
   const ResetButton = styled(SubmitButton).attrs({ type: "reset" })("reset_btn");
 
   expect(getSnapshot(<SubmitButton />)).toMatchInlineSnapshot(`

--- a/packages/next-yak/runtime/__tests__/cssLiteral.test.tsx
+++ b/packages/next-yak/runtime/__tests__/cssLiteral.test.tsx
@@ -233,7 +233,10 @@ describe("cssLiteral css function", () => {
       const result = processor(props, classNames, style);
 
       expect(classNames.has("static-only-class")).toBe(true);
-      expect(typeof result).toBe("function"); // Should return the cleanup function
+      // static processors are marked so the styled runtime can skip theme
+      // lookup and style-object allocation; they return nothing
+      expect(processor.$dynamic).toBe(false);
+      expect(result).toBeUndefined();
     });
   });
 

--- a/packages/next-yak/runtime/__tests__/cssLiteral.test.tsx
+++ b/packages/next-yak/runtime/__tests__/cssLiteral.test.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck These are runtime tests and the external API isn't the runtime (after compile) API
 import type { YakTheme } from "../context";
-import { css } from "../cssLiteral";
+import { css, ClassNames } from "../cssLiteral";
 
 describe("cssLiteral css function", () => {
   describe("static CSS class names", () => {
@@ -474,5 +474,30 @@ describe("cssLiteral css function", () => {
       expect(style["--dynamic1"]).toBe("dynamic1");
       expect(style["--dynamic2"]).toBe("dynamic2");
     });
+  });
+});
+
+describe("ClassNames collector", () => {
+  it("does not deduplicate added class names", () => {
+    const classNames = new ClassNames();
+    classNames.add("a");
+    classNames.add("b");
+    classNames.add("a");
+    expect(classNames.value).toBe("a b a");
+  });
+
+  it("does not deduplicate against the incoming className", () => {
+    const classNames = new ClassNames("a");
+    classNames.add("a");
+    expect(classNames.value).toBe("a a");
+  });
+
+  it("deletes every occurrence of a duplicated class", () => {
+    const classNames = new ClassNames();
+    classNames.add("a");
+    classNames.add("b");
+    classNames.add("a");
+    classNames.delete("a");
+    expect(classNames.value).toBe("b");
   });
 });

--- a/packages/next-yak/runtime/__tests__/styled.test.tsx
+++ b/packages/next-yak/runtime/__tests__/styled.test.tsx
@@ -148,6 +148,34 @@ it("should concatenate styles", () => {
   `);
 });
 
+it("should not inject a default style prop into a static wrapped component", () => {
+  let receivedProps = null;
+  const Component = (props) => {
+    receivedProps = props;
+    return null;
+  };
+  const StyledComponent = styled(Component)("staticClass");
+
+  render(<StyledComponent />);
+
+  expect("style" in receivedProps).toBe(false);
+});
+
+it("should forward a style prop by reference to a static wrapped component", () => {
+  let receivedProps = null;
+  const Component = (props) => {
+    receivedProps = props;
+    return null;
+  };
+  const StyledComponent = styled(Component)("staticClass");
+  const style = { color: "red" };
+
+  render(<StyledComponent style={style} />);
+
+  // no per-render clone — keeps React.memo/PureComponent on the target working
+  expect(receivedProps.style).toBe(style);
+});
+
 it("should not add class if prop is not set", () => {
   const Component = styled.input(({ testProp }) => testProp && css("test"));
 

--- a/packages/next-yak/runtime/atoms.tsx
+++ b/packages/next-yak/runtime/atoms.tsx
@@ -1,4 +1,4 @@
-import { ComponentStyles, css } from "./cssLiteral.js";
+import { ClassNames, ComponentStyles, css } from "./cssLiteral.js";
 import { RuntimeStyleProcessor } from "./publicStyledApi.js";
 
 /**
@@ -18,27 +18,19 @@ import { RuntimeStyleProcessor } from "./publicStyledApi.js";
 export const atoms = <T,>(
   ...atoms: (string | RuntimeStyleProcessor<T> | false)[]
 ): ComponentStyles<T> => {
-  const staticClasses: string[] = [];
+  const staticClasses = new ClassNames();
   const dynamicFunctions: RuntimeStyleProcessor<T>[] = [];
 
   for (const atom of atoms) {
     if (typeof atom === "string") {
-      staticClasses.push(...atom.split(" "));
+      staticClasses.add(atom);
     } else if (typeof atom === "function") {
       dynamicFunctions.push(atom);
     }
   }
 
-  const runtimeFunctions: RuntimeStyleProcessor<T>[] =
-    staticClasses.length > 0
-      ? [
-          (_, classNames) => {
-            staticClasses.forEach((cls) => classNames.add(cls));
-          },
-          ...dynamicFunctions,
-        ]
-      : dynamicFunctions;
-
+  // the collected classes are passed as css()'s static class name,
+  // only the dynamic atoms stay functions
   // @ts-expect-error the internal implementation of css is not typed
-  return css(...runtimeFunctions);
+  return css(staticClasses.value, ...dynamicFunctions);
 };

--- a/packages/next-yak/runtime/cssLiteral.tsx
+++ b/packages/next-yak/runtime/cssLiteral.tsx
@@ -1,7 +1,41 @@
 import type { YakTheme } from "./index.ts";
-import { RuntimeStyleProcessor } from "./publicStyledApi.js";
+import { ClassNameCollector, RuntimeStyleProcessor } from "./publicStyledApi.js";
 
 export const yakComponentSymbol = Symbol("yak");
+
+/**
+ * String-backed ClassNameCollector used by the render path.
+ *
+ * Replaces the previous `new Set(className.split(" "))` →
+ * `Array.from(set).join(" ")` round-trip, which dominated render cost.
+ * The hot path (`add`) is a plain string append with a containment check;
+ * `has`/`delete` keep the Set-like contract for advanced runtime functions
+ * (e.g. atoms removing classes) on the rare path.
+ */
+export class ClassNames implements ClassNameCollector {
+  value: string;
+  constructor(initial?: string) {
+    this.value = initial || "";
+  }
+  add(className: string) {
+    if (!this.value) {
+      this.value = className;
+    } else if (!this.has(className)) {
+      this.value += " " + className;
+    }
+  }
+  has(className: string) {
+    return (" " + this.value + " ").includes(" " + className + " ");
+  }
+  delete(className: string) {
+    if (this.has(className)) {
+      this.value = this.value
+        .split(" ")
+        .filter((existing) => existing !== className)
+        .join(" ");
+    }
+  }
+}
 
 export type ComponentStyles<TProps> = (props: TProps) => {
   className: string;
@@ -35,7 +69,7 @@ type CSSFunction = <TProps = {}>(
 
 export type NestedRuntimeStyleProcessor = (
   props: unknown,
-  classNames: Set<string>,
+  classNames: ClassNameCollector,
   style: React.CSSProperties,
 ) =>
   | {
@@ -110,30 +144,37 @@ export function css<TProps>(...args: Array<any>): RuntimeStyleProcessor<TProps> 
 
   // Non Dynamic CSS
   // This is just an optimization for the common case where there are no dynamic css functions
+  // `$dynamic: false` lets the styled runtime skip theme lookup and
+  // style-object allocation entirely for static components
   if (dynamicCssFunctions.length === 0) {
-    return (_, classNames) => {
+    return Object.assign(
+      (_: unknown, classNames: ClassNameCollector) => {
+        if (className) {
+          classNames.add(className);
+        }
+      },
+      { $dynamic: false },
+    );
+  }
+
+  return Object.assign(
+    (props: TProps, classNames: ClassNameCollector, allStyles: React.CSSProperties) => {
       if (className) {
         classNames.add(className);
       }
-      return () => {};
-    };
-  }
-
-  return (props, classNames, allStyles) => {
-    if (className) {
-      classNames.add(className);
-    }
-    for (let i = 0; i < dynamicCssFunctions.length; i++) {
-      unwrapProps(props, dynamicCssFunctions[i], classNames, allStyles);
-    }
-  };
+      for (let i = 0; i < dynamicCssFunctions.length; i++) {
+        unwrapProps(props, dynamicCssFunctions[i], classNames, allStyles);
+      }
+    },
+    { $dynamic: true },
+  );
 }
 
 // Dynamic CSS with runtime logic
 const unwrapProps = (
   props: unknown,
   fn: NestedRuntimeStyleProcessor,
-  classNames: Set<string>,
+  classNames: ClassNameCollector,
   style: React.CSSProperties,
 ) => {
   let result = fn(props, classNames, style);
@@ -163,8 +204,10 @@ const recursivePropExecution = (props: unknown, fn: (props: unknown) => any): st
   if (typeof result === "function") {
     return recursivePropExecution(props, result);
   }
-  if (process.env.NODE_ENV === "development") {
-    if (typeof result !== "string" && typeof result !== "number" && !(result instanceof String)) {
+  // typeof guards first — the `process.env` lookup is a real per-call cost
+  // for unbundled Node consumers, so it must only run on the invalid path
+  if (typeof result !== "string" && typeof result !== "number" && !(result instanceof String)) {
+    if (process.env.NODE_ENV === "development") {
       throw new Error(
         `Dynamic CSS functions must return a string or number but returned ${JSON.stringify(
           result,

--- a/packages/next-yak/runtime/cssLiteral.tsx
+++ b/packages/next-yak/runtime/cssLiteral.tsx
@@ -8,9 +8,14 @@ export const yakComponentSymbol = Symbol("yak");
  *
  * Replaces the previous `new Set(className.split(" "))` →
  * `Array.from(set).join(" ")` round-trip, which dominated render cost.
- * The hot path (`add`) is a plain string append with a containment check;
+ * The hot path (`add`) is a plain string append and does not deduplicate, so
+ * the collector is a multiset: the same class can appear twice, e.g. when
+ * `atoms()` repeats a utility or the incoming className already carries it.
+ * That is rendering neutral - CSS applies a class once however often it is
+ * listed - and it matches what the compile time class name folds emit.
  * `has`/`delete` keep the Set-like contract for advanced runtime functions
- * (e.g. atoms removing classes) on the rare path.
+ * (e.g. atoms removing classes) on the rare path; `delete` removes every
+ * occurrence.
  */
 export class ClassNames implements ClassNameCollector {
   value: string;
@@ -18,11 +23,7 @@ export class ClassNames implements ClassNameCollector {
     this.value = initial || "";
   }
   add(className: string) {
-    if (!this.value) {
-      this.value = className;
-    } else if (!this.has(className)) {
-      this.value += " " + className;
-    }
+    this.value += (this.value && " ") + className;
   }
   has(className: string) {
     return (" " + this.value + " ").includes(" " + className + " ");

--- a/packages/next-yak/runtime/cssLiteral.tsx
+++ b/packages/next-yak/runtime/cssLiteral.tsx
@@ -4,18 +4,12 @@ import { ClassNameCollector, RuntimeStyleProcessor } from "./publicStyledApi.js"
 export const yakComponentSymbol = Symbol("yak");
 
 /**
- * String-backed ClassNameCollector used by the render path.
+ * String-backed ClassNameCollector used by the render path
  *
- * Replaces the previous `new Set(className.split(" "))` →
- * `Array.from(set).join(" ")` round-trip, which dominated render cost.
- * The hot path (`add`) is a plain string append and does not deduplicate, so
- * the collector is a multiset: the same class can appear twice, e.g. when
- * `atoms()` repeats a utility or the incoming className already carries it.
- * That is rendering neutral - CSS applies a class once however often it is
- * listed - and it matches what the compile time class name folds emit.
- * `has`/`delete` keep the Set-like contract for advanced runtime functions
- * (e.g. atoms removing classes) on the rare path; `delete` removes every
- * occurrence.
+ * `add` is a plain string append and does not deduplicate, so the collector is
+ * a multiset - the same class may appear twice, e.g. `atoms("a b", "a")` → `"a b a"`.
+ * `has`/`delete` cover the rare path where a runtime function inspects or
+ * removes classes; `delete` removes every occurrence
  */
 export class ClassNames implements ClassNameCollector {
   value: string;
@@ -205,8 +199,8 @@ const recursivePropExecution = (props: unknown, fn: (props: unknown) => any): st
   if (typeof result === "function") {
     return recursivePropExecution(props, result);
   }
-  // typeof guards first — the `process.env` lookup is a real per-call cost
-  // for unbundled Node consumers, so it must only run on the invalid path
+  // the `process.env` lookup is a real per-call cost for unbundled Node
+  // consumers, so it must stay behind the typeof guards on the invalid path
   if (typeof result !== "string" && typeof result !== "number" && !(result instanceof String)) {
     if (process.env.NODE_ENV === "development") {
       throw new Error(

--- a/packages/next-yak/runtime/internals/mergeCssProp.ts
+++ b/packages/next-yak/runtime/internals/mergeCssProp.ts
@@ -1,3 +1,4 @@
+import { ClassNames } from "../cssLiteral.js";
 import { RuntimeStyleProcessor } from "../publicStyledApi.js";
 
 /**
@@ -20,8 +21,7 @@ export const mergeCssProp = (
   } & Record<string, unknown>,
   cssProp: RuntimeStyleProcessor<unknown>,
 ) => {
-  const existingClassName = relevantProps.className;
-  const classNames = existingClassName ? new Set(existingClassName.split(" ")) : new Set<string>();
+  const classNames = new ClassNames(relevantProps.className);
 
   const existingStyle = relevantProps.style;
   const style = existingStyle ? { ...existingStyle } : {};
@@ -33,8 +33,8 @@ export const mergeCssProp = (
   if (Object.keys(style).length > 0) {
     result.style = style;
   }
-  if (classNames.size > 0) {
-    result.className = Array.from(classNames).join(" ");
+  if (classNames.value) {
+    result.className = classNames.value;
   }
 
   return result;

--- a/packages/next-yak/runtime/internals/propMarkers.ts
+++ b/packages/next-yak/runtime/internals/propMarkers.ts
@@ -1,0 +1,20 @@
+/** Internal, render-time markers written onto props */
+
+/**
+ * Set on props once the attrs functions have been folded in, so a nested yak
+ * wrapper further out the chain does not merge the same attrs twice.
+ */
+export const ATTRS_MERGED = "$__a" as const;
+
+/**
+ * Set on props once the runtime style processor has run, so an outer yak
+ * component that receives already-processed props skips the collector entirely.
+ */
+export const RUNTIME_STYLES_DONE = "$__r" as const;
+
+/**
+ * Carries the constant `.attrs({...})` object on the merged attrs function,
+ * marking it theme-independent so the fast render path can apply it without
+ * executing anything. Lives on the function, never on props.
+ */
+export const STATIC_ATTRS = "$sa" as const;

--- a/packages/next-yak/runtime/internals/propMarkers.ts
+++ b/packages/next-yak/runtime/internals/propMarkers.ts
@@ -1,20 +1,20 @@
-/** Internal, render-time markers written onto props */
+/** Internal markers used by the render path */
 
 /**
  * Set on props once the attrs functions have been folded in, so a nested yak
- * wrapper further out the chain does not merge the same attrs twice.
+ * wrapper further out the chain does not merge the same attrs twice
  */
 export const ATTRS_MERGED = "$__a" as const;
 
 /**
  * Set on props once the runtime style processor has run, so an outer yak
- * component that receives already-processed props skips the collector entirely.
+ * component that receives already-processed props skips the collector entirely
  */
 export const RUNTIME_STYLES_DONE = "$__r" as const;
 
 /**
  * Carries the constant `.attrs({...})` object on the merged attrs function,
  * marking it theme-independent so the fast render path can apply it without
- * executing anything. Lives on the function, never on props.
+ * executing anything. Lives on the function, never on props
  */
 export const STATIC_ATTRS = "$sa" as const;

--- a/packages/next-yak/runtime/publicStyledApi.ts
+++ b/packages/next-yak/runtime/publicStyledApi.ts
@@ -126,11 +126,10 @@ export type FastOmit<T extends object, U extends string | number | symbol> = {
 };
 
 /**
- * Set-like collector for class names.
+ * Set-like collector for class names
  *
- * Implemented as a string builder in the runtime (the previous
- * Set<string> split → Set → Array.from → join round-trip dominated render
- * cost); a real Set<string> also satisfies this interface.
+ * The runtime implements this as a string builder, a real `Set<string>`
+ * satisfies it as well
  */
 export type ClassNameCollector = {
   add(className: string): void;

--- a/packages/next-yak/runtime/publicStyledApi.ts
+++ b/packages/next-yak/runtime/publicStyledApi.ts
@@ -26,7 +26,7 @@ export interface StyledFn {
  */
 export interface YakComponent<T> extends React.FunctionComponent<T> {
   // This is intentionally typed to hide the internal implementation details.
-  [yakComponentSymbol]: [unknown, unknown, unknown];
+  [yakComponentSymbol]: [unknown, unknown, unknown, unknown];
 }
 
 /**

--- a/packages/next-yak/runtime/publicStyledApi.ts
+++ b/packages/next-yak/runtime/publicStyledApi.ts
@@ -126,13 +126,30 @@ export type FastOmit<T extends object, U extends string | number | symbol> = {
 };
 
 /**
- * Type of all functions that can be passed to manipulate styles
+ * Set-like collector for class names.
+ *
+ * Implemented as a string builder in the runtime (the previous
+ * Set<string> split → Set → Array.from → join round-trip dominated render
+ * cost); a real Set<string> also satisfies this interface.
  */
-export type RuntimeStyleProcessor<T> = (
+export type ClassNameCollector = {
+  add(className: string): void;
+  has(className: string): boolean;
+  delete(className: string): void;
+};
+
+/**
+ * Type of all functions that can be passed to manipulate styles
+ *
+ * `$dynamic` marks processors that execute user functions or write style
+ * values at render time; purely static processors (class names only) can
+ * skip theme lookup and style-object allocation.
+ */
+export type RuntimeStyleProcessor<T> = ((
   props: T,
-  classNames: Set<string>,
+  classNames: ClassNameCollector,
   style: React.CSSProperties,
-) => void;
+) => void) & { $dynamic?: boolean };
 
 /**
  * Utility type to keep the generic API of a component while still being able to use it in a selector

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -224,13 +224,15 @@ const removeNonDomProperties = <T extends Record<string, unknown>>(obj: T): T =>
   return result;
 };
 
-// util function to merge class names, as they are concatenated with a space
-const mergeClassNames = (a?: string, b?: string) => {
-  if (!a && !b) return undefined;
-  if (!a) return b;
-  if (!b) return a;
-  return a + " " + b;
-};
+/**
+ * util function to merge class names, as they are concatenated with a space
+ * e.g.:\
+ * `("a", "b")` → `"a b"`\
+ * `("a", undefined)` → `"a"`\
+ * `(undefined, "b")` → `"b"`\
+ * `(undefined, undefined)` → `undefined`
+ */
+const mergeClassNames = (a?: string, b?: string) => (a && b ? a + " " + b : a || b || undefined);
 
 /**
  * merge props and processed props (including class names and styles)

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -47,8 +47,10 @@ const styledFactory: StyledFn = (Component) =>
  */
 export const styled = styledFactory as Styled;
 
-// Real internal shape of the yakComponentSymbol tuple. Public YakComponent keeps it
-// opaque ([unknown, ...])
+/**
+ * Real shape of the yakComponentSymbol tuple, which the public `YakComponent`
+ * keeps opaque as `[unknown, ...]`
+ */
 type YakComponentInternals = [
   self: React.FunctionComponent,
   attrsFn: AttrsFunction<any, any, any> | undefined,
@@ -131,7 +133,6 @@ const yakStyled: StyledInternal = (Component, attrs) => {
       // attrs functions and dynamic style functions receive the theme —
       // fully static components take the fast path above and never read the
       // theme context
-      //
       const theme = useTheme();
 
       // The first components which is not wrapped in a yak component will execute all attrs functions
@@ -311,11 +312,11 @@ const buildRuntimeAttrsProcessor = <
 
   // A constant `.attrs({...})` is wrapped into `() => attrs`, which makes it
   // indistinguishable from `.attrs(props => ...)` at render time — so record the
-  // object it will always return, the way the style processor records $dynamic.
-  // Only the wrapper closure is tagged, never a user-supplied attrs function.
+  // object it will always return. Only the wrapper closure is tagged, never a
+  // user-supplied attrs function.
   //
   // A `styled(StyledWithAttrs).attrs({...})` chain merges its levels per render
-  // and is not tagged, which keeps a mutation of an attrs object observable.
+  // and is not tagged, which keeps a mutation of an attrs object observable
   if (ownAttrsFn && typeof attrs !== "function") {
     return Object.assign(ownAttrsFn, {
       [INTERNAL.STATIC_ATTRS]: attrs,
@@ -326,10 +327,10 @@ const buildRuntimeAttrsProcessor = <
 };
 
 /**
- * The constant object a `.attrs({...})` processor always returns.
+ * The constant object a `.attrs({...})` processor always returns
  *
  * Kept local to this module — like the `yakComponentSymbol` tuple, it is an
- * implementation detail and must not reach the public `AttrsFunction` type.
+ * implementation detail and must not reach the public `AttrsFunction` type
  */
 type StaticAttrsCarrier = { [K in typeof INTERNAL.STATIC_ATTRS]?: object };
 

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -132,9 +132,6 @@ const yakStyled: StyledInternal = (Component, attrs) => {
       // fully static components take the fast path above and never read the
       // theme context
       //
-      // (this previously gated on `runtimeStylesFn.length` — the function
-      // ARITY, which is always ≥2 — so useTheme() ran for every component
-      // including fully static ones; see EXP-20260609-02)
       const theme = useTheme();
 
       // The first components which is not wrapped in a yak component will execute all attrs functions

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -1,4 +1,5 @@
 import { css, CSSInterpolation, ClassNames, yakComponentSymbol } from "./cssLiteral.js";
+import * as INTERNAL from "./internals/propMarkers.js";
 import React from "react";
 import type {
   Attrs,
@@ -80,7 +81,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
     | string;
 
   const mergedAttrsFn = buildRuntimeAttrsProcessor(attrs, parentAttrsFn);
-  const staticAttrs = (mergedAttrsFn as StaticAttrsCarrier | undefined)?.$staticAttrs;
+  const staticAttrs = (mergedAttrsFn as StaticAttrsCarrier | undefined)?.[INTERNAL.STATIC_ATTRS];
 
   return (styles, ...values) => {
     // combine all interpolated logic into a single function
@@ -105,12 +106,12 @@ const yakStyled: StyledInternal = (Component, attrs) => {
         // className, and `source` then aliases `props` — so the class names are
         // written to the fresh, filtered object rather than back into props
         const source = (
-          staticAttrs && !("$__attrs" in props)
+          staticAttrs && !(INTERNAL.ATTRS_MERGED in props)
             ? combineProps(
                 {
                   ...(props as { className?: string; style?: React.CSSProperties }),
                   // mark the props as processed
-                  $__attrs: true,
+                  [INTERNAL.ATTRS_MERGED]: true,
                 },
                 staticAttrs,
               )
@@ -119,7 +120,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
         const filteredProps = removeNonDomProperties(source) as {
           className?: string;
         };
-        if (!("$__runtimeStylesProcessed" in source)) {
+        if (!(INTERNAL.RUNTIME_STYLES_DONE in source)) {
           const classNames = new ClassNames(source.className);
           runtimeStyleProcessor(source, classNames, undefined as unknown as React.CSSProperties);
           filteredProps.className = classNames.value || undefined;
@@ -140,7 +141,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
       // The first components which is not wrapped in a yak component will execute all attrs functions
       // starting from the innermost yak component to the outermost yak component (itself)
       const combinedProps =
-        "$__attrs" in props
+        INTERNAL.ATTRS_MERGED in props
           ? ({
               theme,
               ...props,
@@ -158,7 +159,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
                   style?: React.CSSProperties;
                 }),
                 // mark the props as processed
-                $__attrs: true,
+                [INTERNAL.ATTRS_MERGED]: true,
               },
               mergedAttrsFn?.({ theme, ...(props as any) }),
             );
@@ -168,7 +169,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
       //
       // inner levels of a styled(Component) chain receive already-processed
       // props and skip this entirely — no collector, no style clone
-      if (!("$__runtimeStylesProcessed" in combinedProps)) {
+      if (!(INTERNAL.RUNTIME_STYLES_DONE in combinedProps)) {
         const classNames = new ClassNames(combinedProps.className);
         // static processors never write style values, so the incoming style
         // object can be passed through without a defensive copy
@@ -177,7 +178,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
           : combinedProps.style;
         runtimeStyleProcessor(combinedProps, classNames, styles as React.CSSProperties);
         // @ts-expect-error this is not typed correctly
-        combinedProps.$__runtimeStylesProcessed = true;
+        combinedProps[INTERNAL.RUNTIME_STYLES_DONE] = true;
 
         combinedProps.className = classNames.value || undefined;
         if (styles !== combinedProps.style) {
@@ -194,7 +195,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
 
       // remove all props that start with a $ sign so they reach neither DOM
       // elements nor custom components — this also strips the internal
-      // $__attrs/$__runtimeStylesProcessed markers, which must not cross a
+      // INTERNAL.ATTRS_MERGED/INTERNAL.RUNTIME_STYLES_DONE markers, which must not cross a
       // custom component boundary (a custom component may render another yak
       // component that has to process its own attrs/styles)
       const filteredProps = removeNonDomProperties(propsBeforeFiltering);
@@ -320,7 +321,9 @@ const buildRuntimeAttrsProcessor = <
   // A `styled(StyledWithAttrs).attrs({...})` chain merges its levels per render
   // and is not tagged, which keeps a mutation of an attrs object observable.
   if (ownAttrsFn && typeof attrs !== "function") {
-    return Object.assign(ownAttrsFn, { $staticAttrs: attrs } as StaticAttrsCarrier);
+    return Object.assign(ownAttrsFn, {
+      [INTERNAL.STATIC_ATTRS]: attrs,
+    } as StaticAttrsCarrier);
   }
 
   return ownAttrsFn || parentAttrsFn;
@@ -332,7 +335,7 @@ const buildRuntimeAttrsProcessor = <
  * Kept local to this module — like the `yakComponentSymbol` tuple, it is an
  * implementation detail and must not reach the public `AttrsFunction` type.
  */
-type StaticAttrsCarrier = { $staticAttrs?: object };
+type StaticAttrsCarrier = { [K in typeof INTERNAL.STATIC_ATTRS]?: object };
 
 /**
  * Merges the runtime style function of the current component with the runtime style function of the parent component

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -19,12 +19,6 @@ import type {
 import { useTheme } from "next-yak/context";
 import type { YakTheme } from "./context/index.tsx";
 
-/**
- * This Symbol is a fake theme which was used instead of the real one from the context
- * to speed up rendering
- */
-const noTheme: YakTheme = {};
-
 //
 // The `styled()` API without `styled.` syntax
 //
@@ -90,24 +84,34 @@ const yakStyled: StyledInternal = (Component, attrs) => {
       parentRuntimeStylesFn,
     );
     const Yak: React.FunctionComponent = (props) => {
-      // skip the theme context lookup when no attrs function and no dynamic
-      // style function can consume it
+      // fast path for fully static components (no attrs, no dynamic styles —
+      // the most common case): contribute the chain's class names and strip
+      // $-props; skips theme lookup, prop spreading and style cloning
+      // entirely (this is NOT against the rule of hooks — the condition is
+      // constant for the lifetime of the component)
+      if (!mergedAttrsFn && !runtimeStyleProcessor.$dynamic) {
+        const filteredProps = removeNonDomProperties(props) as {
+          className?: string;
+        };
+        // props that already went through a yak wrapper (passed through a
+        // custom component boundary) keep their processed className
+        if (!("$__runtimeStylesProcessed" in props)) {
+          const classNames = new ClassNames((props as { className?: string }).className);
+          runtimeStyleProcessor(props, classNames, undefined as unknown as React.CSSProperties);
+          filteredProps.className = classNames.value || undefined;
+        }
+        const Target = targetComponent as React.FunctionComponent;
+        return <Target {...filteredProps} />;
+      }
+
+      // attrs functions and dynamic style functions receive the theme —
+      // fully static components take the fast path above and never read the
+      // theme context
       //
-      // `mergedAttrsFn || runtimeStyleProcessor.$dynamic` is NOT against the rule of
-      // hooks as both are constants defined outside of the component
-      //
-      // for example
-      //
-      // const Button = styled.button`color: red;`
-      //       ^ does not need to have access to theme, so we skip calling useTheme()
-      //
-      // const Button = styled.button`${({ theme }) => css`color: ${theme.color};`}`
-      //       ^ must be have access to theme, so we call useTheme()
-      //
-      // (this previously checked `runtimeStylesFn.length` — the function ARITY,
-      // which is always ≥2 — so useTheme() ran for every component including
-      // fully static ones; see EXP-20260609-02)
-      const theme = mergedAttrsFn || runtimeStyleProcessor.$dynamic ? useTheme() : noTheme;
+      // (this previously gated on `runtimeStylesFn.length` — the function
+      // ARITY, which is always ≥2 — so useTheme() ran for every component
+      // including fully static ones; see EXP-20260609-02)
+      const theme = useTheme();
 
       // The first components which is not wrapped in a yak component will execute all attrs functions
       // starting from the innermost yak component to the outermost yak component (itself)

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -305,7 +305,11 @@ const buildRuntimeStylesProcessor = <T,>(
 ) => {
   if (runtimeStylesFn && parentRuntimeStylesFn) {
     const combined: RuntimeStyleProcessor<T> = Object.assign(
-      (props: T, classNames: Parameters<RuntimeStyleProcessor<T>>[1], style: React.CSSProperties) => {
+      (
+        props: T,
+        classNames: Parameters<RuntimeStyleProcessor<T>>[1],
+        style: React.CSSProperties,
+      ) => {
         parentRuntimeStylesFn(props, classNames, style);
         runtimeStylesFn(props, classNames, style);
       },

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -71,6 +71,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
     | string;
 
   const mergedAttrsFn = buildRuntimeAttrsProcessor(attrs, parentAttrsFn);
+  const staticAttrs = (mergedAttrsFn as StaticAttrsCarrier | undefined)?.$staticAttrs;
 
   return (styles, ...values) => {
     // combine all interpolated logic into a single function
@@ -84,20 +85,34 @@ const yakStyled: StyledInternal = (Component, attrs) => {
       parentRuntimeStylesFn,
     );
     const Yak: React.FunctionComponent = (props) => {
-      // fast path for fully static components (no attrs, no dynamic styles —
-      // the most common case): contribute the chain's class names and strip
-      // $-props; skips theme lookup, prop spreading and style cloning
-      // entirely (this is NOT against the rule of hooks — the condition is
-      // constant for the lifetime of the component)
-      if (!mergedAttrsFn && !runtimeStyleProcessor.$dynamic) {
-        const filteredProps = removeNonDomProperties(props) as {
+      // fast path for components that contribute the same thing on every
+      // render — no attrs at all, or a constant `.attrs({...})` which cannot
+      // read the theme — and no dynamic styles. Contributes the chain's class
+      // names and strips $-props; skips theme lookup, prop spreading and style
+      // cloning entirely (this is NOT against the rule of hooks — the condition
+      // is constant for the lifetime of the component)
+      if ((!mergedAttrsFn || staticAttrs) && !runtimeStyleProcessor.$dynamic) {
+        // props that already went through a yak wrapper keep their processed
+        // className, and `source` then aliases `props` — so the class names are
+        // written to the fresh, filtered object rather than back into props
+        const source = (
+          staticAttrs && !("$__attrs" in props)
+            ? combineProps(
+                {
+                  ...(props as { className?: string; style?: React.CSSProperties }),
+                  // mark the props as processed
+                  $__attrs: true,
+                },
+                staticAttrs,
+              )
+            : props
+        ) as { className?: string; style?: React.CSSProperties };
+        const filteredProps = removeNonDomProperties(source) as {
           className?: string;
         };
-        // props that already went through a yak wrapper (passed through a
-        // custom component boundary) keep their processed className
-        if (!("$__runtimeStylesProcessed" in props)) {
-          const classNames = new ClassNames((props as { className?: string }).className);
-          runtimeStyleProcessor(props, classNames, undefined as unknown as React.CSSProperties);
+        if (!("$__runtimeStylesProcessed" in source)) {
+          const classNames = new ClassNames(source.className);
+          runtimeStyleProcessor(source, classNames, undefined as unknown as React.CSSProperties);
           filteredProps.className = classNames.value || undefined;
         }
         const Target = targetComponent as React.ElementType;
@@ -289,8 +304,27 @@ const buildRuntimeAttrsProcessor = <
     };
   }
 
+  // A constant `.attrs({...})` is wrapped into `() => attrs`, which makes it
+  // indistinguishable from `.attrs(props => ...)` at render time — so record the
+  // object it will always return, the way the style processor records $dynamic.
+  // Only the wrapper closure is tagged, never a user-supplied attrs function.
+  //
+  // A `styled(StyledWithAttrs).attrs({...})` chain merges its levels per render
+  // and is not tagged, which keeps a mutation of an attrs object observable.
+  if (ownAttrsFn && typeof attrs !== "function") {
+    return Object.assign(ownAttrsFn, { $staticAttrs: attrs } as StaticAttrsCarrier);
+  }
+
   return ownAttrsFn || parentAttrsFn;
 };
+
+/**
+ * The constant object a `.attrs({...})` processor always returns.
+ *
+ * Kept local to this module — like the `yakComponentSymbol` tuple, it is an
+ * implementation detail and must not reach the public `AttrsFunction` type.
+ */
+type StaticAttrsCarrier = { $staticAttrs?: object };
 
 /**
  * Merges the runtime style function of the current component with the runtime style function of the parent component

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -46,6 +46,15 @@ const styledFactory: StyledFn = (Component) =>
  */
 export const styled = styledFactory as Styled;
 
+// Real internal shape of the yakComponentSymbol tuple. Public YakComponent keeps it
+// opaque ([unknown, ...])
+type YakComponentInternals = [
+  self: React.FunctionComponent,
+  attrsFn: AttrsFunction<any, any, any> | undefined,
+  styleProcessor: RuntimeStyleProcessor<unknown>,
+  target: React.FunctionComponent | string,
+];
+
 const yakStyled: StyledInternal = (Component, attrs) => {
   const isYakComponent = typeof Component !== "string" && yakComponentSymbol in Component;
 
@@ -196,15 +205,12 @@ const yakStyled: StyledInternal = (Component, attrs) => {
       return <Target {...(filteredProps as React.ComponentProps<typeof Target>)} />;
     };
 
-    // Assign the yakComponentSymbol directly without forwardRef
-    return Object.assign(Yak, {
-      [yakComponentSymbol]: [Yak, mergedAttrsFn, runtimeStyleProcessor, targetComponent] as [
-        unknown,
-        unknown,
-        unknown,
-        unknown,
-      ],
-    });
+    // Direct write instead of Object.assign (faster & smaller)
+    const taggedYak = Yak as React.FunctionComponent & {
+      [yakComponentSymbol]: YakComponentInternals;
+    };
+    taggedYak[yakComponentSymbol] = [Yak, mergedAttrsFn, runtimeStyleProcessor, targetComponent];
+    return taggedYak;
   };
 };
 

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -75,7 +75,6 @@ const yakStyled: StyledInternal = (Component, attrs) => {
   // attrs and style processors are already merged at construction time, so
   // a chain of N levels renders the target directly in ONE wrapper instead
   // of re-entering every parent wrapper per element per render
-  // (the re-entry was the structural ×N multiplier in EXP-20260609-02)
   const targetComponent = (isYakComponent ? parentTarget : Component) as
     | React.FunctionComponent
     | string;

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -58,13 +58,23 @@ const yakStyled: StyledInternal = (Component, attrs) => {
   // if the component that is wrapped is a yak component, we can extract it to render the underlying component directly
   // and we can also extract the attrs function and the dynamic style function to merge it with the current attrs function (or dynamic style function)
   // so that the sequence of the attrs functions is preserved
-  const [parentYakComponent, parentAttrsFn, parentRuntimeStylesFn] = isYakComponent
+  const [, parentAttrsFn, parentRuntimeStylesFn, parentTarget] = isYakComponent
     ? (Component[yakComponentSymbol] as [
         YakComponent<unknown>,
         ExtractAttrsFunction<typeof attrs>,
         RuntimeStyleProcessor<unknown>,
+        React.FunctionComponent | string,
       ])
     : [];
+
+  // the ultimate render target of the whole styled(styled(...)) chain:
+  // attrs and style processors are already merged at construction time, so
+  // a chain of N levels renders the target directly in ONE wrapper instead
+  // of re-entering every parent wrapper per element per render
+  // (the re-entry was the structural ×N multiplier in EXP-20260609-02)
+  const targetComponent = (isYakComponent ? parentTarget : Component) as
+    | React.FunctionComponent
+    | string;
 
   const mergedAttrsFn = buildRuntimeAttrsProcessor(attrs, parentAttrsFn);
 
@@ -154,27 +164,23 @@ const yakStyled: StyledInternal = (Component, attrs) => {
       const propsBeforeFiltering =
         themeAfterAttr === theme ? combinedPropsWithoutTheme : combinedProps;
 
-      // remove all props that start with a $ sign for string components e.g. "button" or "div"
-      // so that they are not passed to the DOM element
-      const filteredProps = !isYakComponent
-        ? removeNonDomProperties(propsBeforeFiltering)
-        : propsBeforeFiltering;
+      // remove all props that start with a $ sign so they reach neither DOM
+      // elements nor custom components — this also strips the internal
+      // $__attrs/$__runtimeStylesProcessed markers, which must not cross a
+      // custom component boundary (a custom component may render another yak
+      // component that has to process its own attrs/styles)
+      const filteredProps = removeNonDomProperties(propsBeforeFiltering);
 
-      return parentYakComponent ? (
-        // if the styled(Component) syntax is used and the component is a yak component
-        // we can call the yak function directly without running through react createElement
-        parentYakComponent(filteredProps)
-      ) : (
-        // if the final component is a string component e.g. styled("div") or a custom non yak fn e.g. styled(MyComponent)
-        <Component
-          {...(filteredProps as React.ComponentProps<Exclude<typeof Component, string>>)}
-        />
-      );
+      // render the chain's target directly — parent wrappers contribute only
+      // their (already merged) attrs and style processors
+      const Target = targetComponent as React.FunctionComponent;
+      return <Target {...filteredProps} />;
     };
 
     // Assign the yakComponentSymbol directly without forwardRef
     return Object.assign(Yak, {
-      [yakComponentSymbol]: [Yak, mergedAttrsFn, runtimeStyleProcessor] as [
+      [yakComponentSymbol]: [Yak, mergedAttrsFn, runtimeStyleProcessor, targetComponent] as [
+        unknown,
         unknown,
         unknown,
         unknown,

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -100,8 +100,8 @@ const yakStyled: StyledInternal = (Component, attrs) => {
           runtimeStyleProcessor(props, classNames, undefined as unknown as React.CSSProperties);
           filteredProps.className = classNames.value || undefined;
         }
-        const Target = targetComponent as React.FunctionComponent;
-        return <Target {...filteredProps} />;
+        const Target = targetComponent as React.ElementType;
+        return <Target {...(filteredProps as React.ComponentProps<typeof Target>)} />;
       }
 
       // attrs functions and dynamic style functions receive the theme —
@@ -177,8 +177,8 @@ const yakStyled: StyledInternal = (Component, attrs) => {
 
       // render the chain's target directly — parent wrappers contribute only
       // their (already merged) attrs and style processors
-      const Target = targetComponent as React.FunctionComponent;
-      return <Target {...filteredProps} />;
+      const Target = targetComponent as React.ElementType;
+      return <Target {...(filteredProps as React.ComponentProps<typeof Target>)} />;
     };
 
     // Assign the yakComponentSymbol directly without forwardRef

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -1,4 +1,4 @@
-import { css, CSSInterpolation, yakComponentSymbol } from "./cssLiteral.js";
+import { css, CSSInterpolation, ClassNames, yakComponentSymbol } from "./cssLiteral.js";
 import React from "react";
 import type {
   Attrs,
@@ -80,11 +80,11 @@ const yakStyled: StyledInternal = (Component, attrs) => {
       parentRuntimeStylesFn,
     );
     const Yak: React.FunctionComponent = (props) => {
-      // if the css component does not require arguments
-      // it can be called without arguments and we skip calling useTheme()
+      // skip the theme context lookup when no attrs function and no dynamic
+      // style function can consume it
       //
-      // `attrsFn || getRuntimeStyles.length` is NOT against the rule of hooks as
-      // getRuntimeStyles and attrsFn are constants defined outside of the component
+      // `mergedAttrsFn || runtimeStyleProcessor.$dynamic` is NOT against the rule of
+      // hooks as both are constants defined outside of the component
       //
       // for example
       //
@@ -93,7 +93,11 @@ const yakStyled: StyledInternal = (Component, attrs) => {
       //
       // const Button = styled.button`${({ theme }) => css`color: ${theme.color};`}`
       //       ^ must be have access to theme, so we call useTheme()
-      const theme = mergedAttrsFn || runtimeStylesFn.length ? useTheme() : noTheme;
+      //
+      // (this previously checked `runtimeStylesFn.length` — the function ARITY,
+      // which is always ≥2 — so useTheme() ran for every component including
+      // fully static ones; see EXP-20260609-02)
+      const theme = mergedAttrsFn || runtimeStyleProcessor.$dynamic ? useTheme() : noTheme;
 
       // The first components which is not wrapped in a yak component will execute all attrs functions
       // starting from the innermost yak component to the outermost yak component (itself)
@@ -121,23 +125,27 @@ const yakStyled: StyledInternal = (Component, attrs) => {
               mergedAttrsFn?.({ theme, ...(props as any) }),
             );
 
-      const classNames = new Set<string>(
-        "className" in combinedProps ? combinedProps.className?.split(" ") : [],
-      );
-      const styles = {
-        ...("style" in combinedProps ? combinedProps.style : {}),
-      };
-
       // execute all functions inside the style literal if not already executed
       // e.g. styled.button`color: ${props => props.color};`
+      //
+      // inner levels of a styled(Component) chain receive already-processed
+      // props and skip this entirely — no collector, no style clone
       if (!("$__runtimeStylesProcessed" in combinedProps)) {
-        runtimeStyleProcessor(combinedProps, classNames, styles);
+        const classNames = new ClassNames(combinedProps.className);
+        // static processors never write style values, so the incoming style
+        // object can be passed through without a defensive copy
+        const styles = runtimeStyleProcessor.$dynamic
+          ? { ...combinedProps.style }
+          : combinedProps.style;
+        runtimeStyleProcessor(combinedProps, classNames, styles as React.CSSProperties);
         // @ts-expect-error this is not typed correctly
         combinedProps.$__runtimeStylesProcessed = true;
-      }
 
-      combinedProps.className = Array.from(classNames).join(" ") || undefined;
-      combinedProps.style = styles;
+        combinedProps.className = classNames.value || undefined;
+        if (styles !== combinedProps.style) {
+          combinedProps.style = styles;
+        }
+      }
 
       // delete the yak theme from the props
       // this must happen after the runtimeStyles are calculated
@@ -286,10 +294,14 @@ const buildRuntimeStylesProcessor = <T,>(
   parentRuntimeStylesFn?: RuntimeStyleProcessor<T>,
 ) => {
   if (runtimeStylesFn && parentRuntimeStylesFn) {
-    const combined: RuntimeStyleProcessor<T> = (props, classNames, style) => {
-      parentRuntimeStylesFn(props, classNames, style);
-      runtimeStylesFn(props, classNames, style);
-    };
+    const combined: RuntimeStyleProcessor<T> = Object.assign(
+      (props: T, classNames: Parameters<RuntimeStyleProcessor<T>>[1], style: React.CSSProperties) => {
+        parentRuntimeStylesFn(props, classNames, style);
+        runtimeStylesFn(props, classNames, style);
+      },
+      // the chain is dynamic if any level is dynamic
+      { $dynamic: runtimeStylesFn.$dynamic || parentRuntimeStylesFn.$dynamic },
+    );
     return combined;
   }
   return runtimeStylesFn || parentRuntimeStylesFn;


### PR DESCRIPTION
This branch rewrites the runtime render path. No API changes, rendered output identical, all runtime tests green — your existing components just render faster, with nothing to change on your side.

**On a real page, against the version you're running today**

A 400-tile product listing (responsive grid, sale badges, wishlist toggles, dynamic rating bars, `@container` queries, focus-visible rings — a real page, not a toy button), `perf` vs the released `next-yak 9.6.0`:

<img width="2313" height="2405" alt="yak-perf-benches" src="https://github.com/user-attachments/assets/7a936034-00fa-4679-b2ac-6664f121ed3f" />

- **SSR render throughput:** 75,925 → **110,092 renders/sec** (+45%)
- **SSR under concurrent load:** 133 → **170 req/sec** (+28%)
- **Server CPU per render:** 5.29 → **3.71 ms** (−30%) — the styling-runtime slice (orange) all but disappears
- **Client hydration:** 18.5 → **16.1 ms** (−13%), **cold mount:** 42.8 → **39.6 ms** (−7%)

That last pair matters: the win isn't only SSR throughput, it's less main-thread work in the browser too. Interaction (in-place re-render) is a tie — that path is dominated by browser layout, not styling.

**Where it comes from**

Four changes did the work. Here's each one, the code in *your* app it speeds up, and how much each synthetic pattern moved against the same code on `main`:

<img width="2182" height="1468" alt="yak-perf-branch" src="https://github.com/user-attachments/assets/11e23bfa-2df1-488e-bd72-598e750ecf32" />


**1. Nested `styled(...)` chains — the biggest win (+430%)**

Extending a styled component, then extending that again:

```tsx
const Button = styled.button`
  color: white;
`;
const Primary = styled(Button)`
  background: blue;
`;
const CallToAction = styled(Primary)`
  font-size: 2rem;
`;
```

Rendering one `<CallToAction />` used to walk every level of the chain at render time — each wrapper calling its parent, redoing the theme read, prop clones and class merging the outer wrapper had already done. The chain now flattens when the component is *defined*: one wrapper renders the final `<button>` directly, no matter how deep the chain goes.

**2. Fully static components take a fast path — the common case (+100% and up)**

Any component with no `${...}` interpolation and no dynamic attrs:

```tsx
const Card = styled.div`
  padding: 16px;
  border-radius: 8px;
`;
```

This is most components in most apps. It used to run the full dynamic machinery on every render — build a Set of class names, subscribe to theme context, clone props and style, set internal markers — none of which it needs. It now early-returns: strip `$`-props, append the class string, render. It also stops subscribing to theme, so on the client these components no longer re-render on a theme switch (they never read the theme).

**3. className building is a string append, not a `Set` round-trip (drives the tree cases)**

Every styled render used to do this, per element:

```tsx
const set = new Set(className?.split(" "));
set.add(ownClassName);
className = Array.from(set).join(" ");
```

In the nested benchmark that round-trip alone was 53% of all process CPU. The compiler already emits a distinct class per component, so the `Set`'s dedup bought nothing in the hot path. It's now a plain string append (the `has`/`delete` contract is kept for atoms and css-prop merging). That's why the deep and wide trees moved most — the cost was paid per class name, per element.

**4. Constant `.attrs()` also takes the fast path (+46%)**

```tsx
const SubmitButton = styled.button.attrs({ type: "submit" })`
  color: white;
`;
```

`.attrs()` with a constant object wraps it in a function internally, which made every attrs component miss the static fast path above. It now recognizes the constant and routes through the same fast path.

**The cost: +170 bytes**

<img width="2084" height="900" alt="yak-bundle-size" src="https://github.com/user-attachments/assets/b76306eb-2261-4727-a3c7-ddf92f5d89ab" />


Runtime size (`internal.js`, minified + brotli) across the branch: +170 B total, 2517 → 2687. The string collector from the className change above is the biggest single piece at +83 B. On the shop page above that shows up as ~200 B more gzipped JS — the trade is a handful of bytes for 1.3–5× render throughput.

**Safety**

- No public API changes — every exported type is byte-identical.
- Rendered HTML is identical across the benchmark suite and the e2e tests.
- All runtime tests green.
- Verified commit-by-commit against `main`: nothing regressed. The only non-win is the css-prop case, flat within measurement noise
