### PR TITLE
Declare React >=19 peer dependency

### DIFF
--- a/.changeset/react-19-peer-dep.md
+++ b/.changeset/react-19-peer-dep.md
@@ -1,0 +1,7 @@
+---
+"next-yak": minor
+---
+
+Declare React >=19 as peer dependency.
+
+The runtime already requires React 19 since 8.0.0 — `useTheme` is built on the `use()` hook (added for async RSC theme contexts in #429), which does not exist in React 18. The peer dependency range just didn't reflect that yet, so React 18 installs would pass `npm install` and then crash at runtime when rendering a themed or dynamic component. This makes the existing requirement explicit.

--- a/packages/next-yak/package.json
+++ b/packages/next-yak/package.json
@@ -175,9 +175,9 @@
     "vitest": "catalog:dev"
   },
   "peerDependencies": {
-    "@types/react": ">=18",
+    "@types/react": ">=19",
     "next": ">=16.1.0",
-    "react": ">=18.0.0",
+    "react": ">=19.0.0",
     "vite": ">=7.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
the peer range says `react >=18.0.0` but the runtime has required react 19 since 8.0.0 — `useTheme` is built on the `use()` hook (came in with the async RSC theme contexts, #429) and `use` doesn't exist in react 18. so a react 18 install passes npm's peer check and then crashes at runtime as soon as a themed or dynamic component renders. this just makes the range honest, nothing about the actual requirement changes. marked as minor not major since the requirement itself shipped half a year ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
