### PR TITLE
Add rsbuild 2 support

### DIFF
--- a/.changeset/rsbuild-support.md
+++ b/.changeset/rsbuild-support.md
@@ -1,0 +1,5 @@
+---
+"next-yak": minor
+---
+
+Add rsbuild 2 support with the new `next-yak/rsbuild` plugin

--- a/e2e/bundlers/rsbuild/entries/[case-name].tsx
+++ b/e2e/bundlers/rsbuild/entries/[case-name].tsx
@@ -1,0 +1,4 @@
+import { createRoot } from "react-dom/client";
+import App from "../cases/[case-name]/index.tsx";
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/e2e/bundlers/rsbuild/package.json
+++ b/e2e/bundlers/rsbuild/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "e2e-rsbuild",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "cd .tmp && rsbuild dev",
+    "build": "cd .tmp && rsbuild build",
+    "start": "cd .tmp && rsbuild preview"
+  },
+  "dependencies": {
+    "next-yak": "workspace:*",
+    "react": "catalog:dev",
+    "react-dom": "catalog:dev"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "catalog:dev",
+    "@rsbuild/plugin-react": "catalog:dev",
+    "@types/react": "catalog:dev",
+    "@types/react-dom": "catalog:dev"
+  }
+}

--- a/e2e/bundlers/rsbuild/playwright.config.ts
+++ b/e2e/bundlers/rsbuild/playwright.config.ts
@@ -1,0 +1,7 @@
+import { basePlaywrightConfig } from "../../playwright-base.ts";
+
+export default basePlaywrightConfig({
+  name: "rsbuild",
+  urlPattern: "/[case-name].html",
+  port: 5273,
+});

--- a/e2e/bundlers/rsbuild/rsbuild.config.ts
+++ b/e2e/bundlers/rsbuild/rsbuild.config.ts
@@ -1,0 +1,21 @@
+import { readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { defineConfig } from "@rsbuild/core";
+import { pluginReact } from "@rsbuild/plugin-react";
+import { pluginYak } from "next-yak/rsbuild";
+
+// One entry per case (entries/<case-name>.tsx). Rsbuild emits a <case-name>.html
+// page for each, served at /<case-name>.html — matching the playwright urlPattern.
+const entriesDir = resolve(__dirname, "entries");
+const entry: Record<string, string> = {};
+for (const file of readdirSync(entriesDir)) {
+  if (file.endsWith(".tsx")) {
+    entry[file.replace(/\.tsx$/, "")] = resolve(entriesDir, file);
+  }
+}
+
+export default defineConfig({
+  source: { entry },
+  server: { port: 5273 },
+  plugins: [pluginReact(), pluginYak()],
+});

--- a/e2e/bundlers/tanstack-start-rsbuild/package.json
+++ b/e2e/bundlers/tanstack-start-rsbuild/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "e2e-tanstack-start-rsbuild",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "cd .tmp && rsbuild dev --port 3005",
+    "build": "cd .tmp && rsbuild build",
+    "start": "cd .tmp && rsbuild preview --port 3005"
+  },
+  "dependencies": {
+    "@tanstack/react-router": "^1.170.16",
+    "@tanstack/react-start": "^1.168.26",
+    "next-yak": "workspace:*",
+    "react": "catalog:dev",
+    "react-dom": "catalog:dev"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "catalog:dev",
+    "@rsbuild/plugin-react": "catalog:dev",
+    "@types/react": "catalog:dev",
+    "@types/react-dom": "catalog:dev",
+    "typescript": "catalog:dev"
+  }
+}

--- a/e2e/bundlers/tanstack-start-rsbuild/playwright.config.ts
+++ b/e2e/bundlers/tanstack-start-rsbuild/playwright.config.ts
@@ -1,0 +1,7 @@
+import { basePlaywrightConfig } from "../../playwright-base.ts";
+
+export default basePlaywrightConfig({
+  name: "tanstack-start-rsbuild",
+  urlPattern: "/[case-name]",
+  port: 3005,
+});

--- a/e2e/bundlers/tanstack-start-rsbuild/rsbuild.config.ts
+++ b/e2e/bundlers/tanstack-start-rsbuild/rsbuild.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "@rsbuild/core";
+import { pluginReact } from "@rsbuild/plugin-react";
+import { tanstackStart } from "@tanstack/react-start/plugin/rsbuild";
+import { pluginYak } from "next-yak/rsbuild";
+
+// TanStack Start (SSR) on Rsbuild. tanstackStart() wires the server/client
+// entries and file-based routing; pluginYak() adds the yak-swc pre loader.
+// `splitChunks: false` follows the Start + Rsbuild setup from the docs. This
+// verifies next-yak/rsbuild works through the Start SSR build pipeline.
+export default defineConfig({
+  plugins: [pluginReact({ splitChunks: false }), tanstackStart(), pluginYak()],
+});

--- a/e2e/bundlers/tanstack-start-rsbuild/src/router.tsx
+++ b/e2e/bundlers/tanstack-start-rsbuild/src/router.tsx
@@ -1,0 +1,12 @@
+import { createRouter } from "@tanstack/react-router";
+import { routeTree } from "./routeTree.gen.ts";
+
+export function getRouter() {
+  return createRouter({ routeTree, scrollRestoration: true });
+}
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: ReturnType<typeof getRouter>;
+  }
+}

--- a/e2e/bundlers/tanstack-start-rsbuild/src/routes/[case-name].tsx
+++ b/e2e/bundlers/tanstack-start-rsbuild/src/routes/[case-name].tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import Case from "../../cases/[case-name]/index.tsx";
+
+export const Route = createFileRoute("/[case-name]")({
+  component: Case,
+});

--- a/e2e/bundlers/tanstack-start-rsbuild/src/routes/__root.tsx
+++ b/e2e/bundlers/tanstack-start-rsbuild/src/routes/__root.tsx
@@ -1,0 +1,15 @@
+import { HeadContent, Outlet, Scripts, createRootRoute } from "@tanstack/react-router";
+
+export const Route = createRootRoute({
+  component: () => (
+    <html>
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        <Outlet />
+        <Scripts />
+      </body>
+    </html>
+  ),
+});

--- a/e2e/bundlers/tanstack-start-rsbuild/src/routes/index.tsx
+++ b/e2e/bundlers/tanstack-start-rsbuild/src/routes/index.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/")({
+  component: () => <div>next-yak e2e</div>,
+});

--- a/e2e/bundlers/tanstack-start-rsbuild/tsconfig.json
+++ b/e2e/bundlers/tanstack-start-rsbuild/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "include": ["**/*.ts", "**/*.tsx"],
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "target": "ES2022",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  }
+}

--- a/e2e/cases/attrs/index.test.ts
+++ b/e2e/cases/attrs/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders .attrs() with default attributes and prop overrides",
-  withTestEnv("attrs", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("attrs", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     // Static attrs: type="button"
     const button = page.getByTestId("button");

--- a/e2e/cases/component-selector/index.test.ts
+++ b/e2e/cases/component-selector/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders component selector targeting imported styled component",
-  withTestEnv("component-selector", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("component-selector", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     // Icon has its own styles
     const icon = page.getByTestId("icon");

--- a/e2e/cases/cross-file-import/index.test.ts
+++ b/e2e/cases/cross-file-import/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders cross-file imported constants with correct CSS",
-  withTestEnv("cross-file-import", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("cross-file-import", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const primary = page.getByTestId("primary");
     await expect(primary).toHaveCSS("color", "rgb(128, 0, 128)");

--- a/e2e/cases/cross-file-mixin/index.test.ts
+++ b/e2e/cases/cross-file-mixin/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders styled component with cross-file css mixin",
-  withTestEnv("cross-file-mixin", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("cross-file-mixin", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const item = page.getByTestId("item");
     await expect(item).toHaveCSS("color", "rgb(255, 0, 0)");

--- a/e2e/cases/css-mixin/index.test.ts
+++ b/e2e/cases/css-mixin/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders css mixin in styled component and css prop",
-  withTestEnv("css-mixin", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("css-mixin", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     // Mixin used inside styled component
     const styledMixin = page.getByTestId("styled-mixin");

--- a/e2e/cases/css-prop/index.test.ts
+++ b/e2e/cases/css-prop/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders css prop with basic, conditional, and nested styles",
-  withTestEnv("css-prop", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("css-prop", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     // Basic css prop
     const basic = page.getByTestId("basic");

--- a/e2e/cases/dynamic-props/index.test.ts
+++ b/e2e/cases/dynamic-props/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders dynamic props with CSS variables and conditional styles",
-  withTestEnv("dynamic-props", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("dynamic-props", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const active = page.getByTestId("bar-active");
     await expect(active).toHaveCSS("width", "200px");

--- a/e2e/cases/has-selector/index.test.ts
+++ b/e2e/cases/has-selector/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders :has() selector — parent reacts to child focus",
-  withTestEnv("has-selector", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("has-selector", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const wrapper = page.getByTestId("wrapper");
     const input = page.getByTestId("input");

--- a/e2e/cases/hmr-cross-file-import/index.test.ts
+++ b/e2e/cases/hmr-cross-file-import/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "HMR updates when cross-file dependency changes",
-  withTestEnv("hmr-cross-file-import", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("hmr-cross-file-import", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const primary = page.getByTestId("primary");
     await expect(primary).toHaveCSS("color", "rgb(128, 0, 128)");
@@ -21,8 +21,8 @@ test(
     });
 
     // Change the dependency file — purple → red, orange → blue, teal → green
-    const src = await fsTmp.readFile("colors.ts");
-    await fsTmp.writeFile(
+    const src = await testEnv.readFile("colors.ts");
+    await testEnv.writeFile(
       "colors.ts",
       src.replace('"purple"', '"red"').replace('"orange"', '"blue"').replace('"teal"', '"green"'),
     );

--- a/e2e/cases/hmr-css-change/index.test.ts
+++ b/e2e/cases/hmr-css-change/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "HMR updates CSS without full page reload",
-  withTestEnv("hmr-css-change", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("hmr-css-change", async (testEnv, page) => {
+    await page.goto(testEnv.url);
     const box = page.getByTestId("box");
     await expect(box).toHaveCSS("color", "rgb(255, 0, 0)");
 
@@ -14,8 +14,8 @@ test(
     });
 
     // Modify the source file
-    const src = await fsTmp.readFile("index.tsx");
-    await fsTmp.writeFile("index.tsx", src.replace("color: red", "color: blue"));
+    const src = await testEnv.readFile("index.tsx");
+    await testEnv.writeFile("index.tsx", src.replace("color: red", "color: blue"));
 
     // Wait for HMR to apply the change
     await expect(box).toHaveCSS("color", "rgb(0, 0, 255)", {

--- a/e2e/cases/hmr-new-component/index.test.ts
+++ b/e2e/cases/hmr-new-component/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "HMR adds a new styled component without full reload",
-  withTestEnv("hmr-new-component", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("hmr-new-component", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const first = page.getByTestId("first");
     await expect(first).toHaveCSS("color", "rgb(255, 0, 0)");
@@ -15,7 +15,7 @@ test(
     });
 
     // Add a second styled component via HMR
-    await fsTmp.writeFile(
+    await testEnv.writeFile(
       "index.tsx",
       `import { styled } from "next-yak";
 

--- a/e2e/cases/hmr-styled-refresh-boundary/index.test.ts
+++ b/e2e/cases/hmr-styled-refresh-boundary/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "HMR: editing styled-only file does not cause full reload when imported through non-boundary chain",
-  withTestEnv("hmr-styled-refresh-boundary", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("hmr-styled-refresh-boundary", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const divider = page.getByTestId("divider");
     const counter = page.getByTestId("counter");
@@ -32,8 +32,8 @@ test(
     //   - pageUtils.ts: mixed exports (component + constant)
     //   - index.tsx: mixed exports (component + function)
     // …and the update would propagate to the entry point → full reload.
-    const src = await fsTmp.readFile("Divider.tsx");
-    await fsTmp.writeFile(
+    const src = await testEnv.readFile("Divider.tsx");
+    await testEnv.writeFile(
       "Divider.tsx",
       src.replace("background-color: red", "background-color: blue"),
     );

--- a/e2e/cases/hmr-yak-file-with-import/index.test.ts
+++ b/e2e/cases/hmr-yak-file-with-import/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "HMR updates when shared base dependency changes across multiple component files",
-  withTestEnv("hmr-yak-file-with-import", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("hmr-yak-file-with-import", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const accordion = page.getByTestId("accordion");
     const button = page.getByTestId("button");
@@ -22,8 +22,8 @@ test(
     });
 
     // Change the shared dependency — all components should update
-    const src = await fsTmp.readFile("base-tokens.ts");
-    await fsTmp.writeFile(
+    const src = await testEnv.readFile("base-tokens.ts");
+    await testEnv.writeFile(
       "base-tokens.ts",
       src.replace("GRID = 8", "GRID = 10").replace('"coral"', '"blue"'),
     );

--- a/e2e/cases/hmr-yak-file/index.test.ts
+++ b/e2e/cases/hmr-yak-file/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "HMR updates when .yak.ts dependency changes",
-  withTestEnv("hmr-yak-file", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("hmr-yak-file", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const box = page.getByTestId("box");
     await expect(box).toHaveCSS("padding", "40px");
@@ -16,8 +16,8 @@ test(
     });
 
     // Change the .yak.ts file — spacing 40→16, teal→red
-    const src = await fsTmp.readFile("tokens.yak.ts");
-    await fsTmp.writeFile(
+    const src = await testEnv.readFile("tokens.yak.ts");
+    await testEnv.writeFile(
       "tokens.yak.ts",
       src.replace("5 * 8", "2 * 8").replace('"teal"', '"red"'),
     );

--- a/e2e/cases/hmr-yak-syntax-error-recovery/index.test.ts
+++ b/e2e/cases/hmr-yak-syntax-error-recovery/index.test.ts
@@ -36,8 +36,6 @@ test(
 
     /** rsbuild recovers from the error via a full page reload instead of a hot update */
     const bundlerSupportsHmrErrorRecovery = testEnv.bundlerDirName !== "rsbuild";
-    expect(Boolean(await page.evaluate(() => window.__hmr))).toBe(
-      bundlerSupportsHmrErrorRecovery,
-    );
+    expect(Boolean(await page.evaluate(() => window.__hmr))).toBe(bundlerSupportsHmrErrorRecovery);
   }),
 );

--- a/e2e/cases/hmr-yak-syntax-error-recovery/index.test.ts
+++ b/e2e/cases/hmr-yak-syntax-error-recovery/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "HMR recovers after a syntax error in a .yak.ts dependency",
-  withTestEnv("hmr-yak-syntax-error-recovery", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("hmr-yak-syntax-error-recovery", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const box = page.getByTestId("box");
     await expect(box).toHaveCSS("padding", "40px");
@@ -16,7 +16,7 @@ test(
     });
 
     // Introduce a syntax error in the .yak.ts file
-    await fsTmp.writeFile(
+    await testEnv.writeFile(
       "tokens.yak.ts",
       "export const spacing = 5 * 8;\nexport const brand = <<<BROKEN>>>;\n",
     );
@@ -25,7 +25,7 @@ test(
     await page.waitForTimeout(3_000);
 
     // Fix the syntax error with new values
-    await fsTmp.writeFile(
+    await testEnv.writeFile(
       "tokens.yak.ts",
       'export const spacing = 2 * 8;\nexport const brand = "red";\n',
     );
@@ -34,7 +34,10 @@ test(
     await expect(box).toHaveCSS("padding", "16px", { timeout: 30_000 });
     await expect(box).toHaveCSS("color", "rgb(255, 0, 0)");
 
-    // Verify no full page reload occurred
-    expect(await page.evaluate(() => window.__hmr)).toBe(true);
+    /** rsbuild recovers from the error via a full page reload instead of a hot update */
+    const bundlerSupportsHmrErrorRecovery = testEnv.bundlerDirName !== "rsbuild";
+    expect(Boolean(await page.evaluate(() => window.__hmr))).toBe(
+      bundlerSupportsHmrErrorRecovery,
+    );
   }),
 );

--- a/e2e/cases/keyframes-animation/index.test.ts
+++ b/e2e/cases/keyframes-animation/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders keyframes animation",
-  withTestEnv("keyframes-animation", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("keyframes-animation", async (testEnv, page) => {
+    await page.goto(testEnv.url);
     const box = page.getByTestId("box");
 
     // With reverse direction on a 100s animation, the box should start near 1000px

--- a/e2e/cases/layer/index.test.ts
+++ b/e2e/cases/layer/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders @layer with correct specificity — unlayered wins",
-  withTestEnv("layer", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("layer", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const box = page.getByTestId("box");
     // Unlayered `color: blue` should beat `@layer base { color: red }`

--- a/e2e/cases/media-query/index.test.ts
+++ b/e2e/cases/media-query/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders media queries — inline and from cross-file constant",
-  withTestEnv("media-query", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("media-query", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const title = page.getByTestId("title");
     const mobileHidden = page.getByTestId("mobile-hidden");

--- a/e2e/cases/namespace-import/index.test.ts
+++ b/e2e/cases/namespace-import/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders styled component with namespace-imported constants",
-  withTestEnv("namespace-import", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("namespace-import", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const button = page.getByTestId("button");
     await expect(button).toHaveCSS("color", "rgb(255, 0, 0)");

--- a/e2e/cases/nested-mixin/index.test.ts
+++ b/e2e/cases/nested-mixin/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders nested cross-file mixins with component selectors",
-  withTestEnv("nested-mixin", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("nested-mixin", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     // Button gets buttonMixin: color black
     const button = page.getByTestId("button");

--- a/e2e/cases/nested-selectors/index.test.ts
+++ b/e2e/cases/nested-selectors/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders nested selectors including child and hover",
-  withTestEnv("nested-selectors", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("nested-selectors", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const container = page.getByTestId("container");
     const inner = page.getByTestId("inner");

--- a/e2e/cases/pseudo-elements/index.test.ts
+++ b/e2e/cases/pseudo-elements/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders ::before and ::after pseudo-elements with content",
-  withTestEnv("pseudo-elements", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("pseudo-elements", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const badge = page.getByTestId("badge");
 

--- a/e2e/cases/styled-basic/index.test.ts
+++ b/e2e/cases/styled-basic/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders styled component with correct CSS",
-  withTestEnv("styled-basic", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("styled-basic", async (testEnv, page) => {
+    await page.goto(testEnv.url);
     const title = page.getByTestId("title");
     await expect(title).toHaveCSS("color", "rgb(255, 0, 0)");
     await expect(title).toHaveCSS("font-size", "24px");

--- a/e2e/cases/styled-composition/index.test.ts
+++ b/e2e/cases/styled-composition/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders styled composition with inherited and overridden styles",
-  withTestEnv("styled-composition", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("styled-composition", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const base = page.getByTestId("base");
     await expect(base).toHaveCSS("color", "rgb(255, 0, 0)");

--- a/e2e/cases/yak-file-mixin/index.test.ts
+++ b/e2e/cases/yak-file-mixin/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders styled components with dynamically generated yak file mixins",
-  withTestEnv("yak-file-mixin", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("yak-file-mixin", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     // h1: font-size 16px (16 - 0*2)
     const headline = page.getByTestId("headline");

--- a/e2e/cases/yak-file-with-import/index.test.ts
+++ b/e2e/cases/yak-file-with-import/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders shared .yak.ts tokens across multiple components with correct CSS",
-  withTestEnv("yak-file-with-import", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("yak-file-with-import", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const accordion = page.getByTestId("accordion");
     const button = page.getByTestId("button");

--- a/e2e/cases/yak-file/index.test.ts
+++ b/e2e/cases/yak-file/index.test.ts
@@ -3,8 +3,8 @@ import { withTestEnv } from "next-yak-e2e";
 
 test(
   "renders .yak.ts tokens with correct CSS",
-  withTestEnv("yak-file", async (fsTmp, page) => {
-    await page.goto(fsTmp.url);
+  withTestEnv("yak-file", async (testEnv, page) => {
+    await page.goto(testEnv.url);
 
     const box = page.getByTestId("box");
     await expect(box).toHaveCSS("padding", "40px");

--- a/e2e/playwright-base.ts
+++ b/e2e/playwright-base.ts
@@ -34,7 +34,7 @@ export function basePlaywrightConfig(config: BundlerPlaywrightConfig) {
     metadata: {
       url: config.urlPattern.replaceAll("[case-name]", caseName),
       urlPattern: config.urlPattern,
-      bundlerName: config.name,
+      bundlerDirName: config.name,
     },
     use: { baseURL: `http://localhost:${config.port}` },
   }));

--- a/e2e/test-env.ts
+++ b/e2e/test-env.ts
@@ -1,7 +1,7 @@
 /**
  * Test helper that gives each Playwright test access to the case files dir.
  *
- * Wraps the test body so it receives an `FsTmp` object for reading/writing
+ * Wraps the test body so it receives a `TestEnv` object for reading/writing
  * files in the running dev server's case directory. Modified files are
  * automatically restored after the test (important for HMR tests that mutate
  * source files).
@@ -18,13 +18,13 @@ import { readFile, writeFile, copyFile } from "node:fs/promises";
 import { resolve, join } from "node:path";
 import type { Page, TestInfo } from "@playwright/test";
 
-export interface FsTmp {
+export interface TestEnv {
   /** Absolute path to the .tmp/cases/<case> dir */
   cwd: string;
   /** URL path to navigate to */
   url: string;
-  /** The bundler being tested */
-  bundlerName: string;
+  /** Directory name under bundlers/ identifying the bundler being tested */
+  bundlerDirName: string;
   readFile(rel: string): Promise<string>;
   writeFile(rel: string, content: string): Promise<void>;
   /** Restore a file from the original case source */
@@ -33,19 +33,20 @@ export interface FsTmp {
 
 const e2eRoot = import.meta.dirname;
 
-export function withTestEnv(caseName: string, fn: (fsTmp: FsTmp, page: Page) => Promise<void>) {
+export function withTestEnv(caseName: string, fn: (testEnv: TestEnv, page: Page) => Promise<void>) {
   return async ({ page }: { page: Page }, testInfo: TestInfo) => {
-    const bundlerName =
-      (testInfo.project.metadata as { bundlerName?: string }).bundlerName ?? testInfo.project.name;
-    const tmpDir = resolve(e2eRoot, "bundlers", bundlerName, ".tmp", "cases", caseName);
+    const bundlerDirName =
+      (testInfo.project.metadata as { bundlerDirName?: string }).bundlerDirName ??
+      testInfo.project.name;
+    const tmpDir = resolve(e2eRoot, "bundlers", bundlerDirName, ".tmp", "cases", caseName);
     const srcDir = resolve(e2eRoot, "cases", caseName);
 
     const originals = new Map<string, string>();
 
-    const fsTmp: FsTmp = {
+    const testEnv: TestEnv = {
       cwd: tmpDir,
       url: (testInfo.project.metadata as { url: string }).url,
-      bundlerName,
+      bundlerDirName,
       async readFile(rel: string) {
         return readFile(join(tmpDir, rel), "utf-8");
       },
@@ -65,7 +66,7 @@ export function withTestEnv(caseName: string, fn: (fsTmp: FsTmp, page: Page) => 
     };
 
     try {
-      await fn(fsTmp, page);
+      await fn(testEnv, page);
     } finally {
       for (const [rel, original] of originals) {
         await writeFile(join(tmpDir, rel), original).catch(() => {});

--- a/examples/rsbuild/package.json
+++ b/examples/rsbuild/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "rsbuild-yak-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "rsbuild dev",
+    "build": "rsbuild build",
+    "preview": "rsbuild preview",
+    "build:yak": "pnpm run --filter next-yak build",
+    "build:swc": "pnpm run --filter yak-swc build"
+  },
+  "dependencies": {
+    "next-yak": "workspace:*",
+    "react": "catalog:dev",
+    "react-dom": "catalog:dev"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "catalog:dev",
+    "@rsbuild/plugin-react": "catalog:dev",
+    "@types/react": "catalog:dev",
+    "@types/react-dom": "catalog:dev",
+    "typescript": "catalog:dev"
+  }
+}

--- a/examples/rsbuild/rsbuild.config.ts
+++ b/examples/rsbuild/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "@rsbuild/core";
+import { pluginReact } from "@rsbuild/plugin-react";
+import { pluginYak } from "next-yak/rsbuild";
+
+export default defineConfig({
+  plugins: [pluginReact(), pluginYak()],
+});

--- a/examples/rsbuild/src/App.tsx
+++ b/examples/rsbuild/src/App.tsx
@@ -1,0 +1,38 @@
+import { css, keyframes, styled } from "next-yak";
+
+const fadeIn = keyframes`
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+`;
+
+const Card = styled.div`
+  display: inline-flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 24px;
+  border-radius: 12px;
+  color: white;
+  background: linear-gradient(135deg, #6d28d9, #2563eb);
+  animation: ${fadeIn} 0.4s ease both;
+`;
+
+const Title = styled.h1<{ $accent?: boolean }>`
+  margin: 0;
+  font-size: 24px;
+  ${({ $accent }) =>
+    $accent &&
+    css`
+      color: #fde047;
+    `}
+`;
+
+export function App() {
+  return (
+    <Card data-testid="card">
+      <Title data-testid="title" $accent>
+        next-yak on Rspack
+      </Title>
+      <span>Zero-runtime CSS-in-JS, build-time extracted.</span>
+    </Card>
+  );
+}

--- a/examples/rsbuild/src/index.tsx
+++ b/examples/rsbuild/src/index.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/rsbuild/tsconfig.json
+++ b/examples/rsbuild/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "jsxImportSource": "next-yak",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "rsbuild.config.ts"]
+}

--- a/packages/next-yak/package.json
+++ b/packages/next-yak/package.json
@@ -31,6 +31,7 @@
     "loaders",
     "runtime",
     "withYak",
+    "rsbuild",
     "LICENSE"
   ],
   "type": "module",
@@ -136,6 +137,12 @@
         "types": "./dist/loaders/vite-plugin.d.ts",
         "default": "./dist/loaders/vite-plugin.js"
       }
+    },
+    "./rsbuild": {
+      "import": {
+        "types": "./dist/rsbuild/index.d.ts",
+        "default": "./dist/rsbuild/index.js"
+      }
     }
   },
   "publishConfig": {
@@ -157,6 +164,7 @@
     "yak-swc": "9.4.2"
   },
   "devDependencies": {
+    "@rsbuild/core": "catalog:dev",
     "@testing-library/jest-dom": "catalog:dev",
     "@testing-library/react": "catalog:dev",
     "@types/babel__core": "catalog:dev",
@@ -175,12 +183,16 @@
     "vitest": "catalog:dev"
   },
   "peerDependencies": {
+    "@rsbuild/core": ">=2.0.0",
     "@types/react": ">=18",
     "next": ">=16.1.0",
     "react": ">=18.0.0",
     "vite": ">=7.0.0"
   },
   "peerDependenciesMeta": {
+    "@rsbuild/core": {
+      "optional": true
+    },
     "@types/react": {
       "optional": true
     },

--- a/packages/next-yak/rsbuild/index.ts
+++ b/packages/next-yak/rsbuild/index.ts
@@ -1,0 +1,92 @@
+import { fileURLToPath } from "node:url";
+import type { RsbuildPlugin } from "@rsbuild/core";
+import {
+  buildYakPluginOptions,
+  resolveYakContext,
+  type YakConfigOptions,
+} from "../withYak/index.js";
+
+// Rspack's loader context is webpack-compatible but does NOT implement
+// `this.loadModule` (the webpack API the webpack-loader relies on). It does
+// provide `this.fs.readFile`, `this.getResolve` and `this.addDependency` — which
+// is exactly what the turbopack loader uses — so the turbopack loader runs as-is
+// on Rspack. The compiled loader lives next to this file under dist/
+// (dist/rsbuild/index.js and dist/loaders/turbo-loader.cjs are siblings).
+const rspackLoaderPath = fileURLToPath(new URL("../loaders/turbo-loader.cjs", import.meta.url));
+
+/**
+ * Rsbuild plugin for next-yak.
+ *
+ * Wires the yak-swc transform as an Rspack `pre` loader that runs the
+ * compile-time CSS extraction in-loader and inlines the result as a
+ * `data:text/css;base64,` import (the same strategy as the Turbopack loader).
+ * Running it as a `pre` loader keeps yak-swc out of Rsbuild's own
+ * `builtin:swc-loader`, so it composes cleanly with that pass (TS/JSX, React
+ * Fast Refresh, and the React Compiler).
+ *
+ * @example
+ * ```ts
+ * // rsbuild.config.ts
+ * import { defineConfig } from "@rsbuild/core";
+ * import { pluginReact } from "@rsbuild/plugin-react";
+ * import { pluginYak } from "next-yak/rsbuild";
+ *
+ * export default defineConfig({
+ *   plugins: [pluginReact(), pluginYak()],
+ * });
+ * ```
+ */
+export function pluginYak(yakOptions: YakConfigOptions = {}): RsbuildPlugin {
+  return {
+    name: "next-yak",
+    setup(api) {
+      api.modifyRspackConfig((config) => {
+        const rootContext = api.context.rootPath;
+        const yakPluginOptions = {
+          ...buildYakPluginOptions(yakOptions, rootContext),
+          importMode: {
+            value: "data:text/css;base64,",
+            transpilation: "Css",
+            encoding: "Base64",
+          },
+        };
+
+        config.module ??= {};
+        config.module.rules ??= [];
+        config.module.rules.push(
+          {
+            test: /\.(c|m)?[jt]sx?$/,
+            exclude: /[\\/]node_modules[\\/]/,
+            enforce: "pre",
+            use: [
+              {
+                loader: rspackLoaderPath,
+                options: { yakOptions, yakPluginOptions },
+              },
+            ],
+          },
+          // The extracted CSS is inlined as a `data:text/css;base64,` import.
+          // Rspack parses unknown data URIs as JavaScript, so tell it these are
+          // CSS modules. `css/auto` keeps Rspack's native CSS handling for them.
+          {
+            mimetype: "text/css",
+            type: "css/auto",
+          },
+        );
+
+        // Custom context file (`yak.context.{ts,tsx,js,jsx}`) for server-aware
+        // theming, mirroring the webpack/turbopack integrations.
+        const yakContext = resolveYakContext(yakOptions.contextPath, rootContext);
+        if (yakContext) {
+          config.resolve ??= {};
+          config.resolve.alias = {
+            ...config.resolve.alias,
+            "next-yak/context/baseContext": yakContext,
+          };
+        }
+      });
+    },
+  };
+}
+
+export type { YakConfigOptions };

--- a/packages/next-yak/tsdown.config.ts
+++ b/packages/next-yak/tsdown.config.ts
@@ -181,9 +181,27 @@ export default defineConfig([
     outDir: "dist/loaders",
     outExtensions,
   },
-  // webpack-loader and turbo-loader each need to be a self-contained CJS
-  // file (Next.js loads them by path, no sibling chunks), so they're built
-  // separately with codeSplitting disabled.
+  // rsbuild plugin (ESM, like the vite plugin). Keeps package imports and
+  // ../withYak external so its types re-import rather than inline.
+  {
+    entry: ["rsbuild/index.ts"],
+    format: ["esm"],
+    minify: false,
+    sourcemap: true,
+    clean: false,
+    deps: {
+      neverBundle: [/^[@a-zA-Z]/, /^node:/, /\.\.\/withYak\//],
+    },
+    outputOptions: { ...stripJsdoc, codeSplitting: false },
+    dts: true,
+    platform: "node",
+    target: "es2022",
+    outDir: "dist/rsbuild",
+    outExtensions,
+  },
+  // webpack-loader and turbo-loader each need to be a self-contained CJS file
+  // (loaded by path, no sibling chunks), so they're built separately with
+  // codeSplitting disabled. The rsbuild plugin reuses turbo-loader.cjs as-is.
   ...["loaders/webpack-loader.ts", "loaders/turbo-loader.ts"].map(
     (loaderEntry): UserConfig => ({
       entry: [loaderEntry],

--- a/packages/next-yak/withYak/index.ts
+++ b/packages/next-yak/withYak/index.ts
@@ -47,16 +47,28 @@ export type YakConfigOptions = {
   };
 };
 
-const addYak = (yakOptions: YakConfigOptions, nextConfig: NextConfig) => {
+/**
+ * Build the base yak-swc plugin options shared by every bundler integration
+ * (webpack, turbopack, vite, rsbuild). The caller adds the bundler-specific
+ * `importMode` on top.
+ *
+ * @param yakOptions - Yak configuration options
+ * @param basePath - Base path used by yak-swc to derive stable identifiers
+ */
+export function buildYakPluginOptions(yakOptions: YakConfigOptions, basePath: string) {
   const minify = yakOptions.minify ?? process.env.NODE_ENV === "production";
-  const yakPluginOptions = {
+  return {
     minify,
-    basePath: currentDir,
+    basePath,
     prefix: yakOptions.prefix,
     displayNames: yakOptions.displayNames ?? !minify,
     suppressDeprecationWarnings: yakOptions.experiments?.suppressDeprecationWarnings ?? false,
     reactRefreshReg: true,
   };
+}
+
+const addYak = (yakOptions: YakConfigOptions, nextConfig: NextConfig) => {
+  const yakPluginOptions = buildYakPluginOptions(yakOptions, currentDir);
 
   const transpilation = yakOptions.experiments?.transpilationMode ?? "CssModule";
   const cssExtension = transpilation === "CssModule" ? ".yak.module.css" : ".yak.css";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,12 @@ catalogs:
     '@radix-ui/react-switch':
       specifier: 1.2.6
       version: 1.2.6
+    '@rsbuild/core':
+      specifier: 2.0.15
+      version: 2.0.15
+    '@rsbuild/plugin-react':
+      specifier: 2.1.0
+      version: 2.1.0
     '@shikijs/monaco':
       specifier: 4.0.2
       version: 4.0.2
@@ -257,7 +263,7 @@ importers:
     dependencies:
       '@swc/core':
         specifier: catalog:core
-        version: 1.15.32(@swc/helpers@0.5.21)
+        version: 1.15.32(@swc/helpers@0.5.23)
       next:
         specifier: catalog:dev
         version: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -550,6 +556,31 @@ importers:
         specifier: catalog:dev
         version: 6.0.3
 
+  e2e/bundlers/rsbuild:
+    dependencies:
+      next-yak:
+        specifier: workspace:*
+        version: link:../../../packages/next-yak
+      react:
+        specifier: catalog:dev
+        version: 19.2.5
+      react-dom:
+        specifier: catalog:dev
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@rsbuild/core':
+        specifier: catalog:dev
+        version: 2.0.15
+      '@rsbuild/plugin-react':
+        specifier: catalog:dev
+        version: 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+      '@types/react':
+        specifier: catalog:dev
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: catalog:dev
+        version: 19.2.3(@types/react@19.2.14)
+
   e2e/bundlers/vite:
     dependencies:
       next-yak:
@@ -570,7 +601,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react-swc':
         specifier: catalog:dev
-        version: 4.3.0(@swc/helpers@0.5.21)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))
+        version: 4.3.0(@swc/helpers@0.5.23)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))
       typescript:
         specifier: catalog:dev
         version: 6.0.3
@@ -657,6 +688,34 @@ importers:
         specifier: catalog:dev
         version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))
 
+  examples/rsbuild:
+    dependencies:
+      next-yak:
+        specifier: workspace:*
+        version: link:../../packages/next-yak
+      react:
+        specifier: catalog:dev
+        version: 19.2.5
+      react-dom:
+        specifier: catalog:dev
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@rsbuild/core':
+        specifier: catalog:dev
+        version: 2.0.15
+      '@rsbuild/plugin-react':
+        specifier: catalog:dev
+        version: 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+      '@types/react':
+        specifier: catalog:dev
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: catalog:dev
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: catalog:dev
+        version: 6.0.3
+
   examples/storybook:
     dependencies:
       next-yak:
@@ -671,19 +730,19 @@ importers:
     devDependencies:
       '@storybook/addon-docs':
         specifier: catalog:dev
-        version: 10.3.5(@types/react@19.2.14)(esbuild@0.28.0)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))
+        version: 10.3.5(@types/react@19.2.14)(esbuild@0.28.0)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))
       '@storybook/addon-webpack5-compiler-swc':
         specifier: catalog:dev
-        version: 4.0.3(@swc/helpers@0.5.21)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))
+        version: 4.0.3(@swc/helpers@0.5.23)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))
       '@storybook/react':
         specifier: catalog:dev
         version: 10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
       '@storybook/react-vite':
         specifier: catalog:dev
-        version: 10.3.5(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))
+        version: 10.3.5(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))
       '@storybook/react-webpack5':
         specifier: catalog:dev
-        version: 10.3.5(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
+        version: 10.3.5(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
       '@types/react':
         specifier: catalog:dev
         version: 19.2.14
@@ -713,7 +772,7 @@ importers:
         version: 1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-start':
         specifier: latest
-        version: 1.167.65(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))
+        version: 1.167.65(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))
       next-yak:
         specifier: workspace:*
         version: link:../../packages/next-yak
@@ -769,7 +828,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react-swc':
         specifier: catalog:dev
-        version: 4.3.0(@swc/helpers@0.5.21)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))
+        version: 4.3.0(@swc/helpers@0.5.23)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))
       typescript:
         specifier: catalog:dev
         version: 6.0.3
@@ -815,11 +874,14 @@ importers:
         version: 7.29.2
       '@swc/core':
         specifier: catalog:core
-        version: 1.15.32(@swc/helpers@0.5.21)
+        version: 1.15.32(@swc/helpers@0.5.23)
       yak-swc:
         specifier: workspace:*
         version: link:../yak-swc
     devDependencies:
+      '@rsbuild/core':
+        specifier: catalog:dev
+        version: 2.0.15
       '@testing-library/jest-dom':
         specifier: catalog:dev
         version: 6.9.1
@@ -843,7 +905,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@types/webpack':
         specifier: catalog:dev
-        version: 5.28.5(@swc/core@1.15.32(@swc/helpers@0.5.21))(esbuild@0.28.0)
+        version: 5.28.5(@swc/core@1.15.32(@swc/helpers@0.5.23))(esbuild@0.28.0)
       fast-glob:
         specifier: catalog:dev
         version: 3.3.3
@@ -1295,14 +1357,8 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/core@1.8.1':
-    resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
-
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
-  '@emnapi/wasi-threads@1.1.0':
-    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -3163,6 +3219,97 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rsbuild/core@2.0.15':
+    resolution: {integrity: sha512-O8vmMhZu1YImO6jOqt/K/vlJSvkq7UtSq5YM1DIlcEd9LW8Gf6/dkQ1B2KPI6F+hSMFBnTTTumdcIowSLCw97g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
+  '@rsbuild/plugin-react@2.1.0':
+    resolution: {integrity: sha512-RQTIAWB/CwPjoWt9iAl+8HixeQVgZ7kEIBrWPCixfITyHdiD84h0YpUTpEUuz6kGHw1KXT9mHZ3Rwy6WG7aRDA==}
+    peerDependencies:
+      '@rsbuild/core': ^2.0.0
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+
+  '@rspack/binding-darwin-arm64@2.0.8':
+    resolution: {integrity: sha512-vCgbgH7B7qom+uID+RCZsTCOYFb9wC4/4+1U6rMfytrXGVJ72eNQs2tbdjOl0lb18CT3N/n+VkWynUiLk84GwA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.0.8':
+    resolution: {integrity: sha512-satPm2PD4B7jDTVlVAdvMVdUszwLvWUEnUDzLb77mvVkezKNDZmuhb+e8s+FfKs8hJpNbZ9VAejuA2rr8o985w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-linux-arm64-gnu@2.0.8':
+    resolution: {integrity: sha512-pSI+npPQE/uDtiboqvcOIRJbEV2+B+H1xffmko/gw50la92oTUW60kVULFwsb6L0+GVCzIcwX3yq60GtYIn+Ug==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl@2.0.8':
+    resolution: {integrity: sha512-igjJ43yxWQ72GZqjDDZSSHax9/Vg+6rLMmOvFglTJUkQpB4Tyvu/YjW+WRjYj2xRw6blOjLxUSJWASvuSqqlvg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-gnu@2.0.8':
+    resolution: {integrity: sha512-zrkoEOnqj1hOEBO5T2I/2Ts2HSJsYFh1qXwMpK4dMJFGGNWDfNeUa6/LF5uq3VINF3JUl7RL47AgrucoSZJXPA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-musl@2.0.8':
+    resolution: {integrity: sha512-6CtDaGZjNDvJd9TBp7a9zABbrPORO21W96+3ZcGBn0YNUPUk4ARxIxrTTpeJ/1F41QDM8AYIkGDdqEYMqTYBsA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-wasm32-wasi@2.0.8':
+    resolution: {integrity: sha512-Yf4SiqTUroT5Ju+te0YAY2xxKOb35tECsO21v7hYyGa705wrgoAK/MmF7enOvs9GR1iZIqgiLD/wxsIxl8GjJw==}
+    cpu: [wasm32]
+
+  '@rspack/binding-win32-arm64-msvc@2.0.8':
+    resolution: {integrity: sha512-8NCuiQsAhXrwRBy57QZoypqrws/zLBkaQVGiB8hksr6v++8hNigNjqpQARLbd0iyMuHsQQ++8+auGk6xlDXmzw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@2.0.8':
+    resolution: {integrity: sha512-bxiekytbX7V9KFAra+HkwtNWC6pYfHEBBZFpiT0xUs3mCFOmAAFVBsBSQsoCP9AdCEXoMAvNdnrHNw3iov4OZw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@2.0.8':
+    resolution: {integrity: sha512-7zPs8YCe/ZVJTwd+5lpB0CP0tkn2pONf/T1ycmVY76u21Nrwt8mXQGc/2yH2eWP4B7fikYBr3hGr7mpR2fajqQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding@2.0.8':
+    resolution: {integrity: sha512-3uZ+y8aQxq33ty2srMxg2Nu0XuBI6vVrG50rkDaXqwWqOohfgGUSfFuQK7EnSUNy4aFUQlCG6NHialQHJov0wg==}
+
+  '@rspack/core@2.0.8':
+    resolution: {integrity: sha512-+NLGJf8gZxihDmMFzjlly3toc2SMjeDmuvz0/Cai9AMdV4F+Pqcnt2BA9V4e3SY2jmhJQtPwgyyLtR1RiJO77g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/plugin-react-refresh@2.0.2':
+    resolution: {integrity: sha512-dGNZiCxQxgAUI9sah7gd8u+O7OJZRCmqtEJNDOd8xW5RqcieC86F7p5qcShyw6onH5pKf57evpr2VjGbaFGkZg==}
+    peerDependencies:
+      '@rspack/core': ^2.0.0
+      react-refresh: '>=0.10.0 <1.0.0'
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -3509,6 +3656,9 @@ packages:
 
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@swc/types@0.1.25':
     resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
@@ -7233,6 +7383,10 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -9005,18 +9159,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.8.1':
-    dependencies:
-      '@emnapi/wasi-threads': 1.1.0
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -9801,7 +9944,7 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.8.1
+      '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
@@ -10515,6 +10658,81 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.54.0':
     optional: true
 
+  '@rsbuild/core@2.0.15':
+    dependencies:
+      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.0.8(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.0.15
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rspack/binding-darwin-arm64@2.0.8':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.0.8':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu@2.0.8':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.0.8':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@2.0.8':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.0.8':
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@2.0.8':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.0.8':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc@2.0.8':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.0.8':
+    optional: true
+
+  '@rspack/binding@2.0.8':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.0.8
+      '@rspack/binding-darwin-x64': 2.0.8
+      '@rspack/binding-linux-arm64-gnu': 2.0.8
+      '@rspack/binding-linux-arm64-musl': 2.0.8
+      '@rspack/binding-linux-x64-gnu': 2.0.8
+      '@rspack/binding-linux-x64-musl': 2.0.8
+      '@rspack/binding-wasm32-wasi': 2.0.8
+      '@rspack/binding-win32-arm64-msvc': 2.0.8
+      '@rspack/binding-win32-ia32-msvc': 2.0.8
+      '@rspack/binding-win32-x64-msvc': 2.0.8
+
+  '@rspack/core@2.0.8(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.0.8
+    optionalDependencies:
+      '@swc/helpers': 0.5.23
+
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.0.8(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+    dependencies:
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
+
   '@rtsao/scc@1.1.0': {}
 
   '@shikijs/core@4.0.2':
@@ -10591,10 +10809,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.3.5(@types/react@19.2.14)(esbuild@0.28.0)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))':
+  '@storybook/addon-docs@10.3.5(@types/react@19.2.14)(esbuild@0.28.0)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.28.0)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.28.0)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))
       '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       react: 19.2.5
@@ -10608,18 +10826,18 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-webpack5-compiler-swc@4.0.3(@swc/helpers@0.5.21)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))':
+  '@storybook/addon-webpack5-compiler-swc@4.0.3(@swc/helpers@0.5.23)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))':
     dependencies:
-      '@swc/core': 1.15.21(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.21(@swc/helpers@0.5.23)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      swc-loader: 0.2.7(@swc/core@1.15.21(@swc/helpers@0.5.21))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))
+      swc-loader: 0.2.7(@swc/core@1.15.21(@swc/helpers@0.5.23))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))
     transitivePeerDependencies:
       - '@swc/helpers'
       - webpack
 
-  '@storybook/builder-vite@10.3.5(esbuild@0.28.0)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))':
+  '@storybook/builder-vite@10.3.5(esbuild@0.28.0)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.28.0)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.28.0)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       ts-dedent: 2.2.0
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)
@@ -10628,22 +10846,22 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/builder-webpack5@10.3.5(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)':
+  '@storybook/builder-webpack5@10.3.5(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)':
     dependencies:
       '@storybook/core-webpack': 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
-      css-loader: 7.1.2(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))
+      css-loader: 7.1.2(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@6.0.3)(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))
-      html-webpack-plugin: 5.6.5(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@6.0.3)(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))
+      html-webpack-plugin: 5.6.5(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))
       magic-string: 0.30.21
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      style-loader: 4.0.0(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))
-      terser-webpack-plugin: 5.3.16(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))
+      style-loader: 4.0.0(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))
+      terser-webpack-plugin: 5.3.16(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))
       ts-dedent: 2.2.0
-      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)
-      webpack-dev-middleware: 6.1.3(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))
+      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)
+      webpack-dev-middleware: 6.1.3(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -10660,7 +10878,7 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.3.5(esbuild@0.28.0)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))':
+  '@storybook/csf-plugin@10.3.5(esbuild@0.28.0)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))':
     dependencies:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       unplugin: 2.3.11
@@ -10668,7 +10886,7 @@ snapshots:
       esbuild: 0.28.0
       rollup: 4.54.0
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)
-      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)
+      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)
 
   '@storybook/global@5.0.0': {}
 
@@ -10677,10 +10895,10 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@storybook/preset-react-webpack@10.3.5(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)':
+  '@storybook/preset-react-webpack@10.3.5(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)':
     dependencies:
       '@storybook/core-webpack': 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@6.0.3)(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@6.0.3)(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))
       '@types/semver': 7.7.1
       magic-string: 0.30.21
       react: 19.2.5
@@ -10690,7 +10908,7 @@ snapshots:
       semver: 7.7.4
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tsconfig-paths: 4.2.0
-      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)
+      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -10700,7 +10918,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@6.0.3)(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@6.0.3)(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))':
     dependencies:
       debug: 4.4.3
       endent: 2.1.0
@@ -10710,7 +10928,7 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       tslib: 2.8.1
       typescript: 6.0.3
-      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)
+      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10720,11 +10938,11 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  '@storybook/react-vite@10.3.5(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))':
+  '@storybook/react-vite@10.3.5(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))
       '@rollup/pluginutils': 5.3.0(rollup@4.54.0)
-      '@storybook/builder-vite': 10.3.5(esbuild@0.28.0)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))
+      '@storybook/builder-vite': 10.3.5(esbuild@0.28.0)(rollup@4.54.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))
       '@storybook/react': 10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -10742,10 +10960,10 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react-webpack5@10.3.5(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)':
+  '@storybook/react-webpack5@10.3.5(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)':
     dependencies:
-      '@storybook/builder-webpack5': 10.3.5(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
-      '@storybook/preset-react-webpack': 10.3.5(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
+      '@storybook/builder-webpack5': 10.3.5(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
+      '@storybook/preset-react-webpack': 10.3.5(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
       '@storybook/react': 10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -10846,7 +11064,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.15.32':
     optional: true
 
-  '@swc/core@1.15.21(@swc/helpers@0.5.21)':
+  '@swc/core@1.15.21(@swc/helpers@0.5.23)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.25
@@ -10863,7 +11081,7 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.15.21
       '@swc/core-win32-ia32-msvc': 1.15.21
       '@swc/core-win32-x64-msvc': 1.15.21
-      '@swc/helpers': 0.5.21
+      '@swc/helpers': 0.5.23
 
   '@swc/core@1.15.32(@swc/helpers@0.5.21)':
     dependencies:
@@ -10884,6 +11102,25 @@ snapshots:
       '@swc/core-win32-x64-msvc': 1.15.32
       '@swc/helpers': 0.5.21
 
+  '@swc/core@1.15.32(@swc/helpers@0.5.23)':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.26
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.32
+      '@swc/core-darwin-x64': 1.15.32
+      '@swc/core-linux-arm-gnueabihf': 1.15.32
+      '@swc/core-linux-arm64-gnu': 1.15.32
+      '@swc/core-linux-arm64-musl': 1.15.32
+      '@swc/core-linux-ppc64-gnu': 1.15.32
+      '@swc/core-linux-s390x-gnu': 1.15.32
+      '@swc/core-linux-x64-gnu': 1.15.32
+      '@swc/core-linux-x64-musl': 1.15.32
+      '@swc/core-win32-arm64-msvc': 1.15.32
+      '@swc/core-win32-ia32-msvc': 1.15.32
+      '@swc/core-win32-x64-msvc': 1.15.32
+      '@swc/helpers': 0.5.23
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
@@ -10891,6 +11128,10 @@ snapshots:
       tslib: 2.8.1
 
   '@swc/helpers@0.5.21':
+    dependencies:
+      tslib: 2.8.1
+
+  '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
 
@@ -10990,7 +11231,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@tanstack/react-start-rsc@0.0.44(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))':
+  '@tanstack/react-start-rsc@0.0.44(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))':
     dependencies:
       '@tanstack/react-router': 1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-start-server': 1.166.52(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -10998,13 +11239,14 @@ snapshots:
       '@tanstack/router-utils': 1.161.8
       '@tanstack/start-client-core': 1.168.2
       '@tanstack/start-fn-stubs': 1.161.6
-      '@tanstack/start-plugin-core': 1.169.20(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))
+      '@tanstack/start-plugin-core': 1.169.20(@rsbuild/core@2.0.15)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))
       '@tanstack/start-server-core': 1.167.30
       '@tanstack/start-storage-context': 1.166.35
       pathe: 2.0.3
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
+      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
       '@vitejs/plugin-rsc': 0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))
     transitivePeerDependencies:
       - '@rsbuild/core'
@@ -11026,20 +11268,21 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.167.65(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))':
+  '@tanstack/react-start@1.167.65(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))':
     dependencies:
       '@tanstack/react-router': 1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-start-client': 1.166.48(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-rsc': 0.0.44(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))
+      '@tanstack/react-start-rsc': 0.0.44(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))
       '@tanstack/react-start-server': 1.166.52(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/router-utils': 1.161.8
       '@tanstack/start-client-core': 1.168.2
-      '@tanstack/start-plugin-core': 1.169.20(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))
+      '@tanstack/start-plugin-core': 1.169.20(@rsbuild/core@2.0.15)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))
       '@tanstack/start-server-core': 1.167.30
       pathe: 2.0.3
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
+      '@rsbuild/core': 2.0.15
       '@vitejs/plugin-rsc': 0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)
     transitivePeerDependencies:
@@ -11077,7 +11320,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.167.35(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))':
+  '@tanstack/router-plugin@1.167.35(@rsbuild/core@2.0.15)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
@@ -11093,6 +11336,7 @@ snapshots:
       unplugin: 3.0.0
       zod: 3.25.76
     optionalDependencies:
+      '@rsbuild/core': 2.0.15
       '@tanstack/react-router': 1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)
       webpack: 5.105.0(esbuild@0.28.0)
@@ -11122,7 +11366,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.161.6': {}
 
-  '@tanstack/start-plugin-core@1.169.20(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))':
+  '@tanstack/start-plugin-core@1.169.20(@rsbuild/core@2.0.15)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.0
@@ -11130,7 +11374,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.40
       '@tanstack/router-core': 1.169.2
       '@tanstack/router-generator': 1.166.42
-      '@tanstack/router-plugin': 1.167.35(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))
+      '@tanstack/router-plugin': 1.167.35(@rsbuild/core@2.0.15)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))
       '@tanstack/router-utils': 1.161.8
       '@tanstack/start-client-core': 1.168.2
       '@tanstack/start-server-core': 1.167.30
@@ -11148,6 +11392,7 @@ snapshots:
       xmlbuilder2: 4.0.3
       zod: 3.25.76
     optionalDependencies:
+      '@rsbuild/core': 2.0.15
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@tanstack/react-router'
@@ -11343,6 +11588,17 @@ snapshots:
       '@types/node': 25.6.0
       tapable: 2.3.0
       webpack: 5.104.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(esbuild@0.28.0)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+      - webpack-cli
+
+  '@types/webpack@5.28.5(@swc/core@1.15.32(@swc/helpers@0.5.23))(esbuild@0.28.0)':
+    dependencies:
+      '@types/node': 25.6.0
+      tapable: 2.3.0
+      webpack: 5.104.1(@swc/core@1.15.32(@swc/helpers@0.5.23))(esbuild@0.28.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -11596,10 +11852,10 @@ snapshots:
       next: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
-  '@vitejs/plugin-react-swc@4.3.0(@swc/helpers@0.5.21)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))':
+  '@vitejs/plugin-react-swc@4.3.0(@swc/helpers@0.5.23)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      '@swc/core': 1.15.21(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.21(@swc/helpers@0.5.23)
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@swc/helpers'
@@ -12310,7 +12566,7 @@ snapshots:
   css-color-keywords@1.0.0:
     optional: true
 
-  css-loader@7.1.2(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)):
+  css-loader@7.1.2(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.12)
       postcss: 8.5.12
@@ -12321,7 +12577,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.4
     optionalDependencies:
-      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)
+      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)
 
   css-select@4.3.0:
     dependencies:
@@ -13271,7 +13527,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@6.0.3)(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@6.0.3)(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)):
     dependencies:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
@@ -13286,7 +13542,7 @@ snapshots:
       semver: 7.7.4
       tapable: 2.3.0
       typescript: 6.0.3
-      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)
+      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)
 
   fraction.js@5.3.4: {}
 
@@ -13735,7 +13991,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.5(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)):
+  html-webpack-plugin@5.6.5(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -13743,7 +13999,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.0
     optionalDependencies:
-      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)
+      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)
 
   htmlparser2@10.1.0:
     dependencies:
@@ -15632,6 +15888,8 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-refresh@0.18.0: {}
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -16313,9 +16571,9 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  style-loader@4.0.0(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)):
+  style-loader@4.0.0(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)):
     dependencies:
-      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)
+      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)
 
   style-to-js@1.1.18:
     dependencies:
@@ -16354,11 +16612,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swc-loader@0.2.7(@swc/core@1.15.21(@swc/helpers@0.5.21))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)):
+  swc-loader@0.2.7(@swc/core@1.15.21(@swc/helpers@0.5.23))(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)):
     dependencies:
-      '@swc/core': 1.15.21(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.21(@swc/helpers@0.5.23)
       '@swc/counter': 0.1.3
-      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)
+      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)
 
   symbol-tree@3.2.4: {}
 
@@ -16392,16 +16650,16 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.16(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)):
+  terser-webpack-plugin@5.3.16(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.44.1
-      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)
+      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)
     optionalDependencies:
-      '@swc/core': 1.15.21(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.21(@swc/helpers@0.5.23)
       esbuild: 0.28.0
 
   terser-webpack-plugin@5.3.16(@swc/core@1.15.32(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack@5.104.1(@swc/core@1.15.32(@swc/helpers@0.5.21))(esbuild@0.28.0)):
@@ -16426,6 +16684,18 @@ snapshots:
       webpack: 5.105.0(@swc/core@1.15.32(@swc/helpers@0.5.21))(esbuild@0.28.0)
     optionalDependencies:
       '@swc/core': 1.15.32(@swc/helpers@0.5.21)
+      esbuild: 0.28.0
+
+  terser-webpack-plugin@5.3.16(@swc/core@1.15.32(@swc/helpers@0.5.23))(esbuild@0.28.0)(webpack@5.104.1(@swc/core@1.15.32(@swc/helpers@0.5.23))(esbuild@0.28.0)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.44.1
+      webpack: 5.104.1(@swc/core@1.15.32(@swc/helpers@0.5.23))(esbuild@0.28.0)
+    optionalDependencies:
+      '@swc/core': 1.15.32(@swc/helpers@0.5.23)
       esbuild: 0.28.0
 
   terser-webpack-plugin@5.3.16(esbuild@0.28.0)(webpack@5.105.0(esbuild@0.28.0)):
@@ -16886,7 +17156,7 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
-  webpack-dev-middleware@6.1.3(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)):
+  webpack-dev-middleware@6.1.3(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -16894,7 +17164,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)
+      webpack: 5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -16938,7 +17208,39 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0):
+  webpack@5.104.1(@swc/core@1.15.32(@swc/helpers@0.5.23))(esbuild@0.28.0):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.15.0
+      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.18.3
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(@swc/core@1.15.32(@swc/helpers@0.5.23))(esbuild@0.28.0)(webpack@5.104.1(@swc/core@1.15.32(@swc/helpers@0.5.23))(esbuild@0.28.0))
+      watchpack: 2.4.4
+      webpack-sources: 3.3.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -16962,7 +17264,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.21))(esbuild@0.28.0))
+      terser-webpack-plugin: 5.3.16(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0)(webpack@5.105.0(@swc/core@1.15.21(@swc/helpers@0.5.23))(esbuild@0.28.0))
       watchpack: 2.5.1
       webpack-sources: 3.3.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,16 +336,16 @@ importers:
         version: 0.8.2
       fumadocs-core:
         specifier: catalog:dev
-        version: 16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
+        version: 16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
       fumadocs-mdx:
         specifier: catalog:dev
-        version: 14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))
+        version: 14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))
       fumadocs-twoslash:
         specifier: catalog:dev
-        version: 3.2.0(0c4684809e9c1eac73254d6d0be3fe4a)
+        version: 3.2.0(db0d3c65a8340ca0b1baf9939705b563)
       fumadocs-ui:
         specifier: catalog:dev
-        version: 16.8.5(@emotion/is-prop-valid@1.4.0)(@tailwindcss/oxide@4.2.4)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)
+        version: 16.8.5(@emotion/is-prop-valid@1.4.0)(@tailwindcss/oxide@4.2.4)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)
       js-base64:
         specifier: catalog:dev
         version: 3.7.8
@@ -580,6 +580,40 @@ importers:
       '@types/react-dom':
         specifier: catalog:dev
         version: 19.2.3(@types/react@19.2.14)
+
+  e2e/bundlers/tanstack-start-rsbuild:
+    dependencies:
+      '@tanstack/react-router':
+        specifier: ^1.170.16
+        version: 1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-start':
+        specifier: ^1.168.26
+        version: 1.168.26(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))
+      next-yak:
+        specifier: workspace:*
+        version: link:../../../packages/next-yak
+      react:
+        specifier: catalog:dev
+        version: 19.2.5
+      react-dom:
+        specifier: catalog:dev
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@rsbuild/core':
+        specifier: catalog:dev
+        version: 2.0.15
+      '@rsbuild/plugin-react':
+        specifier: catalog:dev
+        version: 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+      '@types/react':
+        specifier: catalog:dev
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: catalog:dev
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: catalog:dev
+        version: 6.0.3
 
   e2e/bundlers/vite:
     dependencies:
@@ -3758,6 +3792,10 @@ packages:
     resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
     engines: {node: '>=20.19'}
 
+  '@tanstack/history@1.162.0':
+    resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
+    engines: {node: '>=20.19'}
+
   '@tanstack/react-router@1.169.2':
     resolution: {integrity: sha512-OJM7Kguc7ERnweaNRWsyWgIKcl3z23rD1B4jaxjzd9RGdnzpt2HfrWa9rggbT0Hfzhfo4D2ZmsfoTme035tniQ==}
     engines: {node: '>=20.19'}
@@ -3765,8 +3803,22 @@ packages:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
+  '@tanstack/react-router@1.170.16':
+    resolution: {integrity: sha512-w6eq1IJklujs1tESazaK/FxH0+H2l8vm/QPuu1cD3oRW/ubgKneQpd7b64ti/8gUyEimzimJQZDmJr6YHfP5+g==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
   '@tanstack/react-start-client@1.166.48':
     resolution: {integrity: sha512-6fqwCwe6v+Nvtdf6vg6gxs/0gCXyZEHF18EslNeG/kca2wnXYFuXRhqGJjJaEgMk3WF4IE9mUgFuBSAOY3P7nQ==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-start-client@1.168.14':
+    resolution: {integrity: sha512-oaz43fdOhBWfOPsdLkp3IejwYEXRyeaZ4CYexOPZx3eVXzm4LLozvNkkkBE9aje1sM5MVC2Yo6+cyv2HdVzkHQ==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
@@ -3789,6 +3841,23 @@ packages:
       react-server-dom-rspack:
         optional: true
 
+  '@tanstack/react-start-rsc@0.1.25':
+    resolution: {integrity: sha512-Rwm6cjcS148y2XAebr8jyrwU0SqsRSkW4/CuXesoHg+G3IOnVRHV0HOylJfnznUTVuH1nVhfQRPI5uWPJaw2TA==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@rspack/core': '>=2.0.0-0'
+      '@vitejs/plugin-rsc': '>=0.5.20'
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+      react-server-dom-rspack: '>=0.0.2'
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      '@vitejs/plugin-rsc':
+        optional: true
+      react-server-dom-rspack:
+        optional: true
+
   '@tanstack/react-start-server@1.166.52':
     resolution: {integrity: sha512-46Gx+byIndYywUtyna5h3qatHipJkPFqo/miexfuYPgeVAI6ypQzsw7wxF194H6VAP43m2q+fdLPBXStufoOGw==}
     engines: {node: '>=22.12.0'}
@@ -3796,8 +3865,32 @@ packages:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
+  '@tanstack/react-start-server@1.167.20':
+    resolution: {integrity: sha512-hg9xVI6yNDu+6NCalKz1h3Ea18HZEUu35i/ZMJz1WadwqcArLMp41nM1GNhOAtGIdpycrp9tT7ccqc9zuRMRpQ==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
   '@tanstack/react-start@1.167.65':
     resolution: {integrity: sha512-vCGga3RECeR4VpSVuXIU/+zxak5f2qdpUXdZ2yrgcwwKoYPtatdJm6zjS0Py7UOecRqLqMtSeuOjowBJ1higWQ==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@rsbuild/core': ^2.0.0
+      '@vitejs/plugin-rsc': '*'
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+      vite: '>=7.0.0'
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+      '@vitejs/plugin-rsc':
+        optional: true
+      vite:
+        optional: true
+
+  '@tanstack/react-start@1.168.26':
+    resolution: {integrity: sha512-ZzNecqKWC0p2643/kIcFUdsMrXZ8A4dXm4Yfe9zV/Y0u14MtSkh/Sk76RQYIU5S84VyDyKhHo0Ffh8HQbLdvFw==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rsbuild/core': ^2.0.0
@@ -3823,8 +3916,16 @@ packages:
     resolution: {integrity: sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw==}
     engines: {node: '>=20.19'}
 
+  '@tanstack/router-core@1.171.13':
+    resolution: {integrity: sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA==}
+    engines: {node: '>=20.19'}
+
   '@tanstack/router-generator@1.166.42':
     resolution: {integrity: sha512-2qBWC0t78r6b3vI+AbnvCZcFAvbYBDlLuWZrTjQbcjUmwG3qyeQp983tJyDuj9wb5//adG1tgAGXZkJ3aDwdBg==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/router-generator@1.167.17':
+    resolution: {integrity: sha512-xtB9tB2Ws0tWR6Pi7nc3Qk9IYgoh1mQCKWjHqIl9tf6BNUpKoqniJoPAQ4+LGrK8FeZYU0o0p/qlZEyj9FAulA==}
     engines: {node: '>=20.19'}
 
   '@tanstack/router-plugin@1.167.35':
@@ -3848,16 +3949,49 @@ packages:
       webpack:
         optional: true
 
+  '@tanstack/router-plugin@1.168.18':
+    resolution: {integrity: sha512-MofS28/axfnfnhOD2RSgJEaU882aX5RsAzhGz5Vc4XhAmvCjy919u9JrNs4QsTWFbTD1P7IJ8WFlFVsrg0pStg==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      '@rsbuild/core': '>=1.0.2 || ^2.0.0'
+      '@tanstack/react-router': ^1.170.15
+      vite: '>=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0'
+      vite-plugin-solid: ^2.11.10 || ^3.0.0-0
+      webpack: '>=5.92.0'
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      vite:
+        optional: true
+      vite-plugin-solid:
+        optional: true
+      webpack:
+        optional: true
+
   '@tanstack/router-utils@1.161.8':
     resolution: {integrity: sha512-xyiLWEKjfBAVhauDSSjXxyf7s8elU6SM+V050sbkofvGmIIvkwPFtDsX7Gvwh14kBd6iCwAT+RiPvXTxAptY0Q==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/router-utils@1.162.2':
+    resolution: {integrity: sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ==}
     engines: {node: '>=20.19'}
 
   '@tanstack/start-client-core@1.168.2':
     resolution: {integrity: sha512-/bckv9k/yxY4VmSY2V2MeX7NBsS5uqGvdSPs5WIvW3Uv35DXPrdiumKXTNJeZRNRMtxrM+YfxQPjXLx3C7ykvg==}
     engines: {node: '>=22.12.0'}
 
+  '@tanstack/start-client-core@1.170.12':
+    resolution: {integrity: sha512-gwtZRMPUIAxmDV2AIQUhC0kSW262SV7BkHXEgy5B1woHQdrdsELuGOdJwdweLxrjyefORxk+9MYGqDY0Cxn0bw==}
+    engines: {node: '>=22.12.0'}
+
   '@tanstack/start-fn-stubs@1.161.6':
     resolution: {integrity: sha512-Y6QSlGiLga8cHfvxGGaonXIlt2bIUTVdH6AMjmpMp7+ANNCp+N96GQbjjhLye3JkaxDfP68x5iZA8NK4imgRig==}
+    engines: {node: '>=22.12.0'}
+
+  '@tanstack/start-fn-stubs@1.162.0':
+    resolution: {integrity: sha512-QWfUZ3Yo923tdQn38LyKMU8rcTw69zc+T4dAvgTWV4O56SqFRsGfS0lSWIMhJRwXIx/bvdi7nTUBDdZtTHtpTQ==}
     engines: {node: '>=22.12.0'}
 
   '@tanstack/start-plugin-core@1.169.20':
@@ -3872,12 +4006,32 @@ packages:
       vite:
         optional: true
 
+  '@tanstack/start-plugin-core@1.171.18':
+    resolution: {integrity: sha512-weuOOjRD03BiKcF9NYKL5QADEQOp3yGHb0qIsOX42ENz5XUE4in2fXcVYHjSwwpzs+XGhWIFLp5J385pOVPuZQ==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@rsbuild/core': ^2.0.0
+      vite: '>=7.0.0'
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+      vite:
+        optional: true
+
   '@tanstack/start-server-core@1.167.30':
     resolution: {integrity: sha512-GC0PXzYYSEwfAOC2NxGXFUyYvfbSjVoqnIrzJsyInKd8xQxGEQaVdrebbyx9TV5cj7A5e7EJcWAsf3G3wRDQBw==}
     engines: {node: '>=22.12.0'}
 
+  '@tanstack/start-server-core@1.169.15':
+    resolution: {integrity: sha512-V8ie2G2Ecb3Nklk8/QuKzulxb+tDUqgz6rjJe8Isdp4iKVXZu/TscItkUP/4Q5Bu7W4gUy3P25O6soC1oW1SXQ==}
+    engines: {node: '>=22.12.0'}
+
   '@tanstack/start-storage-context@1.166.35':
     resolution: {integrity: sha512-ZKDkKiorJrKwfEHjatEwRHG7EP3raJPhh6CSl4CFmHW0naIvwaW5gQcxcT8IlHtoGDLYDAjBEcSr3MZyXgqmOA==}
+    engines: {node: '>=22.12.0'}
+
+  '@tanstack/start-storage-context@1.167.15':
+    resolution: {integrity: sha512-Jy0q4vdG6pv76N92+X+ag3fuOV2zINQagYyMN1/es7tPI1vzpKECIU8AqHqzI6ahkwaph7XDvmfUkiLJ3i4LOA==}
     engines: {node: '>=22.12.0'}
 
   '@tanstack/store@0.9.3':
@@ -3887,6 +4041,10 @@ packages:
     resolution: {integrity: sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ==}
     engines: {node: '>=20.19'}
     hasBin: true
+
+  '@tanstack/virtual-file-routes@1.162.0':
+    resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
+    engines: {node: '>=20.19'}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -8621,6 +8779,9 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -8723,7 +8884,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -11214,6 +11375,8 @@ snapshots:
 
   '@tanstack/history@1.161.6': {}
 
+  '@tanstack/history@1.162.0': {}
+
   '@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/history': 1.161.6
@@ -11223,11 +11386,28 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
+  '@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-core': 1.171.13
+      isbot: 5.1.40
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
   '@tanstack/react-start-client@1.166.48(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/react-router': 1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/router-core': 1.169.2
       '@tanstack/start-client-core': 1.168.2
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@tanstack/react-start-client@1.168.14(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/react-router': 1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/start-client-core': 1.170.12
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
@@ -11256,6 +11436,30 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
+  '@tanstack/react-start-rsc@0.1.25(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))':
+    dependencies:
+      '@tanstack/react-router': 1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/start-client-core': 1.170.12
+      '@tanstack/start-fn-stubs': 1.162.0
+      '@tanstack/start-plugin-core': 1.171.18(@rsbuild/core@2.0.15)(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))
+      '@tanstack/start-server-core': 1.169.15
+      '@tanstack/start-storage-context': 1.167.15
+      pathe: 2.0.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
+      '@vitejs/plugin-rsc': 0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))
+    transitivePeerDependencies:
+      - '@rsbuild/core'
+      - crossws
+      - supports-color
+      - vite
+      - vite-plugin-solid
+      - webpack
+
   '@tanstack/react-start-server@1.166.52(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/history': 1.161.6
@@ -11263,6 +11467,16 @@ snapshots:
       '@tanstack/router-core': 1.169.2
       '@tanstack/start-client-core': 1.168.2
       '@tanstack/start-server-core': 1.167.30
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - crossws
+
+  '@tanstack/react-start-server@1.167.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/react-router': 1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/start-server-core': 1.169.15
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
@@ -11293,6 +11507,31 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
+  '@tanstack/react-start@1.168.26(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))':
+    dependencies:
+      '@tanstack/react-router': 1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-start-client': 1.168.14(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-start-rsc': 0.1.25(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))
+      '@tanstack/react-start-server': 1.167.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/start-client-core': 1.170.12
+      '@tanstack/start-plugin-core': 1.171.18(@rsbuild/core@2.0.15)(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))
+      '@tanstack/start-server-core': 1.169.15
+      pathe: 2.0.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@rsbuild/core': 2.0.15
+      '@vitejs/plugin-rsc': 0.5.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - crossws
+      - react-server-dom-rspack
+      - supports-color
+      - vite-plugin-solid
+      - webpack
+
   '@tanstack/react-store@0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/store': 0.9.3
@@ -11307,6 +11546,13 @@ snapshots:
       seroval: 1.5.4
       seroval-plugins: 1.5.4(seroval@1.5.4)
 
+  '@tanstack/router-core@1.171.13':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      cookie-es: 3.1.1
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
   '@tanstack/router-generator@1.166.42':
     dependencies:
       '@babel/types': 7.29.0
@@ -11317,6 +11563,19 @@ snapshots:
       magic-string: 0.30.21
       prettier: 3.8.3
       zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tanstack/router-generator@1.167.17':
+    dependencies:
+      '@babel/types': 7.29.0
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/virtual-file-routes': 1.162.0
+      jiti: 2.7.0
+      magic-string: 0.30.21
+      prettier: 3.8.3
+      zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11343,9 +11602,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@tanstack/router-plugin@1.168.18(@rsbuild/core@2.0.15)(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-generator': 1.167.17
+      '@tanstack/router-utils': 1.162.2
+      chokidar: 5.0.0
+      unplugin: 3.0.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@rsbuild/core': 2.0.15
+      '@tanstack/react-router': 1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)
+      webpack: 5.105.0(esbuild@0.28.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@tanstack/router-utils@1.161.8':
     dependencies:
       '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      ansis: 4.2.0
+      babel-dead-code-elimination: 1.0.12
+      diff: 8.0.4
+      pathe: 2.0.3
+      tinyglobby: 0.2.16
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tanstack/router-utils@1.162.2':
+    dependencies:
       '@babel/generator': 7.29.1
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
@@ -11364,7 +11655,16 @@ snapshots:
       '@tanstack/start-storage-context': 1.166.35
       seroval: 1.5.4
 
+  '@tanstack/start-client-core@1.170.12':
+    dependencies:
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/start-fn-stubs': 1.162.0
+      '@tanstack/start-storage-context': 1.167.15
+      seroval: 1.5.4
+
   '@tanstack/start-fn-stubs@1.161.6': {}
+
+  '@tanstack/start-fn-stubs@1.162.0': {}
 
   '@tanstack/start-plugin-core@1.169.20(@rsbuild/core@2.0.15)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))':
     dependencies:
@@ -11401,6 +11701,38 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
+  '@tanstack/start-plugin-core@1.171.18(@rsbuild/core@2.0.15)(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/core': 7.29.0
+      '@babel/types': 7.29.0
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-generator': 1.167.17
+      '@tanstack/router-plugin': 1.168.18(@rsbuild/core@2.0.15)(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))(webpack@5.105.0(esbuild@0.28.0))
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/start-server-core': 1.169.15
+      exsolve: 1.0.8
+      lightningcss: 1.32.0
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      seroval: 1.5.4
+      source-map: 0.7.6
+      srvx: 0.11.15
+      tinyglobby: 0.2.16
+      ufo: 1.6.4
+      vitefu: 1.1.3(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1))
+      xmlbuilder2: 4.0.3
+      zod: 4.4.3
+    optionalDependencies:
+      '@rsbuild/core': 2.0.15
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - '@tanstack/react-router'
+      - crossws
+      - supports-color
+      - vite-plugin-solid
+      - webpack
+
   '@tanstack/start-server-core@1.167.30':
     dependencies:
       '@tanstack/history': 1.161.6
@@ -11413,13 +11745,31 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
+  '@tanstack/start-server-core@1.169.15':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/start-client-core': 1.170.12
+      '@tanstack/start-storage-context': 1.167.15
+      fetchdts: 0.1.7
+      h3-v2: h3@2.0.1-rc.20
+      seroval: 1.5.4
+    transitivePeerDependencies:
+      - crossws
+
   '@tanstack/start-storage-context@1.166.35':
     dependencies:
       '@tanstack/router-core': 1.169.2
 
+  '@tanstack/start-storage-context@1.167.15':
+    dependencies:
+      '@tanstack/router-core': 1.171.13
+
   '@tanstack/store@0.9.3': {}
 
   '@tanstack/virtual-file-routes@1.161.7': {}
+
+  '@tanstack/virtual-file-routes@1.162.0': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -13584,7 +13934,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6):
+  fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
@@ -13605,7 +13955,7 @@ snapshots:
       vfile: 6.0.3
     optionalDependencies:
       '@mdx-js/mdx': 3.1.1
-      '@tanstack/react-router': 1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-router': 1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -13614,18 +13964,18 @@ snapshots:
       next: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)):
+  fumadocs-mdx@14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.7.1)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.0
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
+      fumadocs-core: 16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
@@ -13648,12 +13998,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-twoslash@3.2.0(0c4684809e9c1eac73254d6d0be3fe4a):
+  fumadocs-twoslash@3.2.0(db0d3c65a8340ca0b1baf9939705b563):
     dependencies:
       '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@shikijs/twoslash': 4.0.2(typescript@6.0.3)
-      fumadocs-core: 16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
-      fumadocs-ui: 16.8.5(@emotion/is-prop-valid@1.4.0)(@tailwindcss/oxide@4.2.4)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)
+      fumadocs-core: 16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
+      fumadocs-ui: 16.8.5(@emotion/is-prop-valid@1.4.0)(@tailwindcss/oxide@4.2.4)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)
       mdast-util-from-markdown: 2.0.3
       mdast-util-gfm: 3.1.0
       mdast-util-to-hast: 13.2.1
@@ -13669,7 +14019,7 @@ snapshots:
       - supports-color
       - typescript
 
-  fumadocs-ui@16.8.5(@emotion/is-prop-valid@1.4.0)(@tailwindcss/oxide@4.2.4)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4):
+  fumadocs-ui@16.8.5(@emotion/is-prop-valid@1.4.0)(@tailwindcss/oxide@4.2.4)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4):
     dependencies:
       '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.2.4)(tailwindcss@4.2.4)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -13683,7 +14033,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
+      fumadocs-core: 16.8.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.16(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.5))(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
       lucide-react: 1.14.0(react@19.2.5)
       motion: 12.38.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-themes: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -17476,5 +17826,7 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,8 @@ catalogs:
     "@swc/counter": 0.1.3
   dev:
     "@babel/preset-typescript": 7.28.5
+    "@rsbuild/core": 2.0.15
+    "@rsbuild/plugin-react": 2.1.0
     "@changesets/cli": 2.31.0
     "@eslint/eslintrc": 3.3.5
     "@monaco-editor/react": 4.7.0


### PR DESCRIPTION
Adds a next-yak/rsbuild plugin for rsbuild 2 / rspack 2. Runs yak-swc as a pre loader and inlines CSS as a data URL, same as the turbopack integration. Drops into the plugins array next to pluginReact, so rsbuild-based setups like TanStack Router's "with rspack" guide work too.

Includes an rsbuild example + e2e coverage. Quirk: rsbuild does a full page reload on yak.ts syntax-error recovery instead of a hot update, so that one assertion is skipped for rsbuild.


```
Total
┌────────────────────────┬───────────┬────────┐
│ Bundler                │ Duration  │ Passed │
├────────────────────────┼───────────┼────────┤
│ next-app-turbopack     │ 7m 53.3s  │ 27/27  │
│ next-app-webpack       │ 13m 20.9s │ 27/27  │
│ next-pages-turbopack   │ 6m 24.5s  │ 27/27  │
│ next-pages-webpack     │ 7m 20.7s  │ 27/27  │
│ rsbuild                │ 4m 5.1s   │ 27/27  │
│ tanstack-start-rsbuild │ 4m 39.0s  │ 27/27  │
│ vite                   │ 4m 14.5s  │ 27/27  │
└────────────────────────┴───────────┴────────┘
```

fixes #507 