### PR TITLE
Tighten import detection for compilation targets

### DIFF
--- a/.changeset/spotty-cougars-hug.md
+++ b/.changeset/spotty-cougars-hug.md
@@ -1,0 +1,5 @@
+---
+"next-yak": minor
+---
+
+Tighten detection when CSS compilation should run

--- a/packages/next-yak/loaders/lib/moduleImportsNextYak.ts
+++ b/packages/next-yak/loaders/lib/moduleImportsNextYak.ts
@@ -1,0 +1,4 @@
+// Match a real `next-yak` import, not a loose substring (e.g. code samples in compiled MDX).
+export const nextYakImportRegex = /(?:\bfrom\s*|\brequire\(\s*)["']next-yak[/"']/;
+
+export const moduleImportsNextYak = (code: string): boolean => nextYakImportRegex.test(code);

--- a/packages/next-yak/loaders/turbo-loader.ts
+++ b/packages/next-yak/loaders/turbo-loader.ts
@@ -7,6 +7,7 @@ import { resolveCrossFileConstant } from "../cross-file-resolver/resolveCrossFil
 import type { YakConfigOptions } from "../withYak/index.js";
 import { createDebugLogger } from "./lib/debugLogger.js";
 import { extractCss } from "./lib/extractCss.js";
+import { moduleImportsNextYak } from "./lib/moduleImportsNextYak.js";
 import { parseExports } from "./lib/resolveCrossFileSelectors.js";
 
 const universalRequire = typeof require === "undefined" ? createRequire(import.meta.url) : require;
@@ -25,8 +26,8 @@ export default async function cssExtractLoader(
 ): Promise<string | void> {
   const callback = this.async();
 
-  // process only files which include next-yak for maximal compile performance
-  if (!code.includes("next-yak")) {
+  // Skip modules that don't genuinely import next-yak, for compile performance.
+  if (!moduleImportsNextYak(code)) {
     return callback(null, code, sourceMap);
   }
 

--- a/packages/next-yak/loaders/vite-plugin.ts
+++ b/packages/next-yak/loaders/vite-plugin.ts
@@ -9,6 +9,7 @@ import { createEvaluator, type Evaluator } from "../isolated-source-eval/index.j
 import { resolveYakContext, YakConfigOptions } from "../withYak/index.js";
 import { createDebugLogger } from "./lib/debugLogger.js";
 import { extractCss } from "./lib/extractCss.js";
+import { nextYakImportRegex } from "./lib/moduleImportsNextYak.js";
 import { parseExports } from "./lib/resolveCrossFileSelectors.js";
 const require = createRequire(import.meta.url);
 
@@ -199,7 +200,7 @@ export async function viteYak(userOptions: ViteYakPluginOptions = {}): Promise<P
           include: sourceFileRegex,
           exclude: [/packages\/next-yak/],
         },
-        code: "next-yak",
+        code: nextYakImportRegex,
       },
       async handler(code, id) {
         try {


### PR DESCRIPTION
Gate the Turbopack loader and Vite plugin on a *real* `import "next-yak"` or `require "next-yak"` import instead of a loose `next-yak` substring match.

This was discovered while working with `fumadocs-mdx` on turbopack where  we compiled the output of it's compiler again and it resulted in broken code.
