### PR TITLE
Add strictCssProp option and stop stripping invalid css props

### DIFF
--- a/.changeset/tidy-eagles-cross.md
+++ b/.changeset/tidy-eagles-cross.md
@@ -1,0 +1,6 @@
+---
+"yak-swc": patch
+"next-yak": patch
+---
+
+Add a `strictCssProp` option (default `true`) that fails the build on a `css` prop next-yak can't handle. Turn it off to leave unrecognized `css` props untouched, e.g. when another library on the same element uses its own `css` prop. Invalid `css` props are now left in place rather than silently stripped.

--- a/docs/playground-wasm/src/lib.rs
+++ b/docs/playground-wasm/src/lib.rs
@@ -108,6 +108,7 @@ fn yak_pass(
                 .into(),
             false, // suppress_deprecation_warnings
             false, // react_refresh_reg
+            false, // strict_css_prop
         );
         program.visit_mut_with(&mut transformer);
     })

--- a/packages/next-yak/loaders/vite-plugin.ts
+++ b/packages/next-yak/loaders/vite-plugin.ts
@@ -61,6 +61,7 @@ export async function viteYak(userOptions: ViteYakPluginOptions = {}): Promise<P
     },
     minify: userOptions.minify ?? process.env.NODE_ENV === "production",
     prefix: userOptions.prefix,
+    strictCssProp: userOptions.strictCssProp,
     contextPath: userOptions.contextPath,
     swcOptions: deepMerge(defaultSwcOptions!, userOptions.swcOptions ?? {}),
   };
@@ -298,6 +299,7 @@ function transform(
               basePath: rootPath,
               prefix: yakOptions.prefix,
               displayNames: yakOptions.displayNames,
+              strictCssProp: yakOptions.strictCssProp ?? true,
               suppressDeprecationWarnings: yakOptions.experiments?.suppressDeprecationWarnings,
               ...(reactRefreshReg ? { reactRefreshReg: true } : {}),
               importMode: {

--- a/packages/next-yak/withYak/index.ts
+++ b/packages/next-yak/withYak/index.ts
@@ -28,6 +28,16 @@ export type YakConfigOptions = {
    * - Increases bundle size slightly when enabled
    */
   displayNames?: boolean;
+  /**
+   * Fail the build when a `css` prop has a value next-yak can't handle
+   * (e.g. a plain string). next-yak claims the `css` prop, so a malformed
+   * value is almost always a mistake worth surfacing.
+   *
+   * Set to `false` to leave such props untouched instead, e.g. when another
+   * library on the same element uses its own `css` prop.
+   * @defaultValue true
+   */
+  strictCssProp?: boolean;
   experiments?: {
     /**
      * Debug logging for transformed files.
@@ -62,6 +72,7 @@ export function buildYakPluginOptions(yakOptions: YakConfigOptions, basePath: st
     basePath,
     prefix: yakOptions.prefix,
     displayNames: yakOptions.displayNames ?? !minify,
+    strictCssProp: yakOptions.strictCssProp ?? true,
     suppressDeprecationWarnings: yakOptions.experiments?.suppressDeprecationWarnings ?? false,
     reactRefreshReg: true,
   };
@@ -109,6 +120,7 @@ function addYakTurbopack(
     basePath: string;
     prefix?: string;
     displayNames: boolean;
+    strictCssProp: boolean;
     importMode: {
       value: string;
       transpilation: string;
@@ -164,6 +176,7 @@ function addYakWebpack(
     basePath: string;
     prefix?: string;
     displayNames: boolean;
+    strictCssProp: boolean;
     importMode: {
       value: string;
       transpilation: string;

--- a/packages/yak-swc/scripts/test-wasm-fixtures.mts
+++ b/packages/yak-swc/scripts/test-wasm-fixtures.mts
@@ -141,20 +141,25 @@ for (const fixtureName of fixtures) {
     const stderrPath = join(fixtureDir, stderr);
     const label = `${fixtureName}/${modeName}`;
 
-    // Diagnostic fixtures: the plugin emits a recoverable error. Natively that
-    // is collected while the transform still produces a "recovered" output.
-    // Through @swc/core the host surfaces the diagnostic differently (it either
-    // throws or leaves the offending code untransformed), so the recovered
-    // output is not reproducible here. The diagnostic itself is covered by
-    // `cargo test`; all we assert is that the plugin doesn't take the host down
-    // in some other way.
+    // Diagnostic fixtures: the plugin emits an error. Natively that is collected
+    // as a recoverable diagnostic while the transform still produces a "recovered"
+    // output, so the recovered output isn't reproducible here. Through @swc/core an
+    // emitted plugin error aborts the transform, so we assert the wasm plugin
+    // surfaces the diagnostic as a throw. This guards the wasm ABI: a regression
+    // that silently drops an error across the boundary (leaving the offending code
+    // untransformed instead of failing) can't be caught by `cargo test`, which only
+    // exercises the native path.
     if (existsSync(stderrPath)) {
+      stats.diagnostics++;
       try {
         runWasmTransform(input, options);
+        failures.push(
+          `${label}: native records a diagnostic (${stderr}) but the wasm transform ` +
+            `succeeded without throwing — the error was dropped across the wasm ABI`,
+        );
       } catch {
         // expected: the host surfaces the diagnostic as a throw
       }
-      stats.diagnostics++;
       continue;
     }
 

--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -78,10 +78,21 @@ pub struct Config {
   /// Enable this in development to prevent full-page reloads on CSS-only edits.
   #[serde(default)]
   pub react_refresh_reg: bool,
+  /// Fail the build when a `css` prop has a value next-yak can't handle
+  /// (e.g. a plain string). Enabled by default: next-yak claims the `css` prop,
+  /// so a malformed value is almost always a mistake worth surfacing. Set to
+  /// false to leave such props untouched instead, e.g. when another library on
+  /// the same element uses its own `css` prop.
+  #[serde(default = "Config::strict_css_prop_default")]
+  pub strict_css_prop: bool,
 }
 
 impl Config {
   fn minify_default() -> bool {
+    true
+  }
+
+  fn strict_css_prop_default() -> bool {
     true
   }
 
@@ -104,6 +115,7 @@ impl Default for Config {
       import_mode: Config::import_mode_default(),
       suppress_deprecation_warnings: Default::default(),
       react_refresh_reg: Default::default(),
+      strict_css_prop: Config::strict_css_prop_default(),
     }
   }
 }
@@ -166,6 +178,8 @@ where
   react_refresh_reg: bool,
   /// Names of exported styled components to register with $RefreshReg$
   exported_styled_names: Vec<String>,
+  /// Fail loudly on a `css` prop next-yak can't handle instead of leaving it untouched
+  strict_css_prop: bool,
 }
 
 impl<GenericComments> TransformVisitor<GenericComments>
@@ -181,6 +195,7 @@ where
     import_mode: CssImportConfig,
     suppress_deprecation_warnings: bool,
     react_refresh_reg: bool,
+    strict_css_prop: bool,
   ) -> Self {
     Self {
       current_css_state: None,
@@ -204,6 +219,7 @@ where
       inside_runtime_expression: false,
       react_refresh_reg,
       exported_styled_names: Vec::new(),
+      strict_css_prop,
     }
   }
 
@@ -968,14 +984,12 @@ where
       self.inside_element_with_css_attribute = true;
       n.visit_mut_children_with(self);
       self.inside_element_with_css_attribute = previous_inside_css_attribute;
-      css_prop.transform(
-        n,
-        &self
-          .yak_library_imports
-          .as_mut()
-          .unwrap()
-          .get_yak_utility_ident("mergeCssProp"),
-      );
+      let merge_ident = self
+        .yak_library_imports
+        .as_mut()
+        .unwrap()
+        .get_yak_utility_ident("mergeCssProp");
+      css_prop.transform(n, &merge_ident, self.strict_css_prop);
     }
   }
 
@@ -1345,6 +1359,7 @@ mod tests {
           },
           false,
           false,
+          true,
         ))
       },
       &input,
@@ -1378,6 +1393,7 @@ mod tests {
           },
           false,
           false,
+          true,
         ))
       },
       &input,
@@ -1411,6 +1427,7 @@ mod tests {
           },
           false,
           false,
+          true,
         ))
       },
       &input,
@@ -1444,6 +1461,7 @@ mod tests {
           },
           false,
           false,
+          true,
         ))
       },
       &input,

--- a/packages/yak-swc/yak_swc/src/plugin.rs
+++ b/packages/yak-swc/yak_swc/src/plugin.rs
@@ -36,5 +36,6 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
     config.import_mode,
     config.suppress_deprecation_warnings,
     config.react_refresh_reg,
+    config.strict_css_prop,
   )))
 }

--- a/packages/yak-swc/yak_swc/src/utils/css_prop.rs
+++ b/packages/yak-swc/yak_swc/src/utils/css_prop.rs
@@ -40,37 +40,60 @@ impl CSSProp {
   ///     className: "myClassName"
   ///   })} />
   /// ```
-  pub fn transform(&self, opening_element: &mut JSXOpeningElement, merge_ident: &Ident) {
-    let result: Result<_, TransformError> = (|| {
-      let value = opening_element.attrs.remove(self.index);
-
-      let removed_attrs: Vec<_> = self
+  pub fn transform(
+    &self,
+    opening_element: &mut JSXOpeningElement,
+    merge_ident: &Ident,
+    strict_css_prop: bool,
+  ) {
+    // Build the replacement from borrowed attributes first, without mutating the
+    // element. That way an invalid `css` prop can be left completely untouched
+    // when strict mode is off (it might belong to another library, not next-yak).
+    let merge_call: Result<Box<Expr>, TransformError> = (|| {
+      let css_expr =
+        Self::extract_css_expr(&opening_element.attrs[self.index], opening_element.span)?;
+      let mapped_props = self
         .relevant_props_indices
         .iter()
-        .rev()
-        .map(|&index| {
-          let adjusted_index = if index > self.index { index - 1 } else { index };
-          opening_element.attrs.remove(adjusted_index)
+        .map(|&index| match &opening_element.attrs[index] {
+          JSXAttrOrSpread::JSXAttr(attr) => Self::map_jsx_attr(attr),
+          JSXAttrOrSpread::SpreadElement(spread) => Ok(PropOrSpread::Spread(spread.clone())),
+          #[cfg(swc_ast_unknown)]
+          _ => Err(TransformError::UnsupportedJSXAttrOrSpread()),
         })
-        .collect();
-      let css_expr = Self::extract_css_expr(&value, opening_element.span)?;
-      let merge_call =
-        Self::create_merge_call(&Self::map_props(&removed_attrs)?, css_expr, merge_ident);
-      let insert_index = opening_element.attrs.len();
-
-      let spread_attr = JSXAttrOrSpread::SpreadElement(SpreadElement {
-        dot3_token: DUMMY_SP,
-        expr: merge_call,
-      });
-      opening_element.attrs.insert(insert_index, spread_attr);
-      Ok(())
+        .collect::<Result<Vec<_>, _>>()?;
+      Ok(Self::create_merge_call(&mapped_props, css_expr, merge_ident))
     })();
 
-    if let Err(err) = result {
-      HANDLER.with(|handler| {
-        handler.span_err(err.span(), err.message());
-      });
+    let merge_call = match merge_call {
+      Ok(merge_call) => merge_call,
+      Err(err) => {
+        // Strict mode (default): a `css` prop next-yak can't handle is almost
+        // always a mistake in a next-yak project, so fail loudly. Otherwise leave
+        // the element untouched so unrelated `css` props keep working.
+        if strict_css_prop {
+          HANDLER.with(|handler| {
+            handler.struct_span_err(err.span(), err.message()).emit();
+          });
+        }
+        return;
+      }
+    };
+
+    // Validation succeeded — remove the consumed attributes and insert the spread.
+    opening_element.attrs.remove(self.index);
+    for &index in self.relevant_props_indices.iter().rev() {
+      let adjusted_index = if index > self.index { index - 1 } else { index };
+      opening_element.attrs.remove(adjusted_index);
     }
+    let insert_index = opening_element.attrs.len();
+    opening_element.attrs.insert(
+      insert_index,
+      JSXAttrOrSpread::SpreadElement(SpreadElement {
+        dot3_token: DUMMY_SP,
+        expr: merge_call,
+      }),
+    );
   }
 
   /// Extracts the CSS expression from a JSX attribute or spread element.
@@ -91,23 +114,6 @@ impl CSSProp {
       #[cfg(swc_ast_unknown)]
       _ => Err(TransformError::UnsupportedSpreadElement(span)),
     }
-  }
-
-  /// Maps JSX attributes or spread elements to PropOrSpread elements.
-  /// This is used to convert JSX attributes to object properties for the merge call.
-  /// Because the order of the properties are already reversed, the attributes are iterated in reverse order.
-  /// This is done to maintain the order of the attributes when they are merged.
-  fn map_props(props: &[JSXAttrOrSpread]) -> Result<Vec<PropOrSpread>, TransformError> {
-    props
-      .iter()
-      .rev()
-      .map(|prop| match prop {
-        JSXAttrOrSpread::JSXAttr(attr) => Self::map_jsx_attr(attr),
-        JSXAttrOrSpread::SpreadElement(spread) => Ok(PropOrSpread::Spread(spread.clone())),
-        #[cfg(swc_ast_unknown)]
-        _ => Err(TransformError::UnsupportedJSXAttrOrSpread()),
-      })
-      .collect()
   }
 
   /// Maps a single JSX attribute to a PropOrSpread element.

--- a/packages/yak-swc/yak_swc/src/utils/css_prop.rs
+++ b/packages/yak-swc/yak_swc/src/utils/css_prop.rs
@@ -62,7 +62,11 @@ impl CSSProp {
           _ => Err(TransformError::UnsupportedJSXAttrOrSpread()),
         })
         .collect::<Result<Vec<_>, _>>()?;
-      Ok(Self::create_merge_call(&mapped_props, css_expr, merge_ident))
+      Ok(Self::create_merge_call(
+        &mapped_props,
+        css_expr,
+        merge_ident,
+      ))
     })();
 
     let merge_call = match merge_call {

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/input.tsx
@@ -1,4 +1,5 @@
 import { css } from "next-yak";
 
+const styles = css`color:red;`;
 const Elem = () => <div css="invalid" />;
 const Elem2 = (props: any) => <div css={props} />;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.dev.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.dev.stderr
@@ -1,7 +1,7 @@
   x Invalid CSS attribute. The 'css' prop should contain a valid CSS-in-JS expression. Example: css={css`color: red;`}
-   ,-[input.js:3:1]
- 2 | 
- 3 | const Elem = () => <div css="invalid" />;
+   ,-[input.js:4:1]
+ 3 | const styles = css`color:red;`;
+ 4 | const Elem = () => <div css="invalid" />;
    :                    ^^^^^^^^^^^^^^^^^^^^^
- 4 | const Elem2 = (props: any) => <div css={props} />;
+ 5 | const Elem2 = (props: any) => <div css={props} />;
    `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.dev.tsx
@@ -1,3 +1,4 @@
 import { css, __yak_mergeCssProp } from "next-yak/internal";
-const Elem = ()=><div/>;
+const styles = /*#__PURE__*/ css();
+const Elem = ()=><div css="invalid"/>;
 const Elem2 = (props: any)=><div {...__yak_mergeCssProp({}, props)}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.prod.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.prod.stderr
@@ -1,7 +1,7 @@
   x Invalid CSS attribute. The 'css' prop should contain a valid CSS-in-JS expression. Example: css={css`color: red;`}
-   ,-[input.js:3:1]
- 2 | 
- 3 | const Elem = () => <div css="invalid" />;
+   ,-[input.js:4:1]
+ 3 | const styles = css`color:red;`;
+ 4 | const Elem = () => <div css="invalid" />;
    :                    ^^^^^^^^^^^^^^^^^^^^^
- 4 | const Elem2 = (props: any) => <div css={props} />;
+ 5 | const Elem2 = (props: any) => <div css={props} />;
    `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.prod.tsx
@@ -1,3 +1,4 @@
 import { css, __yak_mergeCssProp } from "next-yak/internal";
-const Elem = ()=><div/>;
+const styles = /*#__PURE__*/ css();
+const Elem = ()=><div css="invalid"/>;
 const Elem2 = (props: any)=><div {...__yak_mergeCssProp({}, props)}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.dev.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.dev.stderr
@@ -1,7 +1,7 @@
   x Invalid CSS attribute. The 'css' prop should contain a valid CSS-in-JS expression. Example: css={css`color: red;`}
-   ,-[input.js:3:1]
- 2 | 
- 3 | const Elem = () => <div css="invalid" />;
+   ,-[input.js:4:1]
+ 3 | const styles = css`color:red;`;
+ 4 | const Elem = () => <div css="invalid" />;
    :                    ^^^^^^^^^^^^^^^^^^^^^
- 4 | const Elem2 = (props: any) => <div css={props} />;
+ 5 | const Elem2 = (props: any) => <div css={props} />;
    `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.dev.tsx
@@ -1,3 +1,4 @@
 import { css, __yak_mergeCssProp } from "next-yak/internal";
-const Elem = ()=><div/>;
+const styles = /*#__PURE__*/ css();
+const Elem = ()=><div css="invalid"/>;
 const Elem2 = (props: any)=><div {...__yak_mergeCssProp({}, props)}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.prod.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.prod.stderr
@@ -1,7 +1,7 @@
   x Invalid CSS attribute. The 'css' prop should contain a valid CSS-in-JS expression. Example: css={css`color: red;`}
-   ,-[input.js:3:1]
- 2 | 
- 3 | const Elem = () => <div css="invalid" />;
+   ,-[input.js:4:1]
+ 3 | const styles = css`color:red;`;
+ 4 | const Elem = () => <div css="invalid" />;
    :                    ^^^^^^^^^^^^^^^^^^^^^
- 4 | const Elem2 = (props: any) => <div css={props} />;
+ 5 | const Elem2 = (props: any) => <div css={props} />;
    `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.prod.tsx
@@ -1,3 +1,4 @@
 import { css, __yak_mergeCssProp } from "next-yak/internal";
-const Elem = ()=><div/>;
+const styles = /*#__PURE__*/ css();
+const Elem = ()=><div css="invalid"/>;
 const Elem2 = (props: any)=><div {...__yak_mergeCssProp({}, props)}/>;


### PR DESCRIPTION
next-yak claims the `css` prop, so when it hits a value it can't handle (a plain string, some arbitrary expression) the right default is to fail loudly — it's almost always a mistake. But that clashes with elements where another library owns its own `css` prop. This adds a `strictCssProp` option (default `true`) to opt out: when off, an unrecognized `css` prop is left completely untouched instead of erroring.

The option threads from `withYak` (webpack + turbopack) and the vite plugin down into yak-swc as `strict_css_prop` (serde default `true`, so existing configs are unaffected).

While wiring this up the css-prop transform was reworked to validate *before* mutating. Previously it removed the `css` attr and the merged props first, then tried to extract the CSS expression — so an invalid prop got silently stripped even as the error was emitted, and there was no clean way to "leave it alone". Now it builds the replacement from borrowed attrs first; on failure it either emits the diagnostic (strict) or returns without touching the element (non-strict). Valid props still merge exactly as before.

This surfaced a wasm-ABI gap in the fixture lane. The `css-prop-invalid` fixture emits a recoverable diagnostic natively (it has `.stderr` snapshots), but the wasm lane only ran the transform and swallowed whatever happened. Through `@swc/core` an emitted plugin error aborts the transform, so the lane now *asserts* every native-error fixture also throws through the built `.wasm` — a regression that drops an error across the ABI (leaving code untransformed instead of failing) can't be caught by `cargo test`, which never exercises the wasm path. The fixture also gained a `css\`\`` usage so it actually trips the plugin's activation gate and exercises the strict error end-to-end.

Verified: `cargo test` 296 pass, `next-yak` typechecks, wasm lane green (208 match, all diagnostic fixtures throw).