### PR TITLE
Skip changeset check on release PR

### DIFF
--- a/.changeset/tame-jokes-return.md
+++ b/.changeset/tame-jokes-return.md
@@ -1,0 +1,4 @@
+---
+---
+
+Skip the "Verify changeset present" check on the automated `changeset-release/main` release PR, which by design has no changesets.

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   check-changeset:
     name: Verify changeset present
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
The `changeset-release/main` PR consumes all changesets by design, so the changeset check always failed on it. Skip the job for that branch.