### PR TITLE
eslint-plugin-yak: allow prop-derived calls in style-conditions

### DIFF
--- a/.changeset/calm-dingos-call.md
+++ b/.changeset/calm-dingos-call.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-yak": patch
+---
+
+Allow prop-derived function calls as runtime values in the style-conditions rule

--- a/packages/eslint-plugin-yak/rules/styleConditions.test.ts
+++ b/packages/eslint-plugin-yak/rules/styleConditions.test.ts
@@ -65,6 +65,38 @@ ruleTester.run("yak-style-conditions", styleConditions, {
       code: "import { css, styled } from 'next-yak'; css`width: ${({$digit}) => `${5 * $digit + 'px'}`}`",
     },
     {
+      // Valid because the call result depends on a runtime value from props
+      code: `
+        import { styled } from "next-yak";
+
+        const spacing = { 8: "8px" };
+
+        const Grid = styled.div\`
+          grid-template-columns: repeat(
+            auto-fit,
+            minmax(
+              calc(
+                \${({ $baseWidth }) => Math.max(6, $baseWidth)}ch + 3 * \${spacing[8]}
+              ),
+              1fr
+            )
+          );
+        \`;
+      `,
+    },
+    {
+      // Valid because the called function comes from props
+      code: 'import { styled } from "next-yak"; styled.div`width: ${({ $formatter }) => $formatter(6)};`',
+    },
+    {
+      // Valid because the called method comes from props
+      code: 'import { styled } from "next-yak"; styled.div`width: ${({ $theme }) => $theme.spacing(2)};`',
+    },
+    {
+      // Valid because a spread argument comes from props
+      code: 'import { styled } from "next-yak"; styled.div`width: ${({ $widths }) => Math.max(...$widths)}px;`',
+    },
+    {
       // Valid unary conditional
       code: "import { css, styled } from 'next-yak'; css`${({ $visible = false }) => !$visible ? css`display: block;` : css`display: none;`}`",
     },
@@ -112,6 +144,11 @@ ruleTester.run("yak-style-conditions", styleConditions, {
     {
       // Invalid because it's returning a constant (the value is not from props)
       code: "import { css, styled } from 'next-yak'; css`color: ${() => color}`",
+      errors: [{ messageId: "invalidRuntimeReturnValue" }],
+    },
+    {
+      // Invalid because none of the call's dependencies come from props
+      code: "import { styled } from 'next-yak'; styled.div`width: ${() => Math.max(6, baseWidth)}px;`",
       errors: [{ messageId: "invalidRuntimeReturnValue" }],
     },
     {

--- a/packages/eslint-plugin-yak/rules/styleConditions.ts
+++ b/packages/eslint-plugin-yak/rules/styleConditions.ts
@@ -509,6 +509,18 @@ function isNodeAccessingParams(
         isNodeAccessingParams(node.left, params, importedNames) ||
         isNodeAccessingParams(node.right, params, importedNames)
       );
+    case AST_NODE_TYPES.CallExpression:
+      // A call is a runtime value if the callee or any argument is prop-derived, e.g. Math.max(6, $baseWidth)
+      return (
+        isNodeAccessingParams(node.callee, params, importedNames) ||
+        node.arguments.some((argument) =>
+          isNodeAccessingParams(
+            argument.type === AST_NODE_TYPES.SpreadElement ? argument.argument : argument,
+            params,
+            importedNames,
+          ),
+        )
+      );
     case AST_NODE_TYPES.UnaryExpression:
       return isNodeAccessingParams(node.argument, params, importedNames);
     default:


### PR DESCRIPTION
Change for our linting

Before: 

the style-conditions rule flagged arrow functions which call a function at runtime e.g:
`${({ $baseWidth }) => Math.max(6, $baseWidth)}` 

got a false `invalidRuntimeReturnValue` error

After: `isNodeAccessingParams` handles `CallExpression` too. So a call counts as a runtime value when the callee or any argument is prop-derived

Calls with no prop dependency e.g. a const like `Math.max(6, baseWidth)` are still reported as an error