### PR TITLE
Fix multi-token delete on the string collector

### DIFF
--- a/packages/next-yak/runtime/__tests__/cssLiteral.test.tsx
+++ b/packages/next-yak/runtime/__tests__/cssLiteral.test.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck These are runtime tests and the external API isn't the runtime (after compile) API
 import type { YakTheme } from "../context";
-import { css } from "../cssLiteral";
+import { css, ClassNames } from "../cssLiteral";
 
 describe("cssLiteral css function", () => {
   describe("static CSS class names", () => {
@@ -474,5 +474,27 @@ describe("cssLiteral css function", () => {
       expect(style["--dynamic1"]).toBe("dynamic1");
       expect(style["--dynamic2"]).toBe("dynamic2");
     });
+  });
+});
+
+describe("ClassNames collector", () => {
+  it("deletes a multi-token string added as one entry", () => {
+    const classNames = new ClassNames("mx-auto");
+    classNames.add("flex items-center gap-4");
+    classNames.delete("flex items-center gap-4");
+    classNames.add("grid gap-1");
+    expect(classNames.value).toBe("mx-auto grid gap-1");
+  });
+
+  it("still deletes single tokens", () => {
+    const classNames = new ClassNames("a b c");
+    classNames.delete("b");
+    expect(classNames.value).toBe("a c");
+  });
+
+  it("leaves a partially-present group untouched (Set-like: only removes what was added as a group)", () => {
+    const classNames = new ClassNames("mx-auto flex items-center");
+    classNames.delete("flex items-center gap-4");
+    expect(classNames.value).toBe("mx-auto flex items-center");
   });
 });

--- a/packages/next-yak/runtime/cssLiteral.tsx
+++ b/packages/next-yak/runtime/cssLiteral.tsx
@@ -29,9 +29,10 @@ export class ClassNames implements ClassNameCollector {
   }
   delete(className: string) {
     if (this.has(className)) {
+      const remove = new Set(className.split(" "));
       this.value = this.value
         .split(" ")
-        .filter((existing) => existing !== className)
+        .filter((existing) => !remove.has(existing))
         .join(" ");
     }
   }


### PR DESCRIPTION
The string-backed `ClassNames` collector in #558 couldn't delete multi-token strings: `delete("flex items-center gap-4")` split the stored value into tokens but compared each against the whole unsplit argument, so nothing matched and the classes stayed. `atoms()`-style code that adds a class group and later removes it silently kept both.

Splits the delete argument into a token set and filters against it. The `has()` guard stays, so it still only removes a group that's actually present as a contiguous run — matching the old `Set<string>` semantics where you can only delete what you added. Added unit tests for the multi-token, single-token, and partial-match cases.

Finding (3) from the perf-stack review.