### PR TITLE
eslint-plugin-yak: allow class references outside declarations

### DIFF
--- a/.changeset/gentle-lions-think.md
+++ b/.changeset/gentle-lions-think.md
@@ -2,4 +2,9 @@
 "eslint-plugin-yak": patch
 ---
 
-Allow style-condition class references outside CSS declaration values
+Track CSS parser state in `style-conditions` to decide whether an interpolation is a declaration value
+
+The rule used to guess declaration values by checking whether the preceding quasi ends with a colon. It now replays the template's CSS the way yak-swc does, which changes reporting in both directions:
+
+- No longer reported: class references outside declaration values, e.g. `${({ $active }) => $active && activeStyles}`, and interpolations inside at-rule queries (yak-swc already rejects those with a dedicated error).
+- Newly reported: declaration values the colon heuristic missed, such as values nested in `var()` / `calc()` and inside quoted strings.

--- a/.changeset/gentle-lions-think.md
+++ b/.changeset/gentle-lions-think.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-yak": patch
+---
+
+Allow style-condition class references outside CSS declaration values

--- a/.changeset/gentle-lions-think.md
+++ b/.changeset/gentle-lions-think.md
@@ -2,9 +2,4 @@
 "eslint-plugin-yak": patch
 ---
 
-Track CSS parser state in `style-conditions` to decide whether an interpolation is a declaration value
-
-The rule used to guess declaration values by checking whether the preceding quasi ends with a colon. It now replays the template's CSS the way yak-swc does, which changes reporting in both directions:
-
-- No longer reported: class references outside declaration values, e.g. `${({ $active }) => $active && activeStyles}`, and interpolations inside at-rule queries (yak-swc already rejects those with a dedicated error).
-- Newly reported: declaration values the colon heuristic missed, such as values nested in `var()` / `calc()` and inside quoted strings.
+Detect declaration values in the style-conditions rule by parsing the CSS instead of guessing from a trailing colon

--- a/docs/content/docs/eslint-plugin.mdx
+++ b/docs/content/docs/eslint-plugin.mdx
@@ -197,6 +197,8 @@ styled.div`
 
 Warns if runtime performance could be improved by using css literals.
 
+The rule checks arrow functions used as CSS declaration values, where next-yak creates runtime CSS variables. Arrow functions outside declarations are runtime class expressions and may return local or imported css mixins.
+
 Example:
 
 ```tsx title="example.tsx"
@@ -234,6 +236,18 @@ styled.button`
       `; // [!code ++]
     }
   }};
+`;
+```
+
+Extracted css literals can also be reused as conditional classes:
+
+```tsx title="example.tsx"
+const activeStyles = css`
+  opacity: 1;
+`;
+
+styled.button`
+  ${({$active}) => $active && activeStyles}
 `;
 ```
 

--- a/packages/eslint-plugin-yak/README.md
+++ b/packages/eslint-plugin-yak/README.md
@@ -50,11 +50,11 @@ export default defineConfig({
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
 
-| Name                                                                                                                                         | Description                                                                                                   | 🔧 | 💡 |
-| :------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------ | :- | :- |
-| [css-global-deprecated](https://github.com/DigitecGalaxus/next-yak/blob/main/packages/eslint-plugin-yak/docs/rules/css-global-deprecated.md) | Deprecates :global() selectors in favor of native CSS transpilation                                           |    |    |
-| [css-nesting-operator](https://github.com/DigitecGalaxus/next-yak/blob/main/packages/eslint-plugin-yak/docs/rules/css-nesting-operator.md)   | Enforces css selectors in next-yak to correctly use the nesting selector (&)                                  |    | 💡 |
-| [enforce-semicolon](https://github.com/DigitecGalaxus/next-yak/blob/main/packages/eslint-plugin-yak/docs/rules/enforce-semicolon.md)         | Enforces that expression in styled/css literals from next-yak use semicolons                                  | 🔧 |    |
-| [style-conditions](https://github.com/DigitecGalaxus/next-yak/blob/main/packages/eslint-plugin-yak/docs/rules/style-conditions.md)           | Enforces that arrow functions only return runtime values or css literals in styled/css literals from next-yak |    |    |
+| Name                                                                                                                                         | Description                                                                                                  | 🔧 | 💡 |
+| :------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------- | :- | :- |
+| [css-global-deprecated](https://github.com/DigitecGalaxus/next-yak/blob/main/packages/eslint-plugin-yak/docs/rules/css-global-deprecated.md) | Deprecates :global() selectors in favor of native CSS transpilation                                          |    |    |
+| [css-nesting-operator](https://github.com/DigitecGalaxus/next-yak/blob/main/packages/eslint-plugin-yak/docs/rules/css-nesting-operator.md)   | Enforces css selectors in next-yak to correctly use the nesting selector (&)                                 |    | 💡 |
+| [enforce-semicolon](https://github.com/DigitecGalaxus/next-yak/blob/main/packages/eslint-plugin-yak/docs/rules/enforce-semicolon.md)         | Enforces that expression in styled/css literals from next-yak use semicolons                                 | 🔧 |    |
+| [style-conditions](https://github.com/DigitecGalaxus/next-yak/blob/main/packages/eslint-plugin-yak/docs/rules/style-conditions.md)           | Warns when arrow functions in next-yak styled/css literals would create unnecessary or invalid CSS variables |    |    |
 
 <!-- end auto-generated rules list -->

--- a/packages/eslint-plugin-yak/docs/rules/style-conditions.md
+++ b/packages/eslint-plugin-yak/docs/rules/style-conditions.md
@@ -1,6 +1,6 @@
 # yak/style-conditions
 
-📝 Enforces that arrow functions only return runtime values or css literals in styled/css literals from next-yak.
+📝 Warns when arrow functions in next-yak styled/css literals would create unnecessary or invalid CSS variables.
 
 <!-- end auto-generated rule header -->
 
@@ -56,7 +56,7 @@ The yak/style-conditions rule in our linting tools can help identify unnecessary
 
 ## Rule details
 
-This rule triggers a warning if an arrow function doesn't return a css literal or a runtime value.
+This rule triggers a warning when an arrow function inside a CSS declaration returns a static value that would create an unnecessary CSS variable. Arrow functions outside declarations are runtime class expressions, so they may return local or imported css mixins.
 
 The following patterns are considered errors:
 
@@ -89,6 +89,14 @@ styled.button`
 
 styled.button`
   color: ${color};
+`;
+
+const activeStyles = css`
+  opacity: 1;
+`;
+
+styled.button`
+  ${({$active}) => $active && activeStyles}
 `;
 
 styled.button`

--- a/packages/eslint-plugin-yak/rules/styleConditions.test.ts
+++ b/packages/eslint-plugin-yak/rules/styleConditions.test.ts
@@ -33,6 +33,61 @@ ruleTester.run("yak-style-conditions", styleConditions, {
       code: "import { css, styled } from 'next-yak'; styled.button`${({variant}) => variant === 'primary' && css`color: red`}`",
     },
     {
+      // Valid because an extracted css literal returned outside a declaration becomes a class
+      code: `
+        import { css, styled } from "next-yak";
+
+        const activeStyles = css\`
+          opacity: 1;
+        \`;
+
+        const Button = styled.button\`
+          \${({ $isSelected }) => $isSelected && activeStyles}
+        \`;
+      `,
+    },
+    {
+      // Valid because both extracted css literal branches become toggleable classes
+      code: `
+        import { css, styled } from "next-yak";
+
+        const slideUp = css\`
+          transform: translateY(0);
+        \`;
+        const slideDown = css\`
+          transform: translateY(100%);
+        \`;
+
+        const Sheet = styled.div\`
+          \${({ $show }) => ($show ? slideUp : slideDown)}
+        \`;
+      `,
+    },
+    {
+      // Valid because imported mixins are runtime class expressions outside declarations
+      code: `
+        import { styled } from "next-yak";
+        import { activeStyles } from "./styles";
+
+        const Button = styled.button\`
+          \${({ $isSelected }) => $isSelected && activeStyles}
+        \`;
+      `,
+    },
+    {
+      // Valid because pseudo-class colons do not turn nested class expressions into values
+      code: `
+        import { css, styled } from "next-yak";
+
+        const hoverStyles = css\`color: red;\`;
+        const Button = styled.button\`
+          &:hover {
+            \${() => hoverStyles}
+          }
+        \`;
+      `,
+    },
+    {
       // Valid because it's returning a runtime value
       code: "import { css, styled } from 'next-yak'; styled.button`${({variant, primary}) => variant === 'primary' && css`color: ${primary}`}`",
     },
@@ -100,6 +155,25 @@ ruleTester.run("yak-style-conditions", styleConditions, {
       // Valid unary conditional
       code: "import { css, styled } from 'next-yak'; css`${({ $visible = false }) => !$visible ? css`display: block;` : css`display: none;`}`",
     },
+    {
+      // Valid runtime value nested inside a CSS function and custom-property fallback
+      code: `
+        import { styled } from "next-yak";
+        const Box = styled.div\`
+          margin: 4px var(--foo, \${({ $foo }) => $foo});
+        \`;
+      `,
+    },
+    {
+      // Expressions in CSS comments are ignored by Yak's CSS parser
+      code: `
+        import { styled } from "next-yak";
+        const fallback = "red";
+        const Box = styled.div\`
+          /* color: \${() => fallback}; */
+        \`;
+      `,
+    },
     // Ignored because it's not next-yak
     {
       code: "import { css } from 'styled-components'; css`color: ${() => color}`",
@@ -141,6 +215,73 @@ ruleTester.run("yak-style-conditions", styleConditions, {
     },
   ],
   invalid: [
+    {
+      // Static member references inside declarations would create accidental CSS variables
+      code: `
+        import { styled } from "next-yak";
+
+        const radioButtonColors = {
+          RADIO_BORDER_ERROR: "red",
+          RADIO_BORDER: "gray",
+        };
+
+        const Input = styled.input\`
+          border-color: \${({ $hasError, $isDisabled }) =>
+            $hasError && !$isDisabled
+              ? radioButtonColors.RADIO_BORDER_ERROR
+              : radioButtonColors.RADIO_BORDER};
+        \`;
+      `,
+      errors: [{ messageId: "invalidRuntimeReturnValue" }],
+    },
+    {
+      // Nested CSS functions must still be recognised as declaration values
+      code: `
+        import { styled } from "next-yak";
+
+        const fallbackMargin = "4px";
+        const Box = styled.div\`
+          margin: 4px var(--foo, \${({ $foo }) => fallbackMargin});
+        \`;
+      `,
+      errors: [{ messageId: "invalidRuntimeReturnValue" }],
+    },
+    {
+      // Parentheses in calc() must not hide a static declaration value
+      code: `
+        import { styled } from "next-yak";
+
+        const baseWidth = 6;
+        const Box = styled.div\`
+          width: calc(\${() => baseWidth} * 1px);
+        \`;
+      `,
+      errors: [{ messageId: "invalidRuntimeReturnValue" }],
+    },
+    {
+      // Quoted declaration values remain property values across interpolations
+      code: `
+        import { styled } from "next-yak";
+
+        const label = "static";
+        const Box = styled.div\`
+          &::before {
+            content: "prefix \${() => label}";
+          }
+        \`;
+      `,
+      errors: [{ messageId: "invalidRuntimeReturnValue" }],
+    },
+    {
+      // A css literal nested in a CSS function is still invalid as a declaration value
+      code: `
+        import { css, styled } from "next-yak";
+        const Box = styled.div\`
+          margin: var(--foo, \${({ $foo }) => css\`4px\`});
+        \`;
+      `,
+      errors: [{ messageId: "invalidCssReturnValue" }],
+    },
     {
       // Invalid because it's returning a constant (the value is not from props)
       code: "import { css, styled } from 'next-yak'; css`color: ${() => color}`",

--- a/packages/eslint-plugin-yak/rules/styleConditions.test.ts
+++ b/packages/eslint-plugin-yak/rules/styleConditions.test.ts
@@ -174,6 +174,31 @@ ruleTester.run("yak-style-conditions", styleConditions, {
         \`;
       `,
     },
+    {
+      // Single line comments are comments for Yak's CSS parser as well
+      code: `
+        import { styled } from "next-yak";
+        const fallback = "red";
+        const Box = styled.div\`
+          // color: \${() => fallback};
+          color: blue;
+        \`;
+      `,
+    },
+    {
+      // Not reported because a colon inside an at-rule query does not open a
+      // property value. yak-swc rejects dynamic at-rule queries at compile time
+      // with a dedicated error, so this rule stays out of the way.
+      code: `
+        import { styled } from "next-yak";
+        const breakpoint = 600;
+        const Box = styled.div\`
+          @media (min-width: \${() => breakpoint}px) {
+            display: none;
+          }
+        \`;
+      `,
+    },
     // Ignored because it's not next-yak
     {
       code: "import { css } from 'styled-components'; css`color: ${() => color}`",

--- a/packages/eslint-plugin-yak/rules/styleConditions.ts
+++ b/packages/eslint-plugin-yak/rules/styleConditions.ts
@@ -13,7 +13,7 @@ export const styleConditions = createRule({
     type: "suggestion",
     docs: {
       description:
-        "Enforces that arrow functions only return runtime values or css literals in styled/css literals from next-yak",
+        "Warns when arrow functions in next-yak styled/css literals would create unnecessary or invalid CSS variables",
       recommended: true,
       requiresTypeChecking: false,
     },
@@ -49,10 +49,7 @@ export const styleConditions = createRule({
           return;
         }
 
-        const codeBefore = getQuasiBeforeExpression(tag, needle);
-        // Guess that if a quasi ends with a colon that it is a declaration e.g.
-        // css`color: ${({ color }) => color}`
-        if (codeBefore === undefined || !codeBefore.trim().endsWith(":")) {
+        if (!isInsideCssDeclarationValue(tag, needle)) {
           return;
         }
 
@@ -90,6 +87,13 @@ export const styleConditions = createRule({
         // e.g. css`width: ${({ $size }) => $size}px`
         const { tag, params, needle } = findClosestStyledOrCssTag(node, importedNames);
         if (!tag) {
+          return;
+        }
+
+        // Outside a declaration value Yak treats the expression as a runtime class
+        // expression, so returning local or imported css mixins is valid and cannot
+        // accidentally create a CSS variable.
+        if (!isInsideCssDeclarationValue(tag, needle)) {
           return;
         }
 
@@ -323,6 +327,127 @@ function getQuasiBeforeExpression(
     return undefined;
   }
   return tag.quasi.quasis[index].value.raw;
+}
+
+type CssParserState = {
+  comment: "none" | "single-line" | "multi-line";
+  isInsideAtRule: boolean;
+  isInsidePropertyValue: boolean;
+  parenDepth: number;
+  quote: '"' | "'" | undefined;
+};
+
+/**
+ * Checks whether an interpolation is inside a CSS declaration value.
+ *
+ * This mirrors the parser state Yak uses to decide whether a dynamic expression
+ * becomes a CSS variable or a runtime class expression. Earlier interpolations
+ * are represented by a neutral identifier so the surrounding CSS syntax can be
+ * followed without resolving JavaScript values.
+ */
+function isInsideCssDeclarationValue(
+  tag: TSESTree.TaggedTemplateExpression,
+  needle: TSESTree.Node,
+): boolean {
+  const expressionIndex = tag.quasi.expressions.findIndex((expression) => expression === needle);
+  if (expressionIndex === -1) {
+    return false;
+  }
+
+  const state: CssParserState = {
+    comment: "none",
+    isInsideAtRule: false,
+    isInsidePropertyValue: false,
+    parenDepth: 0,
+    quote: undefined,
+  };
+
+  for (let index = 0; index <= expressionIndex; index++) {
+    scanCssSegment(tag.quasi.quasis[index].value.raw, state);
+    if (index < expressionIndex) {
+      scanCssSegment("__yak_expression__", state);
+    }
+  }
+
+  return state.comment === "none" && state.isInsidePropertyValue;
+}
+
+function scanCssSegment(segment: string, state: CssParserState): void {
+  for (let index = 0; index < segment.length; index++) {
+    const char = segment[index];
+    const nextChar = segment[index + 1];
+
+    if (state.comment === "multi-line") {
+      if (char === "*" && nextChar === "/") {
+        state.comment = "none";
+        index++;
+      }
+      continue;
+    }
+    if (state.comment === "single-line") {
+      if (char === "\n") {
+        state.comment = "none";
+      }
+      continue;
+    }
+
+    const isEscaped = hasOddNumberOfPrecedingBackslashes(segment, index);
+    if (state.quote) {
+      if (char === state.quote && !isEscaped) {
+        state.quote = undefined;
+      }
+      continue;
+    }
+    if ((char === '"' || char === "'") && !isEscaped) {
+      state.quote = char;
+      continue;
+    }
+
+    if (state.isInsidePropertyValue) {
+      if (char === "(") {
+        state.parenDepth++;
+        continue;
+      }
+      if (char === ")" && state.parenDepth > 0) {
+        state.parenDepth--;
+      }
+      if (state.parenDepth > 0) {
+        continue;
+      }
+    }
+
+    if (char === "/" && nextChar === "*") {
+      state.comment = "multi-line";
+      index++;
+    } else if (char === "/" && nextChar === "/") {
+      state.comment = "single-line";
+      index++;
+    } else if (char === "}") {
+      state.isInsidePropertyValue = false;
+      state.isInsideAtRule = false;
+      state.parenDepth = 0;
+    } else if (char === "{") {
+      state.isInsidePropertyValue = false;
+      state.isInsideAtRule = false;
+      state.parenDepth = 0;
+    } else if (char === ";") {
+      state.isInsidePropertyValue = false;
+      state.isInsideAtRule = false;
+      state.parenDepth = 0;
+    } else if (!state.isInsidePropertyValue && !state.isInsideAtRule && char === ":") {
+      state.isInsidePropertyValue = true;
+    } else if (!state.isInsidePropertyValue && char === "@") {
+      state.isInsideAtRule = true;
+    }
+  }
+}
+
+function hasOddNumberOfPrecedingBackslashes(segment: string, index: number): boolean {
+  let backslashCount = 0;
+  for (let cursor = index - 1; cursor >= 0 && segment[cursor] === "\\"; cursor--) {
+    backslashCount++;
+  }
+  return backslashCount % 2 === 1;
 }
 
 /**


### PR DESCRIPTION
Change for our linting

Before:

the style-conditions rule flagged local or imported css mixins returned through a variable e.g.:
${({ $isSelected }) => $isSelected && activeStyles}

got a false invalidRuntimeReturnValue error even though Yak compiles expressions outside CSS declarations as runtime classes.

After: the rule mirrors Yaks CSS parser state and only validates arrow return values inside CSS declarations, where values become CSS variables.

Local and imported class references now pass. Static references inside declarations like border-color or nested var() and calc() values are still reported.

Added coverage for logical and ternary class references, imports, pseudo selectors, comments, quotes, and nested CSS functions.