### PR TITLE
Pin the static style prop behavior

### DIFF
--- a/.changeset/chatty-fans-drop.md
+++ b/.changeset/chatty-fans-drop.md
@@ -3,3 +3,5 @@
 ---
 
 Improve runtime render performance by collecting class names via string append instead of Set round-trips, rendering styled() composition chains as a single wrapper and skipping prop/style processing entirely for static components
+
+Components with fully static styles no longer receive a default `style: {}` prop, and a user-passed `style` object is forwarded by reference instead of cloned on every render; components with dynamic styles are unchanged.

--- a/packages/next-yak/runtime/__tests__/styled.test.tsx
+++ b/packages/next-yak/runtime/__tests__/styled.test.tsx
@@ -148,6 +148,34 @@ it("should concatenate styles", () => {
   `);
 });
 
+it("should not inject a default style prop into a static wrapped component", () => {
+  let receivedProps = null;
+  const Component = (props) => {
+    receivedProps = props;
+    return null;
+  };
+  const StyledComponent = styled(Component)("staticClass");
+
+  render(<StyledComponent />);
+
+  expect("style" in receivedProps).toBe(false);
+});
+
+it("should forward a style prop by reference to a static wrapped component", () => {
+  let receivedProps = null;
+  const Component = (props) => {
+    receivedProps = props;
+    return null;
+  };
+  const StyledComponent = styled(Component)("staticClass");
+  const style = { color: "red" };
+
+  render(<StyledComponent style={style} />);
+
+  // no per-render clone — keeps React.memo/PureComponent on the target working
+  expect(receivedProps.style).toBe(style);
+});
+
 it("should not add class if prop is not set", () => {
   const Component = styled.input(({ testProp }) => testProp && css("test"));
 


### PR DESCRIPTION
The static fast path stopped injecting a default `style: {}` and stopped cloning a user-passed `style` per render, which is the behavior we want (it un-breaks `React.memo` on wrapped components) — but nothing locked it in. Adds two tests: one that the target gets no `style` key at all, one that a passed `style` arrives by reference.

Also documents it in the changeset. Scoped the wording to *static* styles on purpose: the dynamic path still clones and still ends up assigning `style: {}`, so the broader "components wrapped in styled()" phrasing would have been wrong.

Finding (7) from the perf-stack review.