### PR TITLE
Only register const declarators for folding

### DIFF
--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -165,9 +165,10 @@ where
   current_declaration: Vec<Declaration>,
   /// e.g Button in const Button = styled.button`color: red;`
   current_variable_name: Option<ScopedVariableReference>,
-  /// Span of the current variable declarator's initializer (type casts and
-  /// parens stripped) - used to check a styled template is the whole
+  /// Span of the current const variable declarator's initializer (type casts
+  /// and parens stripped) - used to check a styled template is the whole
   /// initializer and not nested inside e.g. an HOC call or ternary
+  /// Only set for `const` declarators, the only ones eligible for folding
   current_declarator_init_span: Option<Span>,
   /// Current condition to name nested css expressions
   current_condition: Vec<String>,
@@ -1007,10 +1008,18 @@ where
           id.to_id(),
           vec![id.sym.clone().into()],
         ));
-        self.current_declarator_init_span = decl
-          .init
-          .as_deref()
-          .map(|init| unwrap_type_casts(init).span());
+        // only const declarators may fold - `let`/`var` bindings can be
+        // reassigned, and `var` may even be redeclared, which would register
+        // the same id twice - `immutable_bindings` drops non-const bindings
+        // later anyway, so gating here loses no folds
+        self.current_declarator_init_span = if n.kind == VarDeclKind::Const {
+          decl
+            .init
+            .as_deref()
+            .map(|init| unwrap_type_casts(init).span())
+        } else {
+          None
+        };
         decl.init.visit_mut_with(self);
         self.current_variable_name = previous_variable_name;
         self.current_declarator_init_span = previous_init_span;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/input.tsx
@@ -60,6 +60,14 @@ let Mutable = styled.div`
   color: pink;
 `;
 
+// bails: var redeclaration - both declarations share a single binding
+var Redeclared = styled.div`
+  color: peru;
+`;
+var Redeclared = styled.span`
+  color: plum;
+`;
+
 // folds although the declaration comes after the usage
 const Early = () => <Late>before declaration</Late>;
 const Late = styled.p`
@@ -133,6 +141,7 @@ const NotOptimizable = () => (
     <ExtendedLowercase>bails: lowercase wrapped component</ExtendedLowercase>
     <ExtendedMutable>bails: reassignable wrapped component</ExtendedMutable>
     <Mutable>bails</Mutable>
+    <Redeclared>bails: var redeclaration</Redeclared>
     <Memoized>bails: HOC wrapper</Memoized>
     <ReactMemoized>bails: HOC wrapper</ReactMemoized>
     <Conditional>bails: conditional initializer</Conditional></>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.dev.tsx
@@ -96,6 +96,21 @@ let Mutable = /*YAK Extracted CSS:
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Mutable_m7uBBu"), {
     "displayName": "Mutable"
 });
+// bails: var redeclaration - both declarations share a single binding
+var Redeclared = /*YAK Extracted CSS:
+:global(.input_Redeclared_m7uBBu) {
+  color: peru;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Redeclared_m7uBBu"), {
+    "displayName": "Redeclared"
+});
+var Redeclared = /*YAK Extracted CSS:
+:global(.input_Redeclared_m7uBBu-01) {
+  color: plum;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_span("input_Redeclared_m7uBBu-01"), {
+    "displayName": "Redeclared"
+});
 // folds although the declaration comes after the usage
 const Early = ()=><p className="input_Late_m7uBBu">before declaration</p>;
 const Late = /*YAK Extracted CSS:
@@ -189,6 +204,7 @@ const NotOptimizable = ()=><>
     <ExtendedLowercase>bails: lowercase wrapped component</ExtendedLowercase>
     <ExtendedMutable>bails: reassignable wrapped component</ExtendedMutable>
     <Mutable>bails</Mutable>
+    <Redeclared>bails: var redeclaration</Redeclared>
     <Memoized>bails: HOC wrapper</Memoized>
     <ReactMemoized>bails: HOC wrapper</ReactMemoized>
     <Conditional>bails: conditional initializer</Conditional></>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.prod.tsx
@@ -76,31 +76,42 @@ let Mutable = /*YAK Extracted CSS:
   color: pink;
 }
 */ /*#__PURE__*/ __yak.__yak_div("ym7uBBuB");
-// folds although the declaration comes after the usage
-const Early = ()=><p className="ym7uBBuC">before declaration</p>;
-const Late = /*YAK Extracted CSS:
+// bails: var redeclaration - both declarations share a single binding
+var Redeclared = /*YAK Extracted CSS:
 :global(.ym7uBBuC) {
+  color: peru;
+}
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuC");
+var Redeclared = /*YAK Extracted CSS:
+:global(.ym7uBBuD) {
+  color: plum;
+}
+*/ /*#__PURE__*/ __yak.__yak_span("ym7uBBuD");
+// folds although the declaration comes after the usage
+const Early = ()=><p className="ym7uBBuE">before declaration</p>;
+const Late = /*YAK Extracted CSS:
+:global(.ym7uBBuE) {
   color: gray;
 }
-*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuC");
+*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuE");
 // bails: wrapped in an HOC - folding would drop the wrapper
 const Memoized = memo(/*YAK Extracted CSS:
-:global(.ym7uBBuD) {
+:global(.ym7uBBuF) {
   color: teal;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuD"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuF"));
 // folds: type casts are unwrapped
 const Cast = /*YAK Extracted CSS:
-:global(.ym7uBBuE) {
+:global(.ym7uBBuG) {
   color: brown;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuE") as unknown as typeof Card;
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuG") as unknown as typeof Card;
 const BoxWithMixin = /*YAK Extracted CSS:
-:global(.ym7uBBuF) {
+:global(.ym7uBBuH) {
   background: white;
   color: red;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuF");
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuH");
 const Optimizable = ({ active }: {
     active?: boolean;
 })=><>
@@ -114,38 +125,38 @@ const Optimizable = ({ active }: {
     <div className={__yak_mergeClassNames("ym7uBBu1", active && "active")}>runtime class name merge</div>
     <div $foo="forwarded" className="ym7uBBu1">$props are not filtered</div>
     <div className={/*YAK Extracted CSS:
-:global(.ym7uBBuG) {
+:global(.ym7uBBuI) {
   color: orange;
 }
-*/ /*#__PURE__*/ "ym7uBBu1 ym7uBBuG"}>
+*/ /*#__PURE__*/ "ym7uBBu1 ym7uBBuI"}>
       css prop merge
     </div>
     <div className="ym7uBBu1">
       <section className="ym7uBBu2"/>
     </div>
     <h1 className="ym7uBBu3">folds</h1>
-    <div className="ym7uBBuE">folds through the type cast</div>
+    <div className="ym7uBBuG">folds through the type cast</div>
     <Card className="ym7uBBu7">folds to the wrapped component</Card>
     <Card className="ym7uBBu7 user">merges into the wrapped component</Card>
     <ImportedCard className="ym7uBBu8">folds to the imported component</ImportedCard>
-    <div className="ym7uBBuF">folds with mixin</div>
+    <div className="ym7uBBuH">folds with mixin</div>
   </>;
 // bails: wrapped in React.memo - the HOC result must not fold to a bare DOM element
 const ReactMemoized = React.memo(/*YAK Extracted CSS:
-:global(.ym7uBBuH) {
+:global(.ym7uBBuJ) {
   color: olive;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuH"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuJ"));
 // bails: conditional initializer - the branch is only known at runtime
 const Conditional = props.flag ? /*YAK Extracted CSS:
-:global(.ym7uBBuI) {
+:global(.ym7uBBuK) {
   color: crimson;
 }
-*/ /*#__PURE__*/ __yak.__yak_a("ym7uBBuI") : /*YAK Extracted CSS:
-:global(.ym7uBBuJ) {
+*/ /*#__PURE__*/ __yak.__yak_a("ym7uBBuK") : /*YAK Extracted CSS:
+:global(.ym7uBBuL) {
   color: navy;
 }
-*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBuJ");
+*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBuL");
 const NotOptimizable = ()=><>
     <Card {...props}>bails: spread</Card>
     <Card theme={props.theme}>bails: theme</Card>
@@ -155,6 +166,7 @@ const NotOptimizable = ()=><>
     <ExtendedLowercase>bails: lowercase wrapped component</ExtendedLowercase>
     <ExtendedMutable>bails: reassignable wrapped component</ExtendedMutable>
     <Mutable>bails</Mutable>
+    <Redeclared>bails: var redeclaration</Redeclared>
     <Memoized>bails: HOC wrapper</Memoized>
     <ReactMemoized>bails: HOC wrapper</ReactMemoized>
     <Conditional>bails: conditional initializer</Conditional></>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.dev.tsx
@@ -2,7 +2,7 @@ import React, { memo } from "react";
 import { css, styled, __yak_mergeClassNames } from "next-yak/internal";
 import { ImportedCard } from "./imported-card";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LmlucHV0X0NhcmRfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0JveF9tN3VCQnUgewogIGNvbG9yOiBibHVlOwp9LmlucHV0X1RpdGxlX203dUJCdSB7CiAgZm9udC1zaXplOiAycmVtOwp9LmlucHV0X0R5bmFtaWNfbTd1QkJ1IHsKICBjb2xvcjogdmFyKC0taW5wdXRfRHluYW1pY19fY29sb3JfbTd1QkJ1KTsKfS5pbnB1dF9XaXRoQXR0cnNfbTd1QkJ1IHsKICBjb2xvcjogZ3JlZW47Cn0uaW5wdXRfRXh0ZW5kZWRfbTd1QkJ1IHsKICBjb2xvcjogeWVsbG93Owp9LmlucHV0X0V4dGVuZGVkSW1wb3J0X203dUJCdSB7CiAgY29sb3I6IHNpbHZlcjsKfS5pbnB1dF9FeHRlbmRlZExvd2VyY2FzZV9tN3VCQnUgewogIGNvbG9yOiBnb2xkOwp9LmlucHV0X0V4dGVuZGVkTXV0YWJsZV9tN3VCQnUgewogIGNvbG9yOiBpdm9yeTsKfS5pbnB1dF9NdXRhYmxlX203dUJCdSB7CiAgY29sb3I6IHBpbms7Cn0uaW5wdXRfTGF0ZV9tN3VCQnUgewogIGNvbG9yOiBncmF5Owp9LmlucHV0X01lbW9pemVkX203dUJCdSB7CiAgY29sb3I6IHRlYWw7Cn0uaW5wdXRfQ2FzdF9tN3VCQnUgewogIGNvbG9yOiBicm93bjsKfS5pbnB1dF9Cb3hXaXRoTWl4aW5fbTd1QkJ1IHsKICBiYWNrZ3JvdW5kOiB3aGl0ZTsKICBjb2xvcjogcmVkOwp9LmlucHV0X09wdGltaXphYmxlX203dUJCdSB7CiAgY29sb3I6IG9yYW5nZTsKfS5pbnB1dF9SZWFjdE1lbW9pemVkX203dUJCdSB7CiAgY29sb3I6IG9saXZlOwp9LmlucHV0X0NvbmRpdGlvbmFsX203dUJCdSB7CiAgY29sb3I6IGNyaW1zb247Cn0uaW5wdXRfQ29uZGl0aW9uYWxfbTd1QkJ1LTAxIHsKICBjb2xvcjogbmF2eTsKfQ==";
+import "data:text/css;base64,LmlucHV0X0NhcmRfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0JveF9tN3VCQnUgewogIGNvbG9yOiBibHVlOwp9LmlucHV0X1RpdGxlX203dUJCdSB7CiAgZm9udC1zaXplOiAycmVtOwp9LmlucHV0X0R5bmFtaWNfbTd1QkJ1IHsKICBjb2xvcjogdmFyKC0taW5wdXRfRHluYW1pY19fY29sb3JfbTd1QkJ1KTsKfS5pbnB1dF9XaXRoQXR0cnNfbTd1QkJ1IHsKICBjb2xvcjogZ3JlZW47Cn0uaW5wdXRfRXh0ZW5kZWRfbTd1QkJ1IHsKICBjb2xvcjogeWVsbG93Owp9LmlucHV0X0V4dGVuZGVkSW1wb3J0X203dUJCdSB7CiAgY29sb3I6IHNpbHZlcjsKfS5pbnB1dF9FeHRlbmRlZExvd2VyY2FzZV9tN3VCQnUgewogIGNvbG9yOiBnb2xkOwp9LmlucHV0X0V4dGVuZGVkTXV0YWJsZV9tN3VCQnUgewogIGNvbG9yOiBpdm9yeTsKfS5pbnB1dF9NdXRhYmxlX203dUJCdSB7CiAgY29sb3I6IHBpbms7Cn0uaW5wdXRfUmVkZWNsYXJlZF9tN3VCQnUgewogIGNvbG9yOiBwZXJ1Owp9LmlucHV0X1JlZGVjbGFyZWRfbTd1QkJ1LTAxIHsKICBjb2xvcjogcGx1bTsKfS5pbnB1dF9MYXRlX203dUJCdSB7CiAgY29sb3I6IGdyYXk7Cn0uaW5wdXRfTWVtb2l6ZWRfbTd1QkJ1IHsKICBjb2xvcjogdGVhbDsKfS5pbnB1dF9DYXN0X203dUJCdSB7CiAgY29sb3I6IGJyb3duOwp9LmlucHV0X0JveFdpdGhNaXhpbl9tN3VCQnUgewogIGJhY2tncm91bmQ6IHdoaXRlOwogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfT3B0aW1pemFibGVfbTd1QkJ1IHsKICBjb2xvcjogb3JhbmdlOwp9LmlucHV0X1JlYWN0TWVtb2l6ZWRfbTd1QkJ1IHsKICBjb2xvcjogb2xpdmU7Cn0uaW5wdXRfQ29uZGl0aW9uYWxfbTd1QkJ1IHsKICBjb2xvcjogY3JpbXNvbjsKfS5pbnB1dF9Db25kaXRpb25hbF9tN3VCQnUtMDEgewogIGNvbG9yOiBuYXZ5Owp9";
 const someRef = {
     current: null
 } as any;
@@ -95,6 +95,21 @@ let Mutable = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Mutable_m7uBBu"), {
     "displayName": "Mutable"
+});
+// bails: var redeclaration - both declarations share a single binding
+var Redeclared = /*YAK Extracted CSS:
+.input_Redeclared_m7uBBu {
+  color: peru;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Redeclared_m7uBBu"), {
+    "displayName": "Redeclared"
+});
+var Redeclared = /*YAK Extracted CSS:
+.input_Redeclared_m7uBBu-01 {
+  color: plum;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_span("input_Redeclared_m7uBBu-01"), {
+    "displayName": "Redeclared"
 });
 // folds although the declaration comes after the usage
 const Early = ()=><p className="input_Late_m7uBBu">before declaration</p>;
@@ -189,6 +204,7 @@ const NotOptimizable = ()=><>
     <ExtendedLowercase>bails: lowercase wrapped component</ExtendedLowercase>
     <ExtendedMutable>bails: reassignable wrapped component</ExtendedMutable>
     <Mutable>bails</Mutable>
+    <Redeclared>bails: var redeclaration</Redeclared>
     <Memoized>bails: HOC wrapper</Memoized>
     <ReactMemoized>bails: HOC wrapper</ReactMemoized>
     <Conditional>bails: conditional initializer</Conditional></>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.prod.tsx
@@ -2,7 +2,7 @@ import React, { memo } from "react";
 import { css, styled, __yak_mergeClassNames } from "next-yak/internal";
 import { ImportedCard } from "./imported-card";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LnltN3VCQnUxIHsKICBjb2xvcjogcmVkOwp9LnltN3VCQnUyIHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1MyB7CiAgZm9udC1zaXplOiAycmVtOwp9LnltN3VCQnU0IHsKICBjb2xvcjogdmFyKC0teW03dUJCdTUpOwp9LnltN3VCQnU2IHsKICBjb2xvcjogZ3JlZW47Cn0ueW03dUJCdTcgewogIGNvbG9yOiB5ZWxsb3c7Cn0ueW03dUJCdTggewogIGNvbG9yOiBzaWx2ZXI7Cn0ueW03dUJCdTkgewogIGNvbG9yOiBnb2xkOwp9LnltN3VCQnVBIHsKICBjb2xvcjogaXZvcnk7Cn0ueW03dUJCdUIgewogIGNvbG9yOiBwaW5rOwp9LnltN3VCQnVDIHsKICBjb2xvcjogZ3JheTsKfS55bTd1QkJ1RCB7CiAgY29sb3I6IHRlYWw7Cn0ueW03dUJCdUUgewogIGNvbG9yOiBicm93bjsKfS55bTd1QkJ1RiB7CiAgYmFja2dyb3VuZDogd2hpdGU7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1RyB7CiAgY29sb3I6IG9yYW5nZTsKfS55bTd1QkJ1SCB7CiAgY29sb3I6IG9saXZlOwp9LnltN3VCQnVJIHsKICBjb2xvcjogY3JpbXNvbjsKfS55bTd1QkJ1SiB7CiAgY29sb3I6IG5hdnk7Cn0=";
+import "data:text/css;base64,LnltN3VCQnUxIHsKICBjb2xvcjogcmVkOwp9LnltN3VCQnUyIHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1MyB7CiAgZm9udC1zaXplOiAycmVtOwp9LnltN3VCQnU0IHsKICBjb2xvcjogdmFyKC0teW03dUJCdTUpOwp9LnltN3VCQnU2IHsKICBjb2xvcjogZ3JlZW47Cn0ueW03dUJCdTcgewogIGNvbG9yOiB5ZWxsb3c7Cn0ueW03dUJCdTggewogIGNvbG9yOiBzaWx2ZXI7Cn0ueW03dUJCdTkgewogIGNvbG9yOiBnb2xkOwp9LnltN3VCQnVBIHsKICBjb2xvcjogaXZvcnk7Cn0ueW03dUJCdUIgewogIGNvbG9yOiBwaW5rOwp9LnltN3VCQnVDIHsKICBjb2xvcjogcGVydTsKfS55bTd1QkJ1RCB7CiAgY29sb3I6IHBsdW07Cn0ueW03dUJCdUUgewogIGNvbG9yOiBncmF5Owp9LnltN3VCQnVGIHsKICBjb2xvcjogdGVhbDsKfS55bTd1QkJ1RyB7CiAgY29sb3I6IGJyb3duOwp9LnltN3VCQnVIIHsKICBiYWNrZ3JvdW5kOiB3aGl0ZTsKICBjb2xvcjogcmVkOwp9LnltN3VCQnVJIHsKICBjb2xvcjogb3JhbmdlOwp9LnltN3VCQnVKIHsKICBjb2xvcjogb2xpdmU7Cn0ueW03dUJCdUsgewogIGNvbG9yOiBjcmltc29uOwp9LnltN3VCQnVMIHsKICBjb2xvcjogbmF2eTsKfQ==";
 const someRef = {
     current: null
 } as any;
@@ -76,31 +76,42 @@ let Mutable = /*YAK Extracted CSS:
   color: pink;
 }
 */ /*#__PURE__*/ __yak.__yak_div("ym7uBBuB");
-// folds although the declaration comes after the usage
-const Early = ()=><p className="ym7uBBuC">before declaration</p>;
-const Late = /*YAK Extracted CSS:
+// bails: var redeclaration - both declarations share a single binding
+var Redeclared = /*YAK Extracted CSS:
 .ym7uBBuC {
+  color: peru;
+}
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuC");
+var Redeclared = /*YAK Extracted CSS:
+.ym7uBBuD {
+  color: plum;
+}
+*/ /*#__PURE__*/ __yak.__yak_span("ym7uBBuD");
+// folds although the declaration comes after the usage
+const Early = ()=><p className="ym7uBBuE">before declaration</p>;
+const Late = /*YAK Extracted CSS:
+.ym7uBBuE {
   color: gray;
 }
-*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuC");
+*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuE");
 // bails: wrapped in an HOC - folding would drop the wrapper
 const Memoized = memo(/*YAK Extracted CSS:
-.ym7uBBuD {
+.ym7uBBuF {
   color: teal;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuD"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuF"));
 // folds: type casts are unwrapped
 const Cast = /*YAK Extracted CSS:
-.ym7uBBuE {
+.ym7uBBuG {
   color: brown;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuE") as unknown as typeof Card;
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuG") as unknown as typeof Card;
 const BoxWithMixin = /*YAK Extracted CSS:
-.ym7uBBuF {
+.ym7uBBuH {
   background: white;
   color: red;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuF");
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuH");
 const Optimizable = ({ active }: {
     active?: boolean;
 })=><>
@@ -114,38 +125,38 @@ const Optimizable = ({ active }: {
     <div className={__yak_mergeClassNames("ym7uBBu1", active && "active")}>runtime class name merge</div>
     <div $foo="forwarded" className="ym7uBBu1">$props are not filtered</div>
     <div className={/*YAK Extracted CSS:
-.ym7uBBuG {
+.ym7uBBuI {
   color: orange;
 }
-*/ /*#__PURE__*/ "ym7uBBu1 ym7uBBuG"}>
+*/ /*#__PURE__*/ "ym7uBBu1 ym7uBBuI"}>
       css prop merge
     </div>
     <div className="ym7uBBu1">
       <section className="ym7uBBu2"/>
     </div>
     <h1 className="ym7uBBu3">folds</h1>
-    <div className="ym7uBBuE">folds through the type cast</div>
+    <div className="ym7uBBuG">folds through the type cast</div>
     <Card className="ym7uBBu7">folds to the wrapped component</Card>
     <Card className="ym7uBBu7 user">merges into the wrapped component</Card>
     <ImportedCard className="ym7uBBu8">folds to the imported component</ImportedCard>
-    <div className="ym7uBBuF">folds with mixin</div>
+    <div className="ym7uBBuH">folds with mixin</div>
   </>;
 // bails: wrapped in React.memo - the HOC result must not fold to a bare DOM element
 const ReactMemoized = React.memo(/*YAK Extracted CSS:
-.ym7uBBuH {
+.ym7uBBuJ {
   color: olive;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuH"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuJ"));
 // bails: conditional initializer - the branch is only known at runtime
 const Conditional = props.flag ? /*YAK Extracted CSS:
-.ym7uBBuI {
+.ym7uBBuK {
   color: crimson;
 }
-*/ /*#__PURE__*/ __yak.__yak_a("ym7uBBuI") : /*YAK Extracted CSS:
-.ym7uBBuJ {
+*/ /*#__PURE__*/ __yak.__yak_a("ym7uBBuK") : /*YAK Extracted CSS:
+.ym7uBBuL {
   color: navy;
 }
-*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBuJ");
+*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBuL");
 const NotOptimizable = ()=><>
     <Card {...props}>bails: spread</Card>
     <Card theme={props.theme}>bails: theme</Card>
@@ -155,6 +166,7 @@ const NotOptimizable = ()=><>
     <ExtendedLowercase>bails: lowercase wrapped component</ExtendedLowercase>
     <ExtendedMutable>bails: reassignable wrapped component</ExtendedMutable>
     <Mutable>bails</Mutable>
+    <Redeclared>bails: var redeclaration</Redeclared>
     <Memoized>bails: HOC wrapper</Memoized>
     <ReactMemoized>bails: HOC wrapper</ReactMemoized>
     <Conditional>bails: conditional initializer</Conditional></>;


### PR DESCRIPTION
`var Card = styled.div`…`; var Card = styled.span`…`;` is legal — both declarations share one binding, so the same id got registered twice and tripped `debug_assert!(previous.is_none())`. Release builds compile the assert out (and `immutable_bindings` filters `var` anyway), so users aren't affected, but it panics `cargo test` on legal input.

Now the declarator init span is only recorded for `const`, which is exactly what `immutable_bindings` accepts later — verified zero folds lost by regenerating the snapshots against the unchanged input (byte-identical). Added the `var` redeclaration case to the folding fixture; it panics without the fix.

Finding (15) from the perf-stack review.