### PR TITLE
Don't substitute key into folded style expressions

### DIFF
--- a/packages/yak-swc/yak_swc/src/utils/styled_jsx_fold.rs
+++ b/packages/yak-swc/yak_swc/src/utils/styled_jsx_fold.rs
@@ -593,8 +593,15 @@ fn inline_expression(
 
 /// The runtime passes more than the plain attributes to the class-toggling
 /// expressions - these props can not be substituted from the JSX attributes
+///
+/// `key` is listed for the opposite reason: React strips it before the
+/// component sees props, so the runtime path reads `undefined` while a
+/// substituted fold would see the attribute value - reading it must bail
 fn is_runtime_injected_prop(name: &Atom) -> bool {
-  matches!(name.as_ref(), "theme" | "children" | "className" | "style")
+  matches!(
+    name.as_ref(),
+    "theme" | "children" | "className" | "style" | "key"
+  )
 }
 
 /// Maps the attribute names to their value expressions for substitution

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/input.tsx
@@ -82,6 +82,12 @@ const ClassNameBail = styled.div`
   ${({ className }) => className && css`color: red;`}
 `;
 
+// usages bail: React strips key before the component sees props, so the
+// runtime reads undefined - substituting the attribute value would diverge
+const KeyBail = styled.li`
+  ${({ key }) => key === "active" && css`color: red;`}
+`;
+
 // folds: identifier param with member access - `(p) => p.$x` is the common
 // real-world styled-components style
 const MemberButton = styled.button<{
@@ -109,6 +115,17 @@ const MemberTheme = styled.div<{ $accent?: boolean }>`
 // usages bail: computed member access
 const MemberComputed = styled.div<{ $active?: boolean }>`
   ${(p) => p["$active"] && css`color: red;`}
+`;
+
+// usages bail: key access through the identifier param
+const MemberKey = styled.li`
+  ${(p) => p.key === "active" && css`color: red;`}
+`;
+
+// folds: passing key at a call site never blocks folding - only reading it
+// inside a style expression does
+const KeyedRow = styled.li<{ $active?: boolean }>`
+  ${(p) => p.$active && css`color: red;`}
 `;
 
 const Optimizable = ({ active, size, i }: { active?: boolean; size?: string, i: number }) => (
@@ -145,6 +162,9 @@ const Optimizable = ({ active, size, i }: { active?: boolean; size?: string, i: 
     <MemberButton $active={i % 4 !== 0} $fullWidth={i % 3 === 0} $variant="primary">
       {i}
     </MemberButton>
+    <KeyedRow key={i} $active={active}>
+      key at the call site still folds
+    </KeyedRow>
   </>
 );
 
@@ -163,5 +183,7 @@ const NotOptimizable = () => (
     <MemberEscape $active>bails: whole props object escapes</MemberEscape>
     <MemberTheme $accent>bails: theme access</MemberTheme>
     <MemberComputed $active>bails: computed member access</MemberComputed>
+    <KeyBail key="active">bails: destructured key access</KeyBail>
+    <MemberKey key="active">bails: key access</MemberKey>
   </>
 );

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.dev.tsx
@@ -129,6 +129,15 @@ const ClassNameBail = /*YAK Extracted CSS:
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_ClassNameBail_m7uBBu", ({ className })=>className && /*#__PURE__*/ css("input_ClassNameBail__className_m7uBBu")), {
     "displayName": "ClassNameBail"
 });
+// usages bail: React strips key before the component sees props, so the
+// runtime reads undefined - substituting the attribute value would diverge
+const KeyBail = /*YAK Extracted CSS:
+:global(.input_KeyBail___m7uBBu) {
+  color: red;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_li("input_KeyBail_m7uBBu", ({ key })=>key === "active" && /*#__PURE__*/ css("input_KeyBail___m7uBBu")), {
+    "displayName": "KeyBail"
+});
 // folds: identifier param with member access - `(p) => p.$x` is the common
 // real-world styled-components style
 const MemberButton = /*YAK Extracted CSS:
@@ -174,6 +183,23 @@ const MemberComputed = /*YAK Extracted CSS:
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_MemberComputed_m7uBBu", (p)=>p["$active"] && /*#__PURE__*/ css("input_MemberComputed___m7uBBu")), {
     "displayName": "MemberComputed"
 });
+// usages bail: key access through the identifier param
+const MemberKey = /*YAK Extracted CSS:
+:global(.input_MemberKey___m7uBBu) {
+  color: red;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_li("input_MemberKey_m7uBBu", (p)=>p.key === "active" && /*#__PURE__*/ css("input_MemberKey___m7uBBu")), {
+    "displayName": "MemberKey"
+});
+// folds: passing key at a call site never blocks folding - only reading it
+// inside a style expression does
+const KeyedRow = /*YAK Extracted CSS:
+:global(.input_KeyedRow__p_\$active_m7uBBu) {
+  color: red;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_li("input_KeyedRow_m7uBBu", (p)=>p.$active && /*#__PURE__*/ css("input_KeyedRow__p_$active_m7uBBu")), {
+    "displayName": "KeyedRow"
+});
 const Optimizable = ({ active, size, i: i1 }: {
     active?: boolean;
     size?: string;
@@ -210,6 +236,9 @@ const Optimizable = ({ active, size, i: i1 }: {
     <button className={"input_MemberButton_m7uBBu" + (!(i1 % 4 !== 0) ? " input_MemberButton___m7uBBu" : "") + ("primary" === "secondary" ? " input_MemberButton___m7uBBu-01" : "") + ("primary" === "ghost" ? " input_MemberButton___m7uBBu-02" : "") + (i1 % 3 === 0 ? " input_MemberButton__p_$fullWidth_m7uBBu" : "")}>
       {i1}
     </button>
+    <li key={i1} className={"input_KeyedRow_m7uBBu" + (active ? " input_KeyedRow__p_$active_m7uBBu" : "")}>
+      key at the call site still folds
+    </li>
   </>;
 const NotOptimizable = ()=><>
     <IconContainer {...props}>bails: spread</IconContainer>
@@ -225,4 +254,6 @@ const NotOptimizable = ()=><>
     <MemberEscape $active>bails: whole props object escapes</MemberEscape>
     <MemberTheme $accent>bails: theme access</MemberTheme>
     <MemberComputed $active>bails: computed member access</MemberComputed>
+    <KeyBail key="active">bails: destructured key access</KeyBail>
+    <MemberKey key="active">bails: key access</MemberKey>
   </>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.prod.tsx
@@ -107,43 +107,63 @@ const ClassNameBail = /*YAK Extracted CSS:
   color: red;
 }
 */ /*#__PURE__*/ __yak.__yak_div("ym7uBBuN", ({ className })=>className && /*#__PURE__*/ css("ym7uBBuO"));
+// usages bail: React strips key before the component sees props, so the
+// runtime reads undefined - substituting the attribute value would diverge
+const KeyBail = /*YAK Extracted CSS:
+:global(.ym7uBBuQ) {
+  color: red;
+}
+*/ /*#__PURE__*/ __yak.__yak_li("ym7uBBuP", ({ key })=>key === "active" && /*#__PURE__*/ css("ym7uBBuQ"));
 // folds: identifier param with member access - `(p) => p.$x` is the common
 // real-world styled-components style
 const MemberButton = /*YAK Extracted CSS:
-:global(.ym7uBBuP) {
+:global(.ym7uBBuR) {
   display: inline-flex;
 }
-:global(.ym7uBBuQ) {
+:global(.ym7uBBuS) {
   background-color: #d1d5db;
 }
-:global(.ym7uBBuR) {
+:global(.ym7uBBuT) {
   background-color: #f3f4f6;
 }
-:global(.ym7uBBuS) {
+:global(.ym7uBBuU) {
   background-color: transparent;
 }
-:global(.ym7uBBuT) {
+:global(.ym7uBBuV) {
   width: 100%;
 }
-*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBuP", (p)=>!p.$active && /*#__PURE__*/ css("ym7uBBuQ"), (p)=>p.$variant === "secondary" && /*#__PURE__*/ css("ym7uBBuR"), (p)=>p.$variant === "ghost" && /*#__PURE__*/ css("ym7uBBuS"), (p)=>p.$fullWidth && /*#__PURE__*/ css("ym7uBBuT"));
+*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBuR", (p)=>!p.$active && /*#__PURE__*/ css("ym7uBBuS"), (p)=>p.$variant === "secondary" && /*#__PURE__*/ css("ym7uBBuT"), (p)=>p.$variant === "ghost" && /*#__PURE__*/ css("ym7uBBuU"), (p)=>p.$fullWidth && /*#__PURE__*/ css("ym7uBBuV"));
 // usages bail: the whole props object escapes into the function call
 const MemberEscape = /*YAK Extracted CSS:
-:global(.ym7uBBuV) {
-  color: red;
-}
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuU", (p)=>props.calculate(p) && /*#__PURE__*/ css("ym7uBBuV"));
-// usages bail: theme access through the identifier param
-const MemberTheme = /*YAK Extracted CSS:
 :global(.ym7uBBuX) {
   color: red;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuW", (p)=>p.theme.highContrast && p.$accent && /*#__PURE__*/ css("ym7uBBuX"));
-// usages bail: computed member access
-const MemberComputed = /*YAK Extracted CSS:
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuW", (p)=>props.calculate(p) && /*#__PURE__*/ css("ym7uBBuX"));
+// usages bail: theme access through the identifier param
+const MemberTheme = /*YAK Extracted CSS:
 :global(.ym7uBBuZ) {
   color: red;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuY", (p)=>p["$active"] && /*#__PURE__*/ css("ym7uBBuZ"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuY", (p)=>p.theme.highContrast && p.$accent && /*#__PURE__*/ css("ym7uBBuZ"));
+// usages bail: computed member access
+const MemberComputed = /*YAK Extracted CSS:
+:global(.ym7uBBub) {
+  color: red;
+}
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBua", (p)=>p["$active"] && /*#__PURE__*/ css("ym7uBBub"));
+// usages bail: key access through the identifier param
+const MemberKey = /*YAK Extracted CSS:
+:global(.ym7uBBud) {
+  color: red;
+}
+*/ /*#__PURE__*/ __yak.__yak_li("ym7uBBuc", (p)=>p.key === "active" && /*#__PURE__*/ css("ym7uBBud"));
+// folds: passing key at a call site never blocks folding - only reading it
+// inside a style expression does
+const KeyedRow = /*YAK Extracted CSS:
+:global(.ym7uBBuf) {
+  color: red;
+}
+*/ /*#__PURE__*/ __yak.__yak_li("ym7uBBue", (p)=>p.$active && /*#__PURE__*/ css("ym7uBBuf"));
 const Optimizable = ({ active, size, i: i1 }: {
     active?: boolean;
     size?: string;
@@ -163,10 +183,10 @@ const Optimizable = ({ active, size, i: i1 }: {
       runtime class merge
     </span>
     <span className={"ym7uBBu" + (true ? " ym7uBBu1" : "") + /*YAK Extracted CSS:
-:global(.ym7uBBua) {
+:global(.ym7uBBug) {
   color: orange;
 }
-*/ /*#__PURE__*/ " ym7uBBua"}>
+*/ /*#__PURE__*/ " ym7uBBug"}>
       css prop merge
     </span>
     <p className={"ym7uBBu2" + ("primary" === "primary" ? " ym7uBBu3" : " ym7uBBu4") + (true ? " ym7uBBu5" : "")}>
@@ -177,9 +197,12 @@ const Optimizable = ({ active, size, i: i1 }: {
     <li className={"ym7uBBuA" + (size && size === "big" ? " ym7uBBuB" : "")}>safe to duplicate</li>
     <button disabled={active} className={"ym7uBBuC" + (!active ? " ym7uBBuD" : "")}>kept on the element and inlined</button>
     <button disabled className={"ym7uBBuC" + (!true ? " ym7uBBuD" : "")}>bare non-$ prop</button>
-    <button className={"ym7uBBuP" + (!(i1 % 4 !== 0) ? " ym7uBBuQ" : "") + ("primary" === "secondary" ? " ym7uBBuR" : "") + ("primary" === "ghost" ? " ym7uBBuS" : "") + (i1 % 3 === 0 ? " ym7uBBuT" : "")}>
+    <button className={"ym7uBBuR" + (!(i1 % 4 !== 0) ? " ym7uBBuS" : "") + ("primary" === "secondary" ? " ym7uBBuT" : "") + ("primary" === "ghost" ? " ym7uBBuU" : "") + (i1 % 3 === 0 ? " ym7uBBuV" : "")}>
       {i1}
     </button>
+    <li key={i1} className={"ym7uBBue" + (active ? " ym7uBBuf" : "")}>
+      key at the call site still folds
+    </li>
   </>;
 const NotOptimizable = ()=><>
     <IconContainer {...props}>bails: spread</IconContainer>
@@ -195,4 +218,6 @@ const NotOptimizable = ()=><>
     <MemberEscape $active>bails: whole props object escapes</MemberEscape>
     <MemberTheme $accent>bails: theme access</MemberTheme>
     <MemberComputed $active>bails: computed member access</MemberComputed>
+    <KeyBail key="active">bails: destructured key access</KeyBail>
+    <MemberKey key="active">bails: key access</MemberKey>
   </>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.turbo.dev.tsx
@@ -1,7 +1,7 @@
 import { css, styled, __yak_unitPostFix, __yak_mergeClassNames } from "next-yak/internal";
 import { ImportedCard } from "./imported-card";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LmlucHV0X0ljb25Db250YWluZXJfbTd1QkJ1IHsKICBkaXNwbGF5OiBmbGV4OwogIG1pbi1oZWlnaHQ6IDI0cHg7Cn0KLmlucHV0X0ljb25Db250YWluZXJfX1wkaGFzQ2hpbGRyZW5fbTd1QkJ1IHsKICBtYXJnaW4tcmlnaHQ6IDEycHg7Cn0uaW5wdXRfTWFueV9tN3VCQnUgewogIGNvbG9yOiBibGFjazsKfQouaW5wdXRfTWFueV9fX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfQouaW5wdXRfTWFueV9fX203dUJCdS0wMSB7CiAgY29sb3I6IGJsdWU7Cn0KLmlucHV0X01hbnlfX1wkYm9sZF9tN3VCQnUgewogIGZvbnQtd2VpZ2h0OiBib2xkOwp9LmlucHV0X0ZuX203dUJCdSB7CiAgY29sb3I6IGdyYXk7Cn0KLmlucHV0X0ZuX19cJG9uX203dUJCdSB7CiAgY29sb3I6IGJsYWNrOwp9LmlucHV0X1Njb3BlZF9tN3VCQnUgewogIGNvbG9yOiBncmVlbjsKfQouaW5wdXRfU2NvcGVkX19pc0NvbXBhY3RfbTd1QkJ1IHsKICBsaW5lLWhlaWdodDogMTsKfS5pbnB1dF9Ud2ljZV9tN3VCQnUgewogIHBhZGRpbmc6IDFweDsKfQouaW5wdXRfVHdpY2VfX19tN3VCQnUgewogIHBhZGRpbmc6IDhweDsKfS5pbnB1dF9BY3Rpb25CdXR0b25fbTd1QkJ1IHsKICBjb2xvcjogYmx1ZTsKfQouaW5wdXRfQWN0aW9uQnV0dG9uX19fbTd1QkJ1IHsKICBjdXJzb3I6IHBvaW50ZXI7Cn0uaW5wdXRfVGhlbWVkX203dUJCdSB7CiAgY29sb3I6IGJsYWNrOwp9Ci5pbnB1dF9UaGVtZWRfX19tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfTmVzdGVkQ3NzVmFyaWFibGVfX1wkYWN0aXZlX203dUJCdSB7CiAgd2lkdGg6IHZhcigtLWlucHV0X05lc3RlZENzc1ZhcmlhYmxlX193aWR0aF9tN3VCQnUpOwp9LmlucHV0X0R5bmFtaWNFeHRlbmRlZF9fXCRhY3RpdmVfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0R5bmFtaWNBdHRyc19fXCRhY3RpdmVfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0NsYXNzTmFtZUJhaWxfX2NsYXNzTmFtZV9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfTWVtYmVyQnV0dG9uX203dUJCdSB7CiAgZGlzcGxheTogaW5saW5lLWZsZXg7Cn0KLmlucHV0X01lbWJlckJ1dHRvbl9fX203dUJCdSB7CiAgYmFja2dyb3VuZC1jb2xvcjogI2QxZDVkYjsKfQouaW5wdXRfTWVtYmVyQnV0dG9uX19fbTd1QkJ1LTAxIHsKICBiYWNrZ3JvdW5kLWNvbG9yOiAjZjNmNGY2Owp9Ci5pbnB1dF9NZW1iZXJCdXR0b25fX19tN3VCQnUtMDIgewogIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50Owp9Ci5pbnB1dF9NZW1iZXJCdXR0b25fX3BfXCRmdWxsV2lkdGhfbTd1QkJ1IHsKICB3aWR0aDogMTAwJTsKfS5pbnB1dF9NZW1iZXJFc2NhcGVfX19tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfTWVtYmVyVGhlbWVfX19tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfTWVtYmVyQ29tcHV0ZWRfX19tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfT3B0aW1pemFibGVfbTd1QkJ1IHsKICBjb2xvcjogb3JhbmdlOwp9";
+import "data:text/css;base64,LmlucHV0X0ljb25Db250YWluZXJfbTd1QkJ1IHsKICBkaXNwbGF5OiBmbGV4OwogIG1pbi1oZWlnaHQ6IDI0cHg7Cn0KLmlucHV0X0ljb25Db250YWluZXJfX1wkaGFzQ2hpbGRyZW5fbTd1QkJ1IHsKICBtYXJnaW4tcmlnaHQ6IDEycHg7Cn0uaW5wdXRfTWFueV9tN3VCQnUgewogIGNvbG9yOiBibGFjazsKfQouaW5wdXRfTWFueV9fX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfQouaW5wdXRfTWFueV9fX203dUJCdS0wMSB7CiAgY29sb3I6IGJsdWU7Cn0KLmlucHV0X01hbnlfX1wkYm9sZF9tN3VCQnUgewogIGZvbnQtd2VpZ2h0OiBib2xkOwp9LmlucHV0X0ZuX203dUJCdSB7CiAgY29sb3I6IGdyYXk7Cn0KLmlucHV0X0ZuX19cJG9uX203dUJCdSB7CiAgY29sb3I6IGJsYWNrOwp9LmlucHV0X1Njb3BlZF9tN3VCQnUgewogIGNvbG9yOiBncmVlbjsKfQouaW5wdXRfU2NvcGVkX19pc0NvbXBhY3RfbTd1QkJ1IHsKICBsaW5lLWhlaWdodDogMTsKfS5pbnB1dF9Ud2ljZV9tN3VCQnUgewogIHBhZGRpbmc6IDFweDsKfQouaW5wdXRfVHdpY2VfX19tN3VCQnUgewogIHBhZGRpbmc6IDhweDsKfS5pbnB1dF9BY3Rpb25CdXR0b25fbTd1QkJ1IHsKICBjb2xvcjogYmx1ZTsKfQouaW5wdXRfQWN0aW9uQnV0dG9uX19fbTd1QkJ1IHsKICBjdXJzb3I6IHBvaW50ZXI7Cn0uaW5wdXRfVGhlbWVkX203dUJCdSB7CiAgY29sb3I6IGJsYWNrOwp9Ci5pbnB1dF9UaGVtZWRfX19tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfTmVzdGVkQ3NzVmFyaWFibGVfX1wkYWN0aXZlX203dUJCdSB7CiAgd2lkdGg6IHZhcigtLWlucHV0X05lc3RlZENzc1ZhcmlhYmxlX193aWR0aF9tN3VCQnUpOwp9LmlucHV0X0R5bmFtaWNFeHRlbmRlZF9fXCRhY3RpdmVfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0R5bmFtaWNBdHRyc19fXCRhY3RpdmVfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0NsYXNzTmFtZUJhaWxfX2NsYXNzTmFtZV9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfS2V5QmFpbF9fX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9NZW1iZXJCdXR0b25fbTd1QkJ1IHsKICBkaXNwbGF5OiBpbmxpbmUtZmxleDsKfQouaW5wdXRfTWVtYmVyQnV0dG9uX19fbTd1QkJ1IHsKICBiYWNrZ3JvdW5kLWNvbG9yOiAjZDFkNWRiOwp9Ci5pbnB1dF9NZW1iZXJCdXR0b25fX19tN3VCQnUtMDEgewogIGJhY2tncm91bmQtY29sb3I6ICNmM2Y0ZjY7Cn0KLmlucHV0X01lbWJlckJ1dHRvbl9fX203dUJCdS0wMiB7CiAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7Cn0KLmlucHV0X01lbWJlckJ1dHRvbl9fcF9cJGZ1bGxXaWR0aF9tN3VCQnUgewogIHdpZHRoOiAxMDAlOwp9LmlucHV0X01lbWJlckVzY2FwZV9fX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9NZW1iZXJUaGVtZV9fX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9NZW1iZXJDb21wdXRlZF9fX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9NZW1iZXJLZXlfX19tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfS2V5ZWRSb3dfX3BfXCRhY3RpdmVfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X09wdGltaXphYmxlX203dUJCdSB7CiAgY29sb3I6IG9yYW5nZTsKfQ==";
 const props = {} as any;
 // folds: the class-toggling expression is inlined at the usage
 const IconContainer = /*YAK Extracted CSS:
@@ -129,6 +129,15 @@ const ClassNameBail = /*YAK Extracted CSS:
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_ClassNameBail_m7uBBu", ({ className })=>className && /*#__PURE__*/ css("input_ClassNameBail__className_m7uBBu")), {
     "displayName": "ClassNameBail"
 });
+// usages bail: React strips key before the component sees props, so the
+// runtime reads undefined - substituting the attribute value would diverge
+const KeyBail = /*YAK Extracted CSS:
+.input_KeyBail___m7uBBu {
+  color: red;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_li("input_KeyBail_m7uBBu", ({ key })=>key === "active" && /*#__PURE__*/ css("input_KeyBail___m7uBBu")), {
+    "displayName": "KeyBail"
+});
 // folds: identifier param with member access - `(p) => p.$x` is the common
 // real-world styled-components style
 const MemberButton = /*YAK Extracted CSS:
@@ -174,6 +183,23 @@ const MemberComputed = /*YAK Extracted CSS:
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_MemberComputed_m7uBBu", (p)=>p["$active"] && /*#__PURE__*/ css("input_MemberComputed___m7uBBu")), {
     "displayName": "MemberComputed"
 });
+// usages bail: key access through the identifier param
+const MemberKey = /*YAK Extracted CSS:
+.input_MemberKey___m7uBBu {
+  color: red;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_li("input_MemberKey_m7uBBu", (p)=>p.key === "active" && /*#__PURE__*/ css("input_MemberKey___m7uBBu")), {
+    "displayName": "MemberKey"
+});
+// folds: passing key at a call site never blocks folding - only reading it
+// inside a style expression does
+const KeyedRow = /*YAK Extracted CSS:
+.input_KeyedRow__p_\$active_m7uBBu {
+  color: red;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_li("input_KeyedRow_m7uBBu", (p)=>p.$active && /*#__PURE__*/ css("input_KeyedRow__p_$active_m7uBBu")), {
+    "displayName": "KeyedRow"
+});
 const Optimizable = ({ active, size, i: i1 }: {
     active?: boolean;
     size?: string;
@@ -210,6 +236,9 @@ const Optimizable = ({ active, size, i: i1 }: {
     <button className={"input_MemberButton_m7uBBu" + (!(i1 % 4 !== 0) ? " input_MemberButton___m7uBBu" : "") + ("primary" === "secondary" ? " input_MemberButton___m7uBBu-01" : "") + ("primary" === "ghost" ? " input_MemberButton___m7uBBu-02" : "") + (i1 % 3 === 0 ? " input_MemberButton__p_$fullWidth_m7uBBu" : "")}>
       {i1}
     </button>
+    <li key={i1} className={"input_KeyedRow_m7uBBu" + (active ? " input_KeyedRow__p_$active_m7uBBu" : "")}>
+      key at the call site still folds
+    </li>
   </>;
 const NotOptimizable = ()=><>
     <IconContainer {...props}>bails: spread</IconContainer>
@@ -225,4 +254,6 @@ const NotOptimizable = ()=><>
     <MemberEscape $active>bails: whole props object escapes</MemberEscape>
     <MemberTheme $accent>bails: theme access</MemberTheme>
     <MemberComputed $active>bails: computed member access</MemberComputed>
+    <KeyBail key="active">bails: destructured key access</KeyBail>
+    <MemberKey key="active">bails: key access</MemberKey>
   </>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.turbo.prod.tsx
@@ -1,7 +1,7 @@
 import { css, styled, __yak_unitPostFix, __yak_mergeClassNames } from "next-yak/internal";
 import { ImportedCard } from "./imported-card";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LnltN3VCQnUgewogIGRpc3BsYXk6IGZsZXg7CiAgbWluLWhlaWdodDogMjRweDsKfQoueW03dUJCdTEgewogIG1hcmdpbi1yaWdodDogMTJweDsKfS55bTd1QkJ1MiB7CiAgY29sb3I6IGJsYWNrOwp9Ci55bTd1QkJ1MyB7CiAgY29sb3I6IHJlZDsKfQoueW03dUJCdTQgewogIGNvbG9yOiBibHVlOwp9Ci55bTd1QkJ1NSB7CiAgZm9udC13ZWlnaHQ6IGJvbGQ7Cn0ueW03dUJCdTYgewogIGNvbG9yOiBncmF5Owp9Ci55bTd1QkJ1NyB7CiAgY29sb3I6IGJsYWNrOwp9LnltN3VCQnU4IHsKICBjb2xvcjogZ3JlZW47Cn0KLnltN3VCQnU5IHsKICBsaW5lLWhlaWdodDogMTsKfS55bTd1QkJ1QSB7CiAgcGFkZGluZzogMXB4Owp9Ci55bTd1QkJ1QiB7CiAgcGFkZGluZzogOHB4Owp9LnltN3VCQnVDIHsKICBjb2xvcjogYmx1ZTsKfQoueW03dUJCdUQgewogIGN1cnNvcjogcG9pbnRlcjsKfS55bTd1QkJ1RSB7CiAgY29sb3I6IGJsYWNrOwp9Ci55bTd1QkJ1RiB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1SCB7CiAgd2lkdGg6IHZhcigtLXltN3VCQnVJKTsKfS55bTd1QkJ1SyB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1TSB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1TyB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1UCB7CiAgZGlzcGxheTogaW5saW5lLWZsZXg7Cn0KLnltN3VCQnVRIHsKICBiYWNrZ3JvdW5kLWNvbG9yOiAjZDFkNWRiOwp9Ci55bTd1QkJ1UiB7CiAgYmFja2dyb3VuZC1jb2xvcjogI2YzZjRmNjsKfQoueW03dUJCdVMgewogIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50Owp9Ci55bTd1QkJ1VCB7CiAgd2lkdGg6IDEwMCU7Cn0ueW03dUJCdVYgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdVggewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdVogewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdWEgewogIGNvbG9yOiBvcmFuZ2U7Cn0=";
+import "data:text/css;base64,LnltN3VCQnUgewogIGRpc3BsYXk6IGZsZXg7CiAgbWluLWhlaWdodDogMjRweDsKfQoueW03dUJCdTEgewogIG1hcmdpbi1yaWdodDogMTJweDsKfS55bTd1QkJ1MiB7CiAgY29sb3I6IGJsYWNrOwp9Ci55bTd1QkJ1MyB7CiAgY29sb3I6IHJlZDsKfQoueW03dUJCdTQgewogIGNvbG9yOiBibHVlOwp9Ci55bTd1QkJ1NSB7CiAgZm9udC13ZWlnaHQ6IGJvbGQ7Cn0ueW03dUJCdTYgewogIGNvbG9yOiBncmF5Owp9Ci55bTd1QkJ1NyB7CiAgY29sb3I6IGJsYWNrOwp9LnltN3VCQnU4IHsKICBjb2xvcjogZ3JlZW47Cn0KLnltN3VCQnU5IHsKICBsaW5lLWhlaWdodDogMTsKfS55bTd1QkJ1QSB7CiAgcGFkZGluZzogMXB4Owp9Ci55bTd1QkJ1QiB7CiAgcGFkZGluZzogOHB4Owp9LnltN3VCQnVDIHsKICBjb2xvcjogYmx1ZTsKfQoueW03dUJCdUQgewogIGN1cnNvcjogcG9pbnRlcjsKfS55bTd1QkJ1RSB7CiAgY29sb3I6IGJsYWNrOwp9Ci55bTd1QkJ1RiB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1SCB7CiAgd2lkdGg6IHZhcigtLXltN3VCQnVJKTsKfS55bTd1QkJ1SyB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1TSB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1TyB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1USB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1UiB7CiAgZGlzcGxheTogaW5saW5lLWZsZXg7Cn0KLnltN3VCQnVTIHsKICBiYWNrZ3JvdW5kLWNvbG9yOiAjZDFkNWRiOwp9Ci55bTd1QkJ1VCB7CiAgYmFja2dyb3VuZC1jb2xvcjogI2YzZjRmNjsKfQoueW03dUJCdVUgewogIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50Owp9Ci55bTd1QkJ1ViB7CiAgd2lkdGg6IDEwMCU7Cn0ueW03dUJCdVggewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdVogewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdWIgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdWQgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdWYgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdWcgewogIGNvbG9yOiBvcmFuZ2U7Cn0=";
 const props = {} as any;
 // folds: the class-toggling expression is inlined at the usage
 const IconContainer = /*YAK Extracted CSS:
@@ -107,43 +107,63 @@ const ClassNameBail = /*YAK Extracted CSS:
   color: red;
 }
 */ /*#__PURE__*/ __yak.__yak_div("ym7uBBuN", ({ className })=>className && /*#__PURE__*/ css("ym7uBBuO"));
+// usages bail: React strips key before the component sees props, so the
+// runtime reads undefined - substituting the attribute value would diverge
+const KeyBail = /*YAK Extracted CSS:
+.ym7uBBuQ {
+  color: red;
+}
+*/ /*#__PURE__*/ __yak.__yak_li("ym7uBBuP", ({ key })=>key === "active" && /*#__PURE__*/ css("ym7uBBuQ"));
 // folds: identifier param with member access - `(p) => p.$x` is the common
 // real-world styled-components style
 const MemberButton = /*YAK Extracted CSS:
-.ym7uBBuP {
+.ym7uBBuR {
   display: inline-flex;
 }
-.ym7uBBuQ {
+.ym7uBBuS {
   background-color: #d1d5db;
 }
-.ym7uBBuR {
+.ym7uBBuT {
   background-color: #f3f4f6;
 }
-.ym7uBBuS {
+.ym7uBBuU {
   background-color: transparent;
 }
-.ym7uBBuT {
+.ym7uBBuV {
   width: 100%;
 }
-*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBuP", (p)=>!p.$active && /*#__PURE__*/ css("ym7uBBuQ"), (p)=>p.$variant === "secondary" && /*#__PURE__*/ css("ym7uBBuR"), (p)=>p.$variant === "ghost" && /*#__PURE__*/ css("ym7uBBuS"), (p)=>p.$fullWidth && /*#__PURE__*/ css("ym7uBBuT"));
+*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBuR", (p)=>!p.$active && /*#__PURE__*/ css("ym7uBBuS"), (p)=>p.$variant === "secondary" && /*#__PURE__*/ css("ym7uBBuT"), (p)=>p.$variant === "ghost" && /*#__PURE__*/ css("ym7uBBuU"), (p)=>p.$fullWidth && /*#__PURE__*/ css("ym7uBBuV"));
 // usages bail: the whole props object escapes into the function call
 const MemberEscape = /*YAK Extracted CSS:
-.ym7uBBuV {
-  color: red;
-}
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuU", (p)=>props.calculate(p) && /*#__PURE__*/ css("ym7uBBuV"));
-// usages bail: theme access through the identifier param
-const MemberTheme = /*YAK Extracted CSS:
 .ym7uBBuX {
   color: red;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuW", (p)=>p.theme.highContrast && p.$accent && /*#__PURE__*/ css("ym7uBBuX"));
-// usages bail: computed member access
-const MemberComputed = /*YAK Extracted CSS:
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuW", (p)=>props.calculate(p) && /*#__PURE__*/ css("ym7uBBuX"));
+// usages bail: theme access through the identifier param
+const MemberTheme = /*YAK Extracted CSS:
 .ym7uBBuZ {
   color: red;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuY", (p)=>p["$active"] && /*#__PURE__*/ css("ym7uBBuZ"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuY", (p)=>p.theme.highContrast && p.$accent && /*#__PURE__*/ css("ym7uBBuZ"));
+// usages bail: computed member access
+const MemberComputed = /*YAK Extracted CSS:
+.ym7uBBub {
+  color: red;
+}
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBua", (p)=>p["$active"] && /*#__PURE__*/ css("ym7uBBub"));
+// usages bail: key access through the identifier param
+const MemberKey = /*YAK Extracted CSS:
+.ym7uBBud {
+  color: red;
+}
+*/ /*#__PURE__*/ __yak.__yak_li("ym7uBBuc", (p)=>p.key === "active" && /*#__PURE__*/ css("ym7uBBud"));
+// folds: passing key at a call site never blocks folding - only reading it
+// inside a style expression does
+const KeyedRow = /*YAK Extracted CSS:
+.ym7uBBuf {
+  color: red;
+}
+*/ /*#__PURE__*/ __yak.__yak_li("ym7uBBue", (p)=>p.$active && /*#__PURE__*/ css("ym7uBBuf"));
 const Optimizable = ({ active, size, i: i1 }: {
     active?: boolean;
     size?: string;
@@ -163,10 +183,10 @@ const Optimizable = ({ active, size, i: i1 }: {
       runtime class merge
     </span>
     <span className={"ym7uBBu" + (true ? " ym7uBBu1" : "") + /*YAK Extracted CSS:
-.ym7uBBua {
+.ym7uBBug {
   color: orange;
 }
-*/ /*#__PURE__*/ " ym7uBBua"}>
+*/ /*#__PURE__*/ " ym7uBBug"}>
       css prop merge
     </span>
     <p className={"ym7uBBu2" + ("primary" === "primary" ? " ym7uBBu3" : " ym7uBBu4") + (true ? " ym7uBBu5" : "")}>
@@ -177,9 +197,12 @@ const Optimizable = ({ active, size, i: i1 }: {
     <li className={"ym7uBBuA" + (size && size === "big" ? " ym7uBBuB" : "")}>safe to duplicate</li>
     <button disabled={active} className={"ym7uBBuC" + (!active ? " ym7uBBuD" : "")}>kept on the element and inlined</button>
     <button disabled className={"ym7uBBuC" + (!true ? " ym7uBBuD" : "")}>bare non-$ prop</button>
-    <button className={"ym7uBBuP" + (!(i1 % 4 !== 0) ? " ym7uBBuQ" : "") + ("primary" === "secondary" ? " ym7uBBuR" : "") + ("primary" === "ghost" ? " ym7uBBuS" : "") + (i1 % 3 === 0 ? " ym7uBBuT" : "")}>
+    <button className={"ym7uBBuR" + (!(i1 % 4 !== 0) ? " ym7uBBuS" : "") + ("primary" === "secondary" ? " ym7uBBuT" : "") + ("primary" === "ghost" ? " ym7uBBuU" : "") + (i1 % 3 === 0 ? " ym7uBBuV" : "")}>
       {i1}
     </button>
+    <li key={i1} className={"ym7uBBue" + (active ? " ym7uBBuf" : "")}>
+      key at the call site still folds
+    </li>
   </>;
 const NotOptimizable = ()=><>
     <IconContainer {...props}>bails: spread</IconContainer>
@@ -195,4 +218,6 @@ const NotOptimizable = ()=><>
     <MemberEscape $active>bails: whole props object escapes</MemberEscape>
     <MemberTheme $accent>bails: theme access</MemberTheme>
     <MemberComputed $active>bails: computed member access</MemberComputed>
+    <KeyBail key="active">bails: destructured key access</KeyBail>
+    <MemberKey key="active">bails: key access</MemberKey>
   </>;


### PR DESCRIPTION
React strips `key` before the component sees props, so `${(p) => p.key === activeId && css`…`}` reads `undefined` on the runtime path — but the fold substituted the JSX attribute value, so `<Item key="active" />` folded to `"active" === "active"` and applied styling the runtime path never would. Same source, different rendering depending on whether the usage folded, and foldability flips on unrelated edits.

Adding `key` to `is_runtime_injected_prop` reuses the existing bail-out: a style expression reading `key` just keeps the runtime wrapper, where React's stripping applies. Passing `key={…}` at a call site still folds — only *reading* it bails, so the cost is zero for real code. Fixtures cover both directions.

Finding (16) from the perf-stack review.