### PR TITLE
Fold nested empty css instead of bailing to the runtime

### DIFF
--- a/.changeset/drop-empty-css-prop.md
+++ b/.changeset/drop-empty-css-prop.md
@@ -2,4 +2,4 @@
 "yak-swc": patch
 ---
 
-Drop empty css props at build time instead of emitting a dead class name, e.g. `<div css={css``} />` becomes `<div />` and an empty ternary arm folds to `""`. A nested empty `` css`` `` also folds to an empty class name instead of keeping the whole css prop on the runtime merge path.
+Drop empty css props at build time instead of emitting a dead class name, e.g. `<div css={css``} />` becomes `<div />` and an empty ternary arm folds to `""`. A nested empty ` css` `` also folds to an empty class name instead of keeping the whole css prop on the runtime merge path.

--- a/.changeset/drop-empty-css-prop.md
+++ b/.changeset/drop-empty-css-prop.md
@@ -2,4 +2,4 @@
 "yak-swc": patch
 ---
 
-Drop empty css props at build time instead of emitting a dead class name, e.g. `<div css={css``} />` becomes `<div />` and an empty ternary arm folds to `""`.
+Drop empty css props at build time instead of emitting a dead class name, e.g. `<div css={css``} />` becomes `<div />` and an empty ternary arm folds to `""`. A nested empty `` css`` `` also folds to an empty class name instead of keeping the whole css prop on the runtime merge path.

--- a/packages/yak-swc/yak_swc/src/utils/class_name_fold.rs
+++ b/packages/yak-swc/yak_swc/src/utils/class_name_fold.rs
@@ -179,7 +179,18 @@ pub(crate) fn pure_static_css_class(expr: &Expr, yak_imports: &YakImports) -> Op
   let Expr::Call(call) = unwrap_type_casts(expr) else {
     return None;
   };
-  if !is_yak_css_callee(&call.callee, yak_imports) || call.args.len() != 1 {
+  if !is_yak_css_callee(&call.callee, yak_imports) {
+    return None;
+  }
+  // an argument-less css() carries neither a class name nor runtime content,
+  // so it contributes an empty class name - a nested empty `css``` compiles
+  // to this shape and folds instead of falling back to the runtime path
+  // (note the reverse does not hold: a top level mixin also compiles to a
+  // bare css(), its css is inlined into the consumer)
+  if call.args.is_empty() {
+    return Some("".into());
+  }
+  if call.args.len() != 1 {
     return None;
   }
   let arg = &call.args[0];
@@ -203,6 +214,10 @@ pub(crate) fn is_yak_css_callee(callee: &Callee, yak_imports: &YakImports) -> bo
 }
 
 pub(crate) fn with_leading_space(class_name: &Wtf8Atom) -> Wtf8Atom {
+  // an empty class name (from an empty `css``) contributes nothing
+  if class_name.is_empty() {
+    return "".into();
+  }
   format!(" {}", class_name.to_string_lossy()).into()
 }
 

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-ternary/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-ternary/input.tsx
@@ -70,3 +70,26 @@ const Elem4 = ({ active }: { active: boolean }) => {
     />
   );
 };
+
+// folds: a nested empty mixin contributes nothing instead of keeping the
+// whole css prop on the runtime path - the outer class is still minted as
+// the template carries dynamic content
+const Elem5 = ({ active }: { active: boolean }) => {
+  return <div css={css`${() => active && css``}`} />;
+};
+
+// folds: a nested empty ternary arm becomes an empty string
+const Elem6 = ({ active }: { active: boolean }) => {
+  return (
+    <div
+      css={css`
+        ${() =>
+          active
+            ? css``
+            : css`
+                color: blue;
+              `}
+      `}
+    />
+  );
+};

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-ternary/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-ternary/output.dev.tsx
@@ -61,3 +61,21 @@ const Elem4 = ({ active }: {
 }
 */ /*#__PURE__*/ "input_Elem4_m7uBBu-01"}/>;
 };
+// folds: a nested empty mixin contributes nothing instead of keeping the
+// whole css prop on the runtime path - the outer class is still minted as
+// the template carries dynamic content
+const Elem5 = ({ active }: {
+    active: boolean;
+})=>{
+    return <div className={/*#__PURE__*/ "input_Elem5_m7uBBu" + (active ? "" : "")}/>;
+};
+// folds: a nested empty ternary arm becomes an empty string
+const Elem6 = ({ active }: {
+    active: boolean;
+})=>{
+    return <div className={/*YAK Extracted CSS:
+:global(.input_Elem6__not_active_m7uBBu) {
+  color: blue;
+}
+*/ /*#__PURE__*/ "input_Elem6_m7uBBu" + (active ? "" : " input_Elem6__not_active_m7uBBu")}/>;
+};

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-ternary/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-ternary/output.prod.tsx
@@ -61,3 +61,21 @@ const Elem4 = ({ active }: {
 }
 */ /*#__PURE__*/ "ym7uBBu9"}/>;
 };
+// folds: a nested empty mixin contributes nothing instead of keeping the
+// whole css prop on the runtime path - the outer class is still minted as
+// the template carries dynamic content
+const Elem5 = ({ active }: {
+    active: boolean;
+})=>{
+    return <div className={/*#__PURE__*/ "ym7uBBuA" + (active ? "" : "")}/>;
+};
+// folds: a nested empty ternary arm becomes an empty string
+const Elem6 = ({ active }: {
+    active: boolean;
+})=>{
+    return <div className={/*YAK Extracted CSS:
+:global(.ym7uBBuE) {
+  color: blue;
+}
+*/ /*#__PURE__*/ "ym7uBBuC" + (active ? "" : " ym7uBBuE")}/>;
+};

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-ternary/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-ternary/output.turbo.dev.tsx
@@ -1,5 +1,5 @@
 import { css, __yak_unitPostFix, __yak_mergeCssProp } from "next-yak/internal";
-import "data:text/css;base64,LmlucHV0X0VsZW1fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0VsZW1fbTd1QkJ1LTAxIHsKICBjb2xvcjogYmx1ZTsKfS5pbnB1dF9FbGVtMl9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0KLmlucHV0X0VsZW0yX19iaWdfbTd1QkJ1IHsKICBmb250LXNpemU6IDIwcHg7Cn0uaW5wdXRfRWxlbTJfbTd1QkJ1LTAxIHsKICBjb2xvcjogYmx1ZTsKfS5pbnB1dF9FbGVtM19tN3VCQnUgewogIHdpZHRoOiB2YXIoLS1pbnB1dF9FbGVtM19fd2lkdGhfbTd1QkJ1KTsKfS5pbnB1dF9FbGVtM19tN3VCQnUtMDEgewogIGNvbG9yOiBibHVlOwp9LmlucHV0X0VsZW00X203dUJCdS0wMSB7CiAgY29sb3I6IGJsdWU7Cn0=";
+import "data:text/css;base64,LmlucHV0X0VsZW1fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0VsZW1fbTd1QkJ1LTAxIHsKICBjb2xvcjogYmx1ZTsKfS5pbnB1dF9FbGVtMl9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0KLmlucHV0X0VsZW0yX19iaWdfbTd1QkJ1IHsKICBmb250LXNpemU6IDIwcHg7Cn0uaW5wdXRfRWxlbTJfbTd1QkJ1LTAxIHsKICBjb2xvcjogYmx1ZTsKfS5pbnB1dF9FbGVtM19tN3VCQnUgewogIHdpZHRoOiB2YXIoLS1pbnB1dF9FbGVtM19fd2lkdGhfbTd1QkJ1KTsKfS5pbnB1dF9FbGVtM19tN3VCQnUtMDEgewogIGNvbG9yOiBibHVlOwp9LmlucHV0X0VsZW00X203dUJCdS0wMSB7CiAgY29sb3I6IGJsdWU7Cn0uaW5wdXRfRWxlbTZfX25vdF9hY3RpdmVfbTd1QkJ1IHsKICBjb2xvcjogYmx1ZTsKfQ==";
 // folds: both arms are fully static
 const Elem = ({ active }: {
     active: boolean;
@@ -60,4 +60,22 @@ const Elem4 = ({ active }: {
   color: blue;
 }
 */ /*#__PURE__*/ "input_Elem4_m7uBBu-01"}/>;
+};
+// folds: a nested empty mixin contributes nothing instead of keeping the
+// whole css prop on the runtime path - the outer class is still minted as
+// the template carries dynamic content
+const Elem5 = ({ active }: {
+    active: boolean;
+})=>{
+    return <div className={/*#__PURE__*/ "input_Elem5_m7uBBu" + (active ? "" : "")}/>;
+};
+// folds: a nested empty ternary arm becomes an empty string
+const Elem6 = ({ active }: {
+    active: boolean;
+})=>{
+    return <div className={/*YAK Extracted CSS:
+.input_Elem6__not_active_m7uBBu {
+  color: blue;
+}
+*/ /*#__PURE__*/ "input_Elem6_m7uBBu" + (active ? "" : " input_Elem6__not_active_m7uBBu")}/>;
 };

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-ternary/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-ternary/output.turbo.prod.tsx
@@ -1,5 +1,5 @@
 import { css, __yak_unitPostFix, __yak_mergeCssProp } from "next-yak/internal";
-import "data:text/css;base64,LnltN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdTEgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnUyIHsKICBjb2xvcjogcmVkOwp9Ci55bTd1QkJ1MyB7CiAgZm9udC1zaXplOiAyMHB4Owp9LnltN3VCQnU0IHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1NSB7CiAgd2lkdGg6IHZhcigtLXltN3VCQnU2KTsKfS55bTd1QkJ1NyB7CiAgY29sb3I6IGJsdWU7Cn0ueW03dUJCdTkgewogIGNvbG9yOiBibHVlOwp9";
+import "data:text/css;base64,LnltN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdTEgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnUyIHsKICBjb2xvcjogcmVkOwp9Ci55bTd1QkJ1MyB7CiAgZm9udC1zaXplOiAyMHB4Owp9LnltN3VCQnU0IHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1NSB7CiAgd2lkdGg6IHZhcigtLXltN3VCQnU2KTsKfS55bTd1QkJ1NyB7CiAgY29sb3I6IGJsdWU7Cn0ueW03dUJCdTkgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnVFIHsKICBjb2xvcjogYmx1ZTsKfQ==";
 // folds: both arms are fully static
 const Elem = ({ active }: {
     active: boolean;
@@ -60,4 +60,22 @@ const Elem4 = ({ active }: {
   color: blue;
 }
 */ /*#__PURE__*/ "ym7uBBu9"}/>;
+};
+// folds: a nested empty mixin contributes nothing instead of keeping the
+// whole css prop on the runtime path - the outer class is still minted as
+// the template carries dynamic content
+const Elem5 = ({ active }: {
+    active: boolean;
+})=>{
+    return <div className={/*#__PURE__*/ "ym7uBBuA" + (active ? "" : "")}/>;
+};
+// folds: a nested empty ternary arm becomes an empty string
+const Elem6 = ({ active }: {
+    active: boolean;
+})=>{
+    return <div className={/*YAK Extracted CSS:
+.ym7uBBuE {
+  color: blue;
+}
+*/ /*#__PURE__*/ "ym7uBBuC" + (active ? "" : " ym7uBBuE")}/>;
 };


### PR DESCRIPTION
A nested empty `css``` compiles to an argument-less `css()`, which `pure_static_css_class` rejected (it wanted exactly one arg), so `css={css`\${() => on && css``}`}` kept the whole prop on the runtime merge path — the same shape this PR already handles at the top level, one level down. Now it folds to an empty class name, and an empty class contributes `""` rather than a stray space.

Two notes from doing it:

Zero-arg `css()` is **not** uniquely the empty-template compile — a top-level mixin (`const m = css`color: red;``) compiles to a bare `css()` too, since its css is inlined into the consumer. Returning `""` is still right: an argument-less `css()` carries no class and no runtime either way. Comment says so.

The outer dead class still ships (`<div className={"yElem5" + (active ? "" : "")}`) — the template counts as having dynamic content, so `declarations.is_empty() && !has_dynamic_content` doesn't fire and the class gets minted. Pre-existing and unchanged by this PR; dropping it means touching the minting gate, so I left the changeset wording alone rather than claiming a dead class is gone when it isn't.

Finding (22) from the perf-stack review.