### PR TITLE
Pin css prop fold bail-out shapes

### DIFF
--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/input.tsx
@@ -1,0 +1,49 @@
+// Adversarial shapes for the css prop fold - fold_css_expr only folds css()
+// calls and ternaries, so teaching it Expr::Bin must not silently change
+// these
+import { css } from "next-yak";
+
+const mixin = css`
+  color: red;
+`;
+
+// bails: a top level `&&` is an Expr::Bin, not a css() call or a ternary
+// folding it naively drops the /*YAK Extracted CSS:*/ comment the loader
+// parses, which ships the component unstyled
+const LogicalAnd = ({ on }: { on: boolean }) => (
+  <div
+    css={
+      on &&
+      css`
+        color: blue;
+      `
+    }
+  />
+);
+
+// folds: several condition segments in one template concatenate
+const ManySegments = ({ a, b }: { a: boolean; b: boolean }) => (
+  <div
+    css={css`
+      color: black;
+      ${() =>
+        a &&
+        css`
+          color: red;
+        `}
+      ${() =>
+        b &&
+        css`
+          font-weight: bold;
+        `}
+    `}
+  />
+);
+
+// bails: a mixin reference is an Expr::Ident, not a css() call
+// this pins a known gap rather than the fold: the css prop does not inline a
+// mixin the way a template consumer `${mixin}` does, so `color: red` never
+// ships and this renders unstyled
+// (teaching the fold Expr::Ident would not change it - a mixin compiles to an
+// argument-less css(), which has no base class to fold)
+const MixinIdentifier = () => <div css={mixin} />;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.dev.tsx
@@ -1,0 +1,38 @@
+// Adversarial shapes for the css prop fold - fold_css_expr only folds css()
+// calls and ternaries, so teaching it Expr::Bin must not silently change
+// these
+import { css, __yak_mergeCssProp } from "next-yak/internal";
+import "./input.yak.module.css!=!./input?./input.yak.module.css";
+const mixin = /*#__PURE__*/ css();
+// bails: a top level `&&` is an Expr::Bin, not a css() call or a ternary
+// folding it naively drops the /*YAK Extracted CSS:*/ comment the loader
+// parses, which ships the component unstyled
+const LogicalAnd = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on && /*YAK Extracted CSS:
+:global(.input_LogicalAnd_m7uBBu) {
+  color: blue;
+}
+*/ /*#__PURE__*/ css("input_LogicalAnd_m7uBBu"))}/>;
+// folds: several condition segments in one template concatenate
+const ManySegments = ({ a, b }: {
+    a: boolean;
+    b: boolean;
+})=><div className={/*YAK Extracted CSS:
+:global(.input_ManySegments_m7uBBu) {
+  color: black;
+}
+:global(.input_ManySegments__a_m7uBBu) {
+  color: red;
+}
+:global(.input_ManySegments__b_m7uBBu) {
+  font-weight: bold;
+}
+*/ /*#__PURE__*/ "input_ManySegments_m7uBBu" + (a ? " input_ManySegments__a_m7uBBu" : "") + (b ? " input_ManySegments__b_m7uBBu" : "")}/>;
+// bails: a mixin reference is an Expr::Ident, not a css() call
+// this pins a known gap rather than the fold: the css prop does not inline a
+// mixin the way a template consumer `${mixin}` does, so `color: red` never
+// ships and this renders unstyled
+// (teaching the fold Expr::Ident would not change it - a mixin compiles to an
+// argument-less css(), which has no base class to fold)
+const MixinIdentifier = ()=><div {...__yak_mergeCssProp({}, mixin)}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.prod.tsx
@@ -1,0 +1,38 @@
+// Adversarial shapes for the css prop fold - fold_css_expr only folds css()
+// calls and ternaries, so teaching it Expr::Bin must not silently change
+// these
+import { css, __yak_mergeCssProp } from "next-yak/internal";
+import "./input.yak.module.css!=!./input?./input.yak.module.css";
+const mixin = /*#__PURE__*/ css();
+// bails: a top level `&&` is an Expr::Bin, not a css() call or a ternary
+// folding it naively drops the /*YAK Extracted CSS:*/ comment the loader
+// parses, which ships the component unstyled
+const LogicalAnd = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on && /*YAK Extracted CSS:
+:global(.ym7uBBu1) {
+  color: blue;
+}
+*/ /*#__PURE__*/ css("ym7uBBu1"))}/>;
+// folds: several condition segments in one template concatenate
+const ManySegments = ({ a, b }: {
+    a: boolean;
+    b: boolean;
+})=><div className={/*YAK Extracted CSS:
+:global(.ym7uBBu2) {
+  color: black;
+}
+:global(.ym7uBBu3) {
+  color: red;
+}
+:global(.ym7uBBu4) {
+  font-weight: bold;
+}
+*/ /*#__PURE__*/ "ym7uBBu2" + (a ? " ym7uBBu3" : "") + (b ? " ym7uBBu4" : "")}/>;
+// bails: a mixin reference is an Expr::Ident, not a css() call
+// this pins a known gap rather than the fold: the css prop does not inline a
+// mixin the way a template consumer `${mixin}` does, so `color: red` never
+// ships and this renders unstyled
+// (teaching the fold Expr::Ident would not change it - a mixin compiles to an
+// argument-less css(), which has no base class to fold)
+const MixinIdentifier = ()=><div {...__yak_mergeCssProp({}, mixin)}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.turbo.dev.tsx
@@ -1,0 +1,38 @@
+// Adversarial shapes for the css prop fold - fold_css_expr only folds css()
+// calls and ternaries, so teaching it Expr::Bin must not silently change
+// these
+import { css, __yak_mergeCssProp } from "next-yak/internal";
+import "data:text/css;base64,LmlucHV0X0xvZ2ljYWxBbmRfbTd1QkJ1IHsKICBjb2xvcjogYmx1ZTsKfS5pbnB1dF9NYW55U2VnbWVudHNfbTd1QkJ1IHsKICBjb2xvcjogYmxhY2s7Cn0KLmlucHV0X01hbnlTZWdtZW50c19fYV9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0KLmlucHV0X01hbnlTZWdtZW50c19fYl9tN3VCQnUgewogIGZvbnQtd2VpZ2h0OiBib2xkOwp9";
+const mixin = /*#__PURE__*/ css();
+// bails: a top level `&&` is an Expr::Bin, not a css() call or a ternary
+// folding it naively drops the /*YAK Extracted CSS:*/ comment the loader
+// parses, which ships the component unstyled
+const LogicalAnd = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on && /*YAK Extracted CSS:
+.input_LogicalAnd_m7uBBu {
+  color: blue;
+}
+*/ /*#__PURE__*/ css("input_LogicalAnd_m7uBBu"))}/>;
+// folds: several condition segments in one template concatenate
+const ManySegments = ({ a, b }: {
+    a: boolean;
+    b: boolean;
+})=><div className={/*YAK Extracted CSS:
+.input_ManySegments_m7uBBu {
+  color: black;
+}
+.input_ManySegments__a_m7uBBu {
+  color: red;
+}
+.input_ManySegments__b_m7uBBu {
+  font-weight: bold;
+}
+*/ /*#__PURE__*/ "input_ManySegments_m7uBBu" + (a ? " input_ManySegments__a_m7uBBu" : "") + (b ? " input_ManySegments__b_m7uBBu" : "")}/>;
+// bails: a mixin reference is an Expr::Ident, not a css() call
+// this pins a known gap rather than the fold: the css prop does not inline a
+// mixin the way a template consumer `${mixin}` does, so `color: red` never
+// ships and this renders unstyled
+// (teaching the fold Expr::Ident would not change it - a mixin compiles to an
+// argument-less css(), which has no base class to fold)
+const MixinIdentifier = ()=><div {...__yak_mergeCssProp({}, mixin)}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.turbo.prod.tsx
@@ -1,0 +1,38 @@
+// Adversarial shapes for the css prop fold - fold_css_expr only folds css()
+// calls and ternaries, so teaching it Expr::Bin must not silently change
+// these
+import { css, __yak_mergeCssProp } from "next-yak/internal";
+import "data:text/css;base64,LnltN3VCQnUxIHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1MiB7CiAgY29sb3I6IGJsYWNrOwp9Ci55bTd1QkJ1MyB7CiAgY29sb3I6IHJlZDsKfQoueW03dUJCdTQgewogIGZvbnQtd2VpZ2h0OiBib2xkOwp9";
+const mixin = /*#__PURE__*/ css();
+// bails: a top level `&&` is an Expr::Bin, not a css() call or a ternary
+// folding it naively drops the /*YAK Extracted CSS:*/ comment the loader
+// parses, which ships the component unstyled
+const LogicalAnd = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on && /*YAK Extracted CSS:
+.ym7uBBu1 {
+  color: blue;
+}
+*/ /*#__PURE__*/ css("ym7uBBu1"))}/>;
+// folds: several condition segments in one template concatenate
+const ManySegments = ({ a, b }: {
+    a: boolean;
+    b: boolean;
+})=><div className={/*YAK Extracted CSS:
+.ym7uBBu2 {
+  color: black;
+}
+.ym7uBBu3 {
+  color: red;
+}
+.ym7uBBu4 {
+  font-weight: bold;
+}
+*/ /*#__PURE__*/ "ym7uBBu2" + (a ? " ym7uBBu3" : "") + (b ? " ym7uBBu4" : "")}/>;
+// bails: a mixin reference is an Expr::Ident, not a css() call
+// this pins a known gap rather than the fold: the css prop does not inline a
+// mixin the way a template consumer `${mixin}` does, so `color: red` never
+// ships and this renders unstyled
+// (teaching the fold Expr::Ident would not change it - a mixin compiles to an
+// argument-less css(), which has no base class to fold)
+const MixinIdentifier = ()=><div {...__yak_mergeCssProp({}, mixin)}/>;


### PR DESCRIPTION
`fold_css_expr` only folds `css()` calls and ternaries; the shapes that keep the runtime path were verified by hand but nothing pinned them. Fixture covers a top level `&&`, several condition segments in one template, and a mixin identifier.

The `&&` case is the one that earns its keep — I patched `fold_css_expr` to handle `Expr::Bin` to check, and this was the only fixture in the repo that failed. The naive fold emits `className={"" + (on ? " y2" : "")}` and drops the `/*YAK Extracted CSS:*/` comment `extractCss.ts` parses, so the component ships unstyled — exactly the incident worth a snapshot.

Finding (10) asked for four shapes; I dropped spread-before-css-prop. The `try_fold` guard is an order-independent `any()`, so it's the same path as spread-after, already pinned by `css-prop` Elem4, and it bails before `fold_css_expr` runs so it can't regress. Kept the mixin case but labelled it honestly: it pins the known gap that the css prop doesn't inline mixins (finding 14), and it would not fail on `Expr::Ident` either, since a mixin compiles to an argument-less `css()` with no base class.

Based on #567 rather than main — `class_name_fold.rs` doesn't exist on main yet.

Finding (10) from the perf-stack review.