### PR TITLE
Drop class name deduplication

### DIFF
--- a/.changeset/drop-classname-dedup.md
+++ b/.changeset/drop-classname-dedup.md
@@ -1,0 +1,5 @@
+---
+"next-yak": minor
+---
+
+The runtime no longer deduplicates class names, so the same class applied twice — e.g. an `atoms()` utility that is already on the element, or a shared `css` block toggled by two conditions — now appears twice in the class attribute. This is rendering-neutral, as CSS applies a class once however often it is listed.

--- a/packages/next-yak/runtime/__tests__/cssLiteral.test.tsx
+++ b/packages/next-yak/runtime/__tests__/cssLiteral.test.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck These are runtime tests and the external API isn't the runtime (after compile) API
 import type { YakTheme } from "../context";
-import { css } from "../cssLiteral";
+import { css, ClassNames } from "../cssLiteral";
 
 describe("cssLiteral css function", () => {
   describe("static CSS class names", () => {
@@ -474,5 +474,30 @@ describe("cssLiteral css function", () => {
       expect(style["--dynamic1"]).toBe("dynamic1");
       expect(style["--dynamic2"]).toBe("dynamic2");
     });
+  });
+});
+
+describe("ClassNames collector", () => {
+  it("does not deduplicate added class names", () => {
+    const classNames = new ClassNames();
+    classNames.add("a");
+    classNames.add("b");
+    classNames.add("a");
+    expect(classNames.value).toBe("a b a");
+  });
+
+  it("does not deduplicate against the incoming className", () => {
+    const classNames = new ClassNames("a");
+    classNames.add("a");
+    expect(classNames.value).toBe("a a");
+  });
+
+  it("deletes every occurrence of a duplicated class", () => {
+    const classNames = new ClassNames();
+    classNames.add("a");
+    classNames.add("b");
+    classNames.add("a");
+    classNames.delete("a");
+    expect(classNames.value).toBe("b");
   });
 });

--- a/packages/next-yak/runtime/cssLiteral.tsx
+++ b/packages/next-yak/runtime/cssLiteral.tsx
@@ -23,11 +23,7 @@ export class ClassNames implements ClassNameCollector {
     this.value = initial || "";
   }
   add(className: string) {
-    if (!this.value) {
-      this.value = className;
-    } else {
-      this.value += " " + className;
-    }
+    this.value += (this.value && " ") + className;
   }
   has(className: string) {
     return (" " + this.value + " ").includes(" " + className + " ");

--- a/packages/next-yak/runtime/cssLiteral.tsx
+++ b/packages/next-yak/runtime/cssLiteral.tsx
@@ -8,9 +8,14 @@ export const yakComponentSymbol = Symbol("yak");
  *
  * Replaces the previous `new Set(className.split(" "))` →
  * `Array.from(set).join(" ")` round-trip, which dominated render cost.
- * The hot path (`add`) is a plain string append with a containment check;
+ * The hot path (`add`) is a plain string append and does not deduplicate, so
+ * the collector is a multiset: the same class can appear twice, e.g. when
+ * `atoms()` repeats a utility or the incoming className already carries it.
+ * That is rendering neutral - CSS applies a class once however often it is
+ * listed - and it matches what the compile time class name folds emit.
  * `has`/`delete` keep the Set-like contract for advanced runtime functions
- * (e.g. atoms removing classes) on the rare path.
+ * (e.g. atoms removing classes) on the rare path; `delete` removes every
+ * occurrence.
  */
 export class ClassNames implements ClassNameCollector {
   value: string;
@@ -20,7 +25,7 @@ export class ClassNames implements ClassNameCollector {
   add(className: string) {
     if (!this.value) {
       this.value = className;
-    } else if (!this.has(className)) {
+    } else {
       this.value += " " + className;
     }
   }


### PR DESCRIPTION
The `has()` containment check in `ClassNames.add()` was the last dedup left, and it costs a `" " + value + " "` allocation on every add — the hottest path in the runtime. Now `add()` is a pure string append, which is also what the class name folds emit, so all the class merging paths end up with one behavior to document and test.

Duplicates do reach real output — `mergeCssProp({className: "px-4"}, atoms("px-4", "text-base"))` gives `"px-4 px-4 text-base"` — so the changeset says that rather than the internal `ClassNames.add()`, which isn't exported. It's rendering-neutral: CSS applies a class once however often it's listed. Example DOM snapshots are unchanged.

The collector is a multiset now, so I pinned that `delete()` still removes *every* occurrence — the invariant a future `indexOf`-based delete would quietly break.

Merge before the release is cut, otherwise the no-dedup line ships in a version whose `add()` still dedupes.

Finding (2) from the perf-stack review.