### PR TITLE
Take the static fast path for constant attrs

### DIFF
--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -71,7 +71,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
     | string;
 
   const mergedAttrsFn = buildRuntimeAttrsProcessor(attrs, parentAttrsFn);
-  const staticAttrs = staticAttrsOf(mergedAttrsFn);
+  const staticAttrs = (mergedAttrsFn as StaticAttrsCarrier | undefined)?.$staticAttrs;
 
   return (styles, ...values) => {
     // combine all interpolated logic into a single function
@@ -85,34 +85,19 @@ const yakStyled: StyledInternal = (Component, attrs) => {
       parentRuntimeStylesFn,
     );
     const Yak: React.FunctionComponent = (props) => {
-      // fast path for fully static components (no attrs, no dynamic styles —
-      // the most common case): contribute the chain's class names and strip
-      // $-props; skips theme lookup, prop spreading and style cloning
-      // entirely (this is NOT against the rule of hooks — the condition is
-      // constant for the lifetime of the component)
-      if (!mergedAttrsFn && !runtimeStyleProcessor.$dynamic) {
-        const filteredProps = removeNonDomProperties(props) as {
-          className?: string;
-        };
-        // props that already went through a yak wrapper (passed through a
-        // custom component boundary) keep their processed className
-        if (!("$__runtimeStylesProcessed" in props)) {
-          const classNames = new ClassNames((props as { className?: string }).className);
-          runtimeStyleProcessor(props, classNames, undefined as unknown as React.CSSProperties);
-          filteredProps.className = classNames.value || undefined;
-        }
-        const Target = targetComponent as React.ElementType;
-        return <Target {...(filteredProps as React.ComponentProps<typeof Target>)} />;
-      }
-
-      // the same fast path, one step weaker: a constant `.attrs({...})` cannot
-      // read the theme and contributes the same props on every render, so only
-      // the attrs *function* form needs the theme and the per-render merge
-      if (staticAttrs && !runtimeStyleProcessor.$dynamic) {
+      // fast path for components that contribute the same thing on every
+      // render — no attrs at all, or a constant `.attrs({...})` which cannot
+      // read the theme — and no dynamic styles. Contributes the chain's class
+      // names and strips $-props; skips theme lookup, prop spreading and style
+      // cloning entirely (this is NOT against the rule of hooks — the condition
+      // is constant for the lifetime of the component)
+      if ((!mergedAttrsFn || staticAttrs) && !runtimeStyleProcessor.$dynamic) {
+        // props that already went through a yak wrapper keep their processed
+        // className, and `source` then aliases `props` — so the class names are
+        // written to the fresh, filtered object rather than back into props
         const source = (
-          "$__attrs" in props
-            ? props
-            : combineProps(
+          staticAttrs && !("$__attrs" in props)
+            ? combineProps(
                 {
                   ...(props as { className?: string; style?: React.CSSProperties }),
                   // mark the props as processed
@@ -120,9 +105,8 @@ const yakStyled: StyledInternal = (Component, attrs) => {
                 },
                 staticAttrs,
               )
+            : props
         ) as { className?: string; style?: React.CSSProperties };
-        // `source` aliases `props` when the attrs already ran, so the class
-        // names are written to the fresh, filtered object instead
         const filteredProps = removeNonDomProperties(source) as {
           className?: string;
         };
@@ -320,31 +304,27 @@ const buildRuntimeAttrsProcessor = <
     };
   }
 
+  // A constant `.attrs({...})` is wrapped into `() => attrs`, which makes it
+  // indistinguishable from `.attrs(props => ...)` at render time — so record the
+  // object it will always return, the way the style processor records $dynamic.
+  // Only the wrapper closure is tagged, never a user-supplied attrs function.
+  //
+  // A `styled(StyledWithAttrs).attrs({...})` chain merges its levels per render
+  // and is not tagged, which keeps a mutation of an attrs object observable.
   if (ownAttrsFn && typeof attrs !== "function") {
-    return tagStaticAttrs(ownAttrsFn, attrs as object);
+    return Object.assign(ownAttrsFn, { $staticAttrs: attrs } as StaticAttrsCarrier);
   }
 
   return ownAttrsFn || parentAttrsFn;
 };
 
 /**
- * A constant `.attrs({...})` is wrapped into `() => attrs`, which makes it
- * indistinguishable from `.attrs(props => ...)` at render time — so the object
- * it will always return is recorded on the processor, which allows the
- * component to take a fast path (see the `staticAttrs` branch in `Yak`).
+ * The constant object a `.attrs({...})` processor always returns.
  *
- * Only components whose own attrs are constant are tagged; a
- * `styled(StyledWithAttrs).attrs({...})` chain merges the levels per render,
- * which keeps a mutation of an attrs object observable.
+ * Kept local to this module — like the `yakComponentSymbol` tuple, it is an
+ * implementation detail and must not reach the public `AttrsFunction` type.
  */
-const staticAttrsSymbol = Symbol("yak.staticAttrs");
-
-const tagStaticAttrs = <F extends Function>(fn: F, value: object): F =>
-  Object.assign(fn, { [staticAttrsSymbol]: value });
-
-/** The constant object an attrs processor always returns, if it has one */
-const staticAttrsOf = (fn?: Function): object | undefined =>
-  fn ? (fn as unknown as Record<symbol, object>)[staticAttrsSymbol] : undefined;
+type StaticAttrsCarrier = { $staticAttrs?: object };
 
 /**
  * Merges the runtime style function of the current component with the runtime style function of the parent component

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -71,6 +71,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
     | string;
 
   const mergedAttrsFn = buildRuntimeAttrsProcessor(attrs, parentAttrsFn);
+  const staticAttrs = staticAttrsOf(mergedAttrsFn);
 
   return (styles, ...values) => {
     // combine all interpolated logic into a single function
@@ -98,6 +99,36 @@ const yakStyled: StyledInternal = (Component, attrs) => {
         if (!("$__runtimeStylesProcessed" in props)) {
           const classNames = new ClassNames((props as { className?: string }).className);
           runtimeStyleProcessor(props, classNames, undefined as unknown as React.CSSProperties);
+          filteredProps.className = classNames.value || undefined;
+        }
+        const Target = targetComponent as React.ElementType;
+        return <Target {...(filteredProps as React.ComponentProps<typeof Target>)} />;
+      }
+
+      // the same fast path, one step weaker: a constant `.attrs({...})` cannot
+      // read the theme and contributes the same props on every render, so only
+      // the attrs *function* form needs the theme and the per-render merge
+      if (staticAttrs && !runtimeStyleProcessor.$dynamic) {
+        const source = (
+          "$__attrs" in props
+            ? props
+            : combineProps(
+                {
+                  ...(props as { className?: string; style?: React.CSSProperties }),
+                  // mark the props as processed
+                  $__attrs: true,
+                },
+                staticAttrs,
+              )
+        ) as { className?: string; style?: React.CSSProperties };
+        // `source` aliases `props` when the attrs already ran, so the class
+        // names are written to the fresh, filtered object instead
+        const filteredProps = removeNonDomProperties(source) as {
+          className?: string;
+        };
+        if (!("$__runtimeStylesProcessed" in source)) {
+          const classNames = new ClassNames(source.className);
+          runtimeStyleProcessor(source, classNames, undefined as unknown as React.CSSProperties);
           filteredProps.className = classNames.value || undefined;
         }
         const Target = targetComponent as React.ElementType;
@@ -289,8 +320,31 @@ const buildRuntimeAttrsProcessor = <
     };
   }
 
+  if (ownAttrsFn && typeof attrs !== "function") {
+    return tagStaticAttrs(ownAttrsFn, attrs as object);
+  }
+
   return ownAttrsFn || parentAttrsFn;
 };
+
+/**
+ * A constant `.attrs({...})` is wrapped into `() => attrs`, which makes it
+ * indistinguishable from `.attrs(props => ...)` at render time — so the object
+ * it will always return is recorded on the processor, which allows the
+ * component to take a fast path (see the `staticAttrs` branch in `Yak`).
+ *
+ * Only components whose own attrs are constant are tagged; a
+ * `styled(StyledWithAttrs).attrs({...})` chain merges the levels per render,
+ * which keeps a mutation of an attrs object observable.
+ */
+const staticAttrsSymbol = Symbol("yak.staticAttrs");
+
+const tagStaticAttrs = <F extends Function>(fn: F, value: object): F =>
+  Object.assign(fn, { [staticAttrsSymbol]: value });
+
+/** The constant object an attrs processor always returns, if it has one */
+const staticAttrsOf = (fn?: Function): object | undefined =>
+  fn ? (fn as unknown as Record<symbol, object>)[staticAttrsSymbol] : undefined;
 
 /**
  * Merges the runtime style function of the current component with the runtime style function of the parent component


### PR DESCRIPTION
The static fast path gates on `!mergedAttrsFn`, but `.attrs({...})` with a constant object gets wrapped into `() => attrs` — so a fully static component was excluded from the fast path purely because of that wrapper, and paid a `useTheme()` context lookup plus the per-render merge for attrs that can never change.

This records the constant object on the attrs processor, so those components take a fast path too. Worth +19% on the Attrs SSR lane (1005 -> 1312 ops/sec, 1000 `styled.div.attrs({...})` components); rendered output is byte-identical.

The object is read live on every render via `combineProps`, exactly as `() => attrs` did, so mutating an attrs object after the definition is still observed. `styled(StyledWithAttrs).attrs({...})` chains keep the existing per-render path.