### PR TITLE
Bail folding on function-expression style conditions

### DIFF
--- a/packages/yak-swc/yak_swc/src/utils/styled_jsx_fold.rs
+++ b/packages/yak-swc/yak_swc/src/utils/styled_jsx_fold.rs
@@ -104,9 +104,10 @@ impl StyledJsxFold {
   ///   these shapes exclude .attrs(...) chains
   /// - `class_name` is the static class name the compiled call carries as
   ///   its first argument
-  /// - `runtime_expressions` must all be class-toggling arrows/functions
-  ///   over props - anything else (e.g. an unresolved mixin reference) keeps
-  ///   the runtime path
+  /// - `runtime_expressions` must all be class-toggling arrows over props -
+  ///   anything else keeps the runtime path. Function expressions bail too:
+  ///   they bind `this`/`arguments`, which inlining would silently rebind to
+  ///   the enclosing component
   pub fn try_register(
     &mut self,
     declaration: Option<&ScopedVariableReference>,
@@ -125,7 +126,7 @@ impl StyledJsxFold {
     };
     if !runtime_expressions
       .iter()
-      .all(|expr| matches!(expr, Expr::Arrow(_) | Expr::Fn(_)))
+      .all(|expr| matches!(expr, Expr::Arrow(_)))
     {
       return;
     }
@@ -839,15 +840,6 @@ fn inline_expression(
       };
       (arrow.params.iter().collect(), body)
     }
-    Expr::Fn(function) if !function.function.is_async && !function.function.is_generator => (
-      function
-        .function
-        .params
-        .iter()
-        .map(|param| &param.pat)
-        .collect(),
-      single_return_expr(function.function.body.as_ref()?)?,
-    ),
     _ => return None,
   };
   let (mut condition, cons_class, alt_class) = fold_condition_body(body, yak_imports)?;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/input.tsx
@@ -24,7 +24,8 @@ const Many = styled.p<{ $variant?: string; $bold?: boolean }>`
   ${({ $bold }) => $bold && css`font-weight: bold;`}
 `;
 
-// folds: function expression form with a block body
+// bails: function expressions bind this/arguments, which inlining would
+// rebind to the enclosing component
 const Fn = styled.i<{ $on?: boolean }>`
   color: gray;
   ${function ({ $on }) {

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/input.tsx
@@ -24,15 +24,6 @@ const Many = styled.p<{ $variant?: string; $bold?: boolean }>`
   ${({ $bold }) => $bold && css`font-weight: bold;`}
 `;
 
-// bails: function expressions bind this/arguments, which inlining would
-// rebind to the enclosing component
-const Fn = styled.i<{ $on?: boolean }>`
-  color: gray;
-  ${function ({ $on }) {
-    return $on && css`color: black;`;
-  }}
-`;
-
 // folds: zero-arg expressions reference the outer scope like the css prop
 const isCompact = true;
 const Scoped = styled.em`
@@ -91,6 +82,15 @@ const Defaulted = styled.mark<{ $size?: string }>`
 `;
 const Rested = styled.mark<{ $size?: string }>`
   ${({ $size, ...rest }) => $size && rest && css`padding: 8px;`}
+`;
+
+// usages bail: a function expression binds this/arguments, which inlining
+// would rebind to the enclosing component
+const Fn = styled.i<{ $on?: boolean }>`
+  color: gray;
+  ${function ({ $on }) {
+    return $on && css`color: black;`;
+  }}
 `;
 
 // folds: non-$ props toggle classes AND stay on the element - the attribute
@@ -211,7 +211,6 @@ const Optimizable = ({ active, size, i }: { active?: boolean; size?: string, i: 
     <Many $variant="primary" $bold>
       two inlined expressions
     </Many>
-    <Fn $on={active}>function form</Fn>
     <Scoped>outer scope condition</Scoped>
     <Twice $size={size}>safe to duplicate</Twice>
     <ActionButton disabled={active}>kept on the element and inlined</ActionButton>
@@ -304,6 +303,7 @@ const NotOptimizable = () => (
     <Renamed $size="big">bails: renamed destructuring</Renamed>
     <Defaulted>bails: default value destructuring</Defaulted>
     <Rested $size="big">bails: rest element destructuring</Rested>
+    <Fn $on>bails: function expression condition</Fn>
     {/* spriteFor() would jump both rolls: the namespaced name is the only
         difference from the wrapped `id={...}` case above */}
     <Sprite $active={props.roll()} xlink:href={props.getSize()} $muted={props.roll()}>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.dev.tsx
@@ -32,7 +32,8 @@ const Many = /*YAK Extracted CSS:
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_p("input_Many_m7uBBu", ({ $variant })=>$variant === "primary" ? /*#__PURE__*/ css("input_Many___m7uBBu") : /*#__PURE__*/ css("input_Many___m7uBBu-01"), ({ $bold })=>$bold && /*#__PURE__*/ css("input_Many__$bold_m7uBBu")), {
     "displayName": "Many"
 });
-// folds: function expression form with a block body
+// bails: function expressions bind this/arguments, which inlining would
+// rebind to the enclosing component
 const Fn = /*YAK Extracted CSS:
 :global(.input_Fn_m7uBBu) {
   color: gray;
@@ -325,7 +326,7 @@ const Optimizable = ({ active, size, i: i1 }: {
     <p className={"input_Many_m7uBBu" + ("primary" === "primary" ? " input_Many___m7uBBu" : " input_Many___m7uBBu-01") + (true ? " input_Many__$bold_m7uBBu" : "")}>
       two inlined expressions
     </p>
-    <i className={"input_Fn_m7uBBu" + (active ? " input_Fn__$on_m7uBBu" : "")}>function form</i>
+    <Fn $on={active}>function form</Fn>
     <em className={"input_Scoped_m7uBBu" + (isCompact ? " input_Scoped__isCompact_m7uBBu" : "")}>outer scope condition</em>
     <li className={"input_Twice_m7uBBu" + (size && size === "big" ? " input_Twice___m7uBBu" : "")}>safe to duplicate</li>
     <button disabled={active} className={"input_ActionButton_m7uBBu" + (!active ? " input_ActionButton___m7uBBu" : "")}>kept on the element and inlined</button>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.dev.tsx
@@ -32,20 +32,6 @@ const Many = /*YAK Extracted CSS:
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_p("input_Many_m7uBBu", ({ $variant })=>$variant === "primary" ? /*#__PURE__*/ css("input_Many___m7uBBu") : /*#__PURE__*/ css("input_Many___m7uBBu-01"), ({ $bold })=>$bold && /*#__PURE__*/ css("input_Many__$bold_m7uBBu")), {
     "displayName": "Many"
 });
-// bails: function expressions bind this/arguments, which inlining would
-// rebind to the enclosing component
-const Fn = /*YAK Extracted CSS:
-:global(.input_Fn_m7uBBu) {
-  color: gray;
-}
-:global(.input_Fn__\$on_m7uBBu) {
-  color: black;
-}
-*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_i("input_Fn_m7uBBu", function({ $on }) {
-    return $on && /*#__PURE__*/ css("input_Fn__$on_m7uBBu");
-}), {
-    "displayName": "Fn"
-});
 // folds: zero-arg expressions reference the outer scope like the css prop
 const isCompact = true;
 const Scoped = /*YAK Extracted CSS:
@@ -151,6 +137,20 @@ const Rested = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_mark("input_Rested_m7uBBu", ({ $size, ...rest })=>$size && rest && /*#__PURE__*/ css("input_Rested___m7uBBu")), {
     "displayName": "Rested"
+});
+// usages bail: a function expression binds this/arguments, which inlining
+// would rebind to the enclosing component
+const Fn = /*YAK Extracted CSS:
+:global(.input_Fn_m7uBBu) {
+  color: gray;
+}
+:global(.input_Fn__\$on_m7uBBu) {
+  color: black;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_i("input_Fn_m7uBBu", function({ $on }) {
+    return $on && /*#__PURE__*/ css("input_Fn__$on_m7uBBu");
+}), {
+    "displayName": "Fn"
 });
 // folds: non-$ props toggle classes AND stay on the element - the attribute
 // value ends up in the DOM attribute and the className condition
@@ -326,7 +326,6 @@ const Optimizable = ({ active, size, i: i1 }: {
     <p className={"input_Many_m7uBBu" + ("primary" === "primary" ? " input_Many___m7uBBu" : " input_Many___m7uBBu-01") + (true ? " input_Many__$bold_m7uBBu" : "")}>
       two inlined expressions
     </p>
-    <Fn $on={active}>function form</Fn>
     <em className={"input_Scoped_m7uBBu" + (isCompact ? " input_Scoped__isCompact_m7uBBu" : "")}>outer scope condition</em>
     <li className={"input_Twice_m7uBBu" + (size && size === "big" ? " input_Twice___m7uBBu" : "")}>safe to duplicate</li>
     <button disabled={active} className={"input_ActionButton_m7uBBu" + (!active ? " input_ActionButton___m7uBBu" : "")}>kept on the element and inlined</button>
@@ -413,6 +412,7 @@ const NotOptimizable = ()=><>
     <Renamed $size="big">bails: renamed destructuring</Renamed>
     <Defaulted>bails: default value destructuring</Defaulted>
     <Rested $size="big">bails: rest element destructuring</Rested>
+    <Fn $on>bails: function expression condition</Fn>
     { /* spriteFor() would jump both rolls: the namespaced name is the only
         difference from the wrapped `id={...}` case above */ }
     <Sprite $active={props.roll()} xlink:href={props.getSize()} $muted={props.roll()}>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.prod.tsx
@@ -28,7 +28,8 @@ const Many = /*YAK Extracted CSS:
   font-weight: bold;
 }
 */ /*#__PURE__*/ __yak.__yak_p("ym7uBBu2", ({ $variant })=>$variant === "primary" ? /*#__PURE__*/ css("ym7uBBu3") : /*#__PURE__*/ css("ym7uBBu4"), ({ $bold })=>$bold && /*#__PURE__*/ css("ym7uBBu5"));
-// folds: function expression form with a block body
+// bails: function expressions bind this/arguments, which inlining would
+// rebind to the enclosing component
 const Fn = /*YAK Extracted CSS:
 :global(.ym7uBBu6) {
   color: gray;
@@ -271,7 +272,7 @@ const Optimizable = ({ active, size, i: i1 }: {
     <p className={"ym7uBBu2" + ("primary" === "primary" ? " ym7uBBu3" : " ym7uBBu4") + (true ? " ym7uBBu5" : "")}>
       two inlined expressions
     </p>
-    <i className={"ym7uBBu6" + (active ? " ym7uBBu7" : "")}>function form</i>
+    <Fn $on={active}>function form</Fn>
     <em className={"ym7uBBu8" + (isCompact ? " ym7uBBu9" : "")}>outer scope condition</em>
     <li className={"ym7uBBuA" + (size && size === "big" ? " ym7uBBuB" : "")}>safe to duplicate</li>
     <button disabled={active} className={"ym7uBBuT" + (!active ? " ym7uBBuU" : "")}>kept on the element and inlined</button>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.prod.tsx
@@ -28,38 +28,26 @@ const Many = /*YAK Extracted CSS:
   font-weight: bold;
 }
 */ /*#__PURE__*/ __yak.__yak_p("ym7uBBu2", ({ $variant })=>$variant === "primary" ? /*#__PURE__*/ css("ym7uBBu3") : /*#__PURE__*/ css("ym7uBBu4"), ({ $bold })=>$bold && /*#__PURE__*/ css("ym7uBBu5"));
-// bails: function expressions bind this/arguments, which inlining would
-// rebind to the enclosing component
-const Fn = /*YAK Extracted CSS:
-:global(.ym7uBBu6) {
-  color: gray;
-}
-:global(.ym7uBBu7) {
-  color: black;
-}
-*/ /*#__PURE__*/ __yak.__yak_i("ym7uBBu6", function({ $on }) {
-    return $on && /*#__PURE__*/ css("ym7uBBu7");
-});
 // folds: zero-arg expressions reference the outer scope like the css prop
 const isCompact = true;
 const Scoped = /*YAK Extracted CSS:
-:global(.ym7uBBu8) {
+:global(.ym7uBBu6) {
   color: green;
 }
-:global(.ym7uBBu9) {
+:global(.ym7uBBu7) {
   line-height: 1;
 }
-*/ /*#__PURE__*/ __yak.__yak_em("ym7uBBu8", ()=>isCompact && /*#__PURE__*/ css("ym7uBBu9"));
+*/ /*#__PURE__*/ __yak.__yak_em("ym7uBBu6", ()=>isCompact && /*#__PURE__*/ css("ym7uBBu7"));
 // the twice-referenced $size attribute is read at two sites, so an impure
 // value would be evaluated twice - it is bound once instead
 const Twice = /*YAK Extracted CSS:
-:global(.ym7uBBuA) {
+:global(.ym7uBBu8) {
   padding: 1px;
 }
-:global(.ym7uBBuB) {
+:global(.ym7uBBu9) {
   padding: 8px;
 }
-*/ /*#__PURE__*/ __yak.__yak_li("ym7uBBuA", ({ $size })=>$size && $size === "big" && /*#__PURE__*/ css("ym7uBBuB"));
+*/ /*#__PURE__*/ __yak.__yak_li("ym7uBBu8", ({ $size })=>$size && $size === "big" && /*#__PURE__*/ css("ym7uBBu9"));
 // folds: one read, inside a callback - an impure value would run once per list
 // element, so a single read is enough to bind it
 const sizes = [
@@ -68,64 +56,76 @@ const sizes = [
     3
 ];
 const InCallback = /*YAK Extracted CSS:
-:global(.ym7uBBuD) {
+:global(.ym7uBBuB) {
   color: red;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuC", ({ $n })=>sizes.some((x)=>x > $n) && /*#__PURE__*/ css("ym7uBBuD"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuA", ({ $n })=>sizes.some((x)=>x > $n) && /*#__PURE__*/ css("ym7uBBuB"));
 // folds: one read, behind a short circuit - an impure value would not run at
 // all when the left side is falsy
 const ShortCircuit = /*YAK Extracted CSS:
-:global(.ym7uBBuF) {
+:global(.ym7uBBuD) {
   color: blue;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuE", ({ $b })=>isCompact && $b && /*#__PURE__*/ css("ym7uBBuF"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuC", ({ $b })=>isCompact && $b && /*#__PURE__*/ css("ym7uBBuD"));
 // folds: the conditions read $a before $b, the attributes pass $b first - the
 // arguments follow the attributes, not the conditions
 const Pair = /*YAK Extracted CSS:
-:global(.ym7uBBuH) {
+:global(.ym7uBBuF) {
   color: red;
 }
-:global(.ym7uBBuI) {
+:global(.ym7uBBuG) {
   top: 0;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuG", ({ $a })=>$a && /*#__PURE__*/ css("ym7uBBuH"), ({ $b })=>$b && /*#__PURE__*/ css("ym7uBBuI"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuE", ({ $a })=>$a && /*#__PURE__*/ css("ym7uBBuF"), ({ $b })=>$b && /*#__PURE__*/ css("ym7uBBuG"));
 // folds: a single condition to pin what counts as safe to inline
 const colors = {
     big: "red"
 } as Record<string, string>;
 const Boxed = /*YAK Extracted CSS:
-:global(.ym7uBBuK) {
+:global(.ym7uBBuI) {
   color: red;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuJ", ({ $v })=>$v && /*#__PURE__*/ css("ym7uBBuK"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuH", ({ $v })=>$v && /*#__PURE__*/ css("ym7uBBuI"));
 // folds: an arrow returning from a block body is a condition like any other
 const BlockBody = /*YAK Extracted CSS:
-:global(.ym7uBBuL) {
+:global(.ym7uBBuJ) {
   padding: 1px;
 }
-:global(.ym7uBBuM) {
+:global(.ym7uBBuK) {
   padding: 8px;
 }
-*/ /*#__PURE__*/ __yak.__yak_aside("ym7uBBuL", ({ $wide })=>{
-    return $wide && /*#__PURE__*/ css("ym7uBBuM");
+*/ /*#__PURE__*/ __yak.__yak_aside("ym7uBBuJ", ({ $wide })=>{
+    return $wide && /*#__PURE__*/ css("ym7uBBuK");
 });
 // usages bail: only plain destructuring substitutes - a rename, a default or a
 // rest element all keep the runtime path
 const Renamed = /*YAK Extracted CSS:
+:global(.ym7uBBuM) {
+  padding: 8px;
+}
+*/ /*#__PURE__*/ __yak.__yak_mark("ym7uBBuL", ({ $size: size })=>size && size === "big" && /*#__PURE__*/ css("ym7uBBuM"));
+const Defaulted = /*YAK Extracted CSS:
 :global(.ym7uBBuO) {
   padding: 8px;
 }
-*/ /*#__PURE__*/ __yak.__yak_mark("ym7uBBuN", ({ $size: size })=>size && size === "big" && /*#__PURE__*/ css("ym7uBBuO"));
-const Defaulted = /*YAK Extracted CSS:
+*/ /*#__PURE__*/ __yak.__yak_mark("ym7uBBuN", ({ $size = "big" })=>$size === "big" && /*#__PURE__*/ css("ym7uBBuO"));
+const Rested = /*YAK Extracted CSS:
 :global(.ym7uBBuQ) {
   padding: 8px;
 }
-*/ /*#__PURE__*/ __yak.__yak_mark("ym7uBBuP", ({ $size = "big" })=>$size === "big" && /*#__PURE__*/ css("ym7uBBuQ"));
-const Rested = /*YAK Extracted CSS:
-:global(.ym7uBBuS) {
-  padding: 8px;
+*/ /*#__PURE__*/ __yak.__yak_mark("ym7uBBuP", ({ $size, ...rest })=>$size && rest && /*#__PURE__*/ css("ym7uBBuQ"));
+// usages bail: a function expression binds this/arguments, which inlining
+// would rebind to the enclosing component
+const Fn = /*YAK Extracted CSS:
+:global(.ym7uBBuR) {
+  color: gray;
 }
-*/ /*#__PURE__*/ __yak.__yak_mark("ym7uBBuR", ({ $size, ...rest })=>$size && rest && /*#__PURE__*/ css("ym7uBBuS"));
+:global(.ym7uBBuS) {
+  color: black;
+}
+*/ /*#__PURE__*/ __yak.__yak_i("ym7uBBuR", function({ $on }) {
+    return $on && /*#__PURE__*/ css("ym7uBBuS");
+});
 // folds: non-$ props toggle classes AND stay on the element - the attribute
 // value ends up in the DOM attribute and the className condition
 const ActionButton = /*YAK Extracted CSS:
@@ -272,69 +272,68 @@ const Optimizable = ({ active, size, i: i1 }: {
     <p className={"ym7uBBu2" + ("primary" === "primary" ? " ym7uBBu3" : " ym7uBBu4") + (true ? " ym7uBBu5" : "")}>
       two inlined expressions
     </p>
-    <Fn $on={active}>function form</Fn>
-    <em className={"ym7uBBu8" + (isCompact ? " ym7uBBu9" : "")}>outer scope condition</em>
-    <li className={"ym7uBBuA" + (size && size === "big" ? " ym7uBBuB" : "")}>safe to duplicate</li>
+    <em className={"ym7uBBu6" + (isCompact ? " ym7uBBu7" : "")}>outer scope condition</em>
+    <li className={"ym7uBBu8" + (size && size === "big" ? " ym7uBBu9" : "")}>safe to duplicate</li>
     <button disabled={active} className={"ym7uBBuT" + (!active ? " ym7uBBuU" : "")}>kept on the element and inlined</button>
     <button disabled className={"ym7uBBuT" + (!true ? " ym7uBBuU" : "")}>bare non-$ prop</button>
     { /* two read sites, so the value is bound once instead of rolled twice -
         the two conditions could otherwise disagree */ }
-    <li className={((__yak_$size)=>"ym7uBBuA" + (__yak_$size && __yak_$size === "big" ? " ym7uBBuB" : ""))(props.getSize())}>bound: read at two sites</li>
+    <li className={((__yak_$size)=>"ym7uBBu8" + (__yak_$size && __yak_$size === "big" ? " ym7uBBu9" : ""))(props.getSize())}>bound: read at two sites</li>
     { /* the attribute stays on the element AND feeds the condition, so binding
         it around the element is the only way to evaluate it once - otherwise
         the button could be disabled while it is styled as enabled */ }
     {((__yak_disabled)=><button disabled={__yak_disabled} className={"ym7uBBuT" + (!__yak_disabled ? " ym7uBBuU" : "")}>bound: element and condition</button>)(props.isBusy())}
     { /* one read, but inside a callback: the value would run once per list
         element */ }
-    <div className={((__yak_$n)=>"ym7uBBuC" + (sizes.some((x)=>x > __yak_$n) ? " ym7uBBuD" : ""))(props.roll())}>bound: read inside a callback</div>
+    <div className={((__yak_$n)=>"ym7uBBuA" + (sizes.some((x)=>x > __yak_$n) ? " ym7uBBuB" : ""))(props.roll())}>bound: read inside a callback</div>
     { /* one read, but behind a short circuit: the value would not run at all */ }
-    <div className={((__yak_$b)=>"ym7uBBuE" + (isCompact && __yak_$b ? " ym7uBBuF" : ""))(props.roll())}>bound: read behind a short circuit</div>
+    <div className={((__yak_$b)=>"ym7uBBuC" + (isCompact && __yak_$b ? " ym7uBBuD" : ""))(props.roll())}>bound: read behind a short circuit</div>
     { /* the allowlist is not "does it contain a call" - none of these is one */ }
-    <div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(i1++)}>bound: update expression</div>
-    <div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(new Date())}>bound: new expression</div>
-    <div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(props.getSize() as number)}>bound: judged under the type cast</div>
+    <div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(i1++)}>bound: update expression</div>
+    <div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(new Date())}>bound: new expression</div>
+    <div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(props.getSize() as number)}>bound: judged under the type cast</div>
     { /* effect free but identity bearing - two reads would be two elements */ }
-    <div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(<i/>)}>bound: jsx element</div>
+    <div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(<i/>)}>bound: jsx element</div>
     { /* an impure builtin is bound like any other call, and stays in argument
         position: React's own purity rule flags it here exactly as it flags it
         in the source */ }
-    <div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(Math.random())}>bound: impure builtin</div>
+    <div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(Math.random())}>bound: impure builtin</div>
     { /* inlined: a computed member over pure operands, and a comparison - the
         most common dynamic prop shapes there are */ }
-    <div className={"ym7uBBuJ" + (colors[size!] ? " ym7uBBuK" : "")}>inlined: computed member</div>
-    <div className={"ym7uBBuJ" + (i1 % 4 !== 0 ? " ym7uBBuK" : "")}>inlined: comparison</div>
+    <div className={"ym7uBBuH" + (colors[size!] ? " ym7uBBuI" : "")}>inlined: computed member</div>
+    <div className={"ym7uBBuH" + (i1 % 4 !== 0 ? " ym7uBBuI" : "")}>inlined: comparison</div>
     { /* the conditions read $a first; the arguments follow the attributes */ }
-    <div className={((__yak_$b, __yak_$a)=>"ym7uBBuG" + (__yak_$a ? " ym7uBBuH" : "") + (__yak_$b ? " ym7uBBuI" : ""))(props.roll(), props.getSize())}>bound: arguments in attribute order</div>
+    <div className={((__yak_$b, __yak_$a)=>"ym7uBBuE" + (__yak_$a ? " ym7uBBuF" : "") + (__yak_$b ? " ym7uBBuG" : ""))(props.roll(), props.getSize())}>bound: arguments in attribute order</div>
     { /* attribute position ran getSize() twice, so binding does too */ }
-    <div className={((__yak_$b, __yak_$a)=>"ym7uBBuG" + (__yak_$a ? " ym7uBBuH" : "") + (__yak_$b ? " ym7uBBuI" : ""))(props.getSize(), props.getSize())}>bound: never deduplicated</div>
+    <div className={((__yak_$b, __yak_$a)=>"ym7uBBuE" + (__yak_$a ? " ym7uBBuF" : "") + (__yak_$b ? " ym7uBBuG" : ""))(props.getSize(), props.getSize())}>bound: never deduplicated</div>
     { /* read by no condition: it never leaves attribute position */ }
-    <div id={props.getSize()} className={"ym7uBBuJ" + (active ? " ym7uBBuK" : "")}>inlined: unread attribute stays put</div>
+    <div id={props.getSize()} className={"ym7uBBuH" + (active ? " ym7uBBuI" : "")}>inlined: unread attribute stays put</div>
     { /* an arrow may move, so an event handler never forces the element-wrap */ }
-    <div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(props.roll())} onClick={()=>props.track()}>bound: handler may move</div>
+    <div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(props.roll())} onClick={()=>props.track()}>bound: handler may move</div>
     { /* the user className composes around the block, after it - which is where
         it already ran */ }
-    <div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(props.roll()) + " user"}>bound: static className merge</div>
-    <div className={__yak_mergeClassNames(((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(props.roll()), size)}>bound: runtime className merge</div>
+    <div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(props.roll()) + " user"}>bound: static className merge</div>
+    <div className={__yak_mergeClassNames(((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(props.roll()), size)}>bound: runtime className merge</div>
     <button className={"ym7uBBul" + (!(i1 % 4 !== 0) ? " ym7uBBum" : "") + ("primary" === "secondary" ? " ym7uBBun" : "") + ("primary" === "ghost" ? " ym7uBBuo" : "") + (i1 % 3 === 0 ? " ym7uBBup" : "")}>
       {i1}
     </button>
     <li key={i1} className={"ym7uBBuy" + (active ? " ym7uBBuz" : "")}>
       key at the call site still folds
     </li>
-    <aside className={"ym7uBBuL" + (active ? " ym7uBBuM" : "")}>block body arrow</aside>
+    <aside className={"ym7uBBuJ" + (active ? " ym7uBBuK" : "")}>block body arrow</aside>
     { /* getSize() ran between the two rolls, and may not jump the parameter
         block, so the whole element is wrapped and captures all three in
         source order */ }
-    {((__yak_$a, __yak_id, __yak_$b)=><div id={__yak_id} className={"ym7uBBuG" + (__yak_$a ? " ym7uBBuH" : "") + (__yak_$b ? " ym7uBBuI" : "")}>
+    {((__yak_$a, __yak_id, __yak_$b)=><div id={__yak_id} className={"ym7uBBuE" + (__yak_$a ? " ym7uBBuF" : "") + (__yak_$b ? " ym7uBBuG" : "")}>
       wrapped: nothing may jump the block
     </div>)(props.roll(), props.getSize(), props.roll())}
     { /* the user className ran BEFORE the roll, and it composes around the
         block, which would run it after - so this escalates too */ }
-    {((__yak_className, __yak_$v)=><div className={__yak_mergeClassNames("ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""), __yak_className)}>wrapped: className ran first</div>)(props.getSize(), props.roll())}
+    {((__yak_className, __yak_$v)=><div className={__yak_mergeClassNames("ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""), __yak_className)}>wrapped: className ran first</div>)(props.getSize(), props.roll())}
     { /* an unread $prop is dropped before the DOM, so its value never runs at
         all - a side effect nobody consumes, which React's purity rule already
         forbids */ }
-    <div className={"ym7uBBuJ" + (active ? " ym7uBBuK" : "")}>elided: unread $prop</div>
+    <div className={"ym7uBBuH" + (active ? " ym7uBBuI" : "")}>elided: unread $prop</div>
     { /* key and children stay normal JSX on the wrapped element */ }
     {sizes.map((it)=>((__yak_disabled)=><button key={it} disabled={__yak_disabled} className={"ym7uBBuT" + (!__yak_disabled ? " ym7uBBuU" : "")}>
         wrapped in a list
@@ -343,7 +342,7 @@ const Optimizable = ({ active, size, i: i1 }: {
 // folds: await is legal in an async server component and impure, so it is
 // bound - which only works because the value never moves out of argument
 // position: awaiting inside the synthesized closure would not even parse
-const AsyncPage = async ()=><div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(await props.load())}>bound: await stays an argument</div>;
+const AsyncPage = async ()=><div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(await props.load())}>bound: await stays an argument</div>;
 const NotOptimizable = ()=><>
     <IconContainer {...props}>bails: spread</IconContainer>
     <Themed $accent>bails: theme access</Themed>
@@ -359,6 +358,7 @@ const NotOptimizable = ()=><>
     <Renamed $size="big">bails: renamed destructuring</Renamed>
     <Defaulted>bails: default value destructuring</Defaulted>
     <Rested $size="big">bails: rest element destructuring</Rested>
+    <Fn $on>bails: function expression condition</Fn>
     { /* spriteFor() would jump both rolls: the namespaced name is the only
         difference from the wrapped `id={...}` case above */ }
     <Sprite $active={props.roll()} xlink:href={props.getSize()} $muted={props.roll()}>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.turbo.dev.tsx
@@ -32,7 +32,8 @@ const Many = /*YAK Extracted CSS:
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_p("input_Many_m7uBBu", ({ $variant })=>$variant === "primary" ? /*#__PURE__*/ css("input_Many___m7uBBu") : /*#__PURE__*/ css("input_Many___m7uBBu-01"), ({ $bold })=>$bold && /*#__PURE__*/ css("input_Many__$bold_m7uBBu")), {
     "displayName": "Many"
 });
-// folds: function expression form with a block body
+// bails: function expressions bind this/arguments, which inlining would
+// rebind to the enclosing component
 const Fn = /*YAK Extracted CSS:
 .input_Fn_m7uBBu {
   color: gray;
@@ -325,7 +326,7 @@ const Optimizable = ({ active, size, i: i1 }: {
     <p className={"input_Many_m7uBBu" + ("primary" === "primary" ? " input_Many___m7uBBu" : " input_Many___m7uBBu-01") + (true ? " input_Many__$bold_m7uBBu" : "")}>
       two inlined expressions
     </p>
-    <i className={"input_Fn_m7uBBu" + (active ? " input_Fn__$on_m7uBBu" : "")}>function form</i>
+    <Fn $on={active}>function form</Fn>
     <em className={"input_Scoped_m7uBBu" + (isCompact ? " input_Scoped__isCompact_m7uBBu" : "")}>outer scope condition</em>
     <li className={"input_Twice_m7uBBu" + (size && size === "big" ? " input_Twice___m7uBBu" : "")}>safe to duplicate</li>
     <button disabled={active} className={"input_ActionButton_m7uBBu" + (!active ? " input_ActionButton___m7uBBu" : "")}>kept on the element and inlined</button>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.turbo.dev.tsx
@@ -1,7 +1,7 @@
 import { css, styled, __yak_unitPostFix, __yak_mergeClassNames } from "next-yak/internal";
 import { ImportedCard } from "./imported-card";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LmlucHV0X0ljb25Db250YWluZXJfbTd1QkJ1IHsKICBkaXNwbGF5OiBmbGV4OwogIG1pbi1oZWlnaHQ6IDI0cHg7Cn0KLmlucHV0X0ljb25Db250YWluZXJfX1wkaGFzQ2hpbGRyZW5fbTd1QkJ1IHsKICBtYXJnaW4tcmlnaHQ6IDEycHg7Cn0uaW5wdXRfTWFueV9tN3VCQnUgewogIGNvbG9yOiBibGFjazsKfQouaW5wdXRfTWFueV9fX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfQouaW5wdXRfTWFueV9fX203dUJCdS0wMSB7CiAgY29sb3I6IGJsdWU7Cn0KLmlucHV0X01hbnlfX1wkYm9sZF9tN3VCQnUgewogIGZvbnQtd2VpZ2h0OiBib2xkOwp9LmlucHV0X0ZuX203dUJCdSB7CiAgY29sb3I6IGdyYXk7Cn0KLmlucHV0X0ZuX19cJG9uX203dUJCdSB7CiAgY29sb3I6IGJsYWNrOwp9LmlucHV0X1Njb3BlZF9tN3VCQnUgewogIGNvbG9yOiBncmVlbjsKfQouaW5wdXRfU2NvcGVkX19pc0NvbXBhY3RfbTd1QkJ1IHsKICBsaW5lLWhlaWdodDogMTsKfS5pbnB1dF9Ud2ljZV9tN3VCQnUgewogIHBhZGRpbmc6IDFweDsKfQouaW5wdXRfVHdpY2VfX19tN3VCQnUgewogIHBhZGRpbmc6IDhweDsKfS5pbnB1dF9JbkNhbGxiYWNrX19fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X1Nob3J0Q2lyY3VpdF9fX203dUJCdSB7CiAgY29sb3I6IGJsdWU7Cn0uaW5wdXRfUGFpcl9fXCRhX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfQouaW5wdXRfUGFpcl9fXCRiX203dUJCdSB7CiAgdG9wOiAwOwp9LmlucHV0X0JveGVkX19cJHZfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0Jsb2NrQm9keV9tN3VCQnUgewogIHBhZGRpbmc6IDFweDsKfQouaW5wdXRfQmxvY2tCb2R5X19cJHdpZGVfbTd1QkJ1IHsKICBwYWRkaW5nOiA4cHg7Cn0uaW5wdXRfUmVuYW1lZF9fX203dUJCdSB7CiAgcGFkZGluZzogOHB4Owp9LmlucHV0X0RlZmF1bHRlZF9fX203dUJCdSB7CiAgcGFkZGluZzogOHB4Owp9LmlucHV0X1Jlc3RlZF9fX203dUJCdSB7CiAgcGFkZGluZzogOHB4Owp9LmlucHV0X0FjdGlvbkJ1dHRvbl9tN3VCQnUgewogIGNvbG9yOiBibHVlOwp9Ci5pbnB1dF9BY3Rpb25CdXR0b25fX19tN3VCQnUgewogIGN1cnNvcjogcG9pbnRlcjsKfS5pbnB1dF9UaGVtZWRfbTd1QkJ1IHsKICBjb2xvcjogYmxhY2s7Cn0KLmlucHV0X1RoZW1lZF9fX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9OZXN0ZWRDc3NWYXJpYWJsZV9fXCRhY3RpdmVfbTd1QkJ1IHsKICB3aWR0aDogdmFyKC0taW5wdXRfTmVzdGVkQ3NzVmFyaWFibGVfX3dpZHRoX203dUJCdSk7Cn0uaW5wdXRfRHluYW1pY0V4dGVuZGVkX19cJGFjdGl2ZV9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfRHluYW1pY0F0dHJzX19cJGFjdGl2ZV9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfU3ByaXRlX19cJGFjdGl2ZV9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0KLmlucHV0X1Nwcml0ZV9fXCRtdXRlZF9tN3VCQnUgewogIG9wYWNpdHk6IDAuNTsKfS5pbnB1dF9DbGFzc05hbWVCYWlsX19jbGFzc05hbWVfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0tleUJhaWxfX19tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfTWVtYmVyQnV0dG9uX203dUJCdSB7CiAgZGlzcGxheTogaW5saW5lLWZsZXg7Cn0KLmlucHV0X01lbWJlckJ1dHRvbl9fX203dUJCdSB7CiAgYmFja2dyb3VuZC1jb2xvcjogI2QxZDVkYjsKfQouaW5wdXRfTWVtYmVyQnV0dG9uX19fbTd1QkJ1LTAxIHsKICBiYWNrZ3JvdW5kLWNvbG9yOiAjZjNmNGY2Owp9Ci5pbnB1dF9NZW1iZXJCdXR0b25fX19tN3VCQnUtMDIgewogIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50Owp9Ci5pbnB1dF9NZW1iZXJCdXR0b25fX3BfXCRmdWxsV2lkdGhfbTd1QkJ1IHsKICB3aWR0aDogMTAwJTsKfS5pbnB1dF9NZW1iZXJFc2NhcGVfX19tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfTWVtYmVyVGhlbWVfX19tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfTWVtYmVyQ29tcHV0ZWRfX19tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfTWVtYmVyS2V5X19fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0tleWVkUm93X19wX1wkYWN0aXZlX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9PcHRpbWl6YWJsZV9tN3VCQnUgewogIGNvbG9yOiBvcmFuZ2U7Cn0=";
+import "data:text/css;base64,LmlucHV0X0ljb25Db250YWluZXJfbTd1QkJ1IHsKICBkaXNwbGF5OiBmbGV4OwogIG1pbi1oZWlnaHQ6IDI0cHg7Cn0KLmlucHV0X0ljb25Db250YWluZXJfX1wkaGFzQ2hpbGRyZW5fbTd1QkJ1IHsKICBtYXJnaW4tcmlnaHQ6IDEycHg7Cn0uaW5wdXRfTWFueV9tN3VCQnUgewogIGNvbG9yOiBibGFjazsKfQouaW5wdXRfTWFueV9fX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfQouaW5wdXRfTWFueV9fX203dUJCdS0wMSB7CiAgY29sb3I6IGJsdWU7Cn0KLmlucHV0X01hbnlfX1wkYm9sZF9tN3VCQnUgewogIGZvbnQtd2VpZ2h0OiBib2xkOwp9LmlucHV0X1Njb3BlZF9tN3VCQnUgewogIGNvbG9yOiBncmVlbjsKfQouaW5wdXRfU2NvcGVkX19pc0NvbXBhY3RfbTd1QkJ1IHsKICBsaW5lLWhlaWdodDogMTsKfS5pbnB1dF9Ud2ljZV9tN3VCQnUgewogIHBhZGRpbmc6IDFweDsKfQouaW5wdXRfVHdpY2VfX19tN3VCQnUgewogIHBhZGRpbmc6IDhweDsKfS5pbnB1dF9JbkNhbGxiYWNrX19fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X1Nob3J0Q2lyY3VpdF9fX203dUJCdSB7CiAgY29sb3I6IGJsdWU7Cn0uaW5wdXRfUGFpcl9fXCRhX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfQouaW5wdXRfUGFpcl9fXCRiX203dUJCdSB7CiAgdG9wOiAwOwp9LmlucHV0X0JveGVkX19cJHZfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0Jsb2NrQm9keV9tN3VCQnUgewogIHBhZGRpbmc6IDFweDsKfQouaW5wdXRfQmxvY2tCb2R5X19cJHdpZGVfbTd1QkJ1IHsKICBwYWRkaW5nOiA4cHg7Cn0uaW5wdXRfUmVuYW1lZF9fX203dUJCdSB7CiAgcGFkZGluZzogOHB4Owp9LmlucHV0X0RlZmF1bHRlZF9fX203dUJCdSB7CiAgcGFkZGluZzogOHB4Owp9LmlucHV0X1Jlc3RlZF9fX203dUJCdSB7CiAgcGFkZGluZzogOHB4Owp9LmlucHV0X0ZuX203dUJCdSB7CiAgY29sb3I6IGdyYXk7Cn0KLmlucHV0X0ZuX19cJG9uX203dUJCdSB7CiAgY29sb3I6IGJsYWNrOwp9LmlucHV0X0FjdGlvbkJ1dHRvbl9tN3VCQnUgewogIGNvbG9yOiBibHVlOwp9Ci5pbnB1dF9BY3Rpb25CdXR0b25fX19tN3VCQnUgewogIGN1cnNvcjogcG9pbnRlcjsKfS5pbnB1dF9UaGVtZWRfbTd1QkJ1IHsKICBjb2xvcjogYmxhY2s7Cn0KLmlucHV0X1RoZW1lZF9fX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9OZXN0ZWRDc3NWYXJpYWJsZV9fXCRhY3RpdmVfbTd1QkJ1IHsKICB3aWR0aDogdmFyKC0taW5wdXRfTmVzdGVkQ3NzVmFyaWFibGVfX3dpZHRoX203dUJCdSk7Cn0uaW5wdXRfRHluYW1pY0V4dGVuZGVkX19cJGFjdGl2ZV9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfRHluYW1pY0F0dHJzX19cJGFjdGl2ZV9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfU3ByaXRlX19cJGFjdGl2ZV9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0KLmlucHV0X1Nwcml0ZV9fXCRtdXRlZF9tN3VCQnUgewogIG9wYWNpdHk6IDAuNTsKfS5pbnB1dF9DbGFzc05hbWVCYWlsX19jbGFzc05hbWVfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0tleUJhaWxfX19tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfTWVtYmVyQnV0dG9uX203dUJCdSB7CiAgZGlzcGxheTogaW5saW5lLWZsZXg7Cn0KLmlucHV0X01lbWJlckJ1dHRvbl9fX203dUJCdSB7CiAgYmFja2dyb3VuZC1jb2xvcjogI2QxZDVkYjsKfQouaW5wdXRfTWVtYmVyQnV0dG9uX19fbTd1QkJ1LTAxIHsKICBiYWNrZ3JvdW5kLWNvbG9yOiAjZjNmNGY2Owp9Ci5pbnB1dF9NZW1iZXJCdXR0b25fX19tN3VCQnUtMDIgewogIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50Owp9Ci5pbnB1dF9NZW1iZXJCdXR0b25fX3BfXCRmdWxsV2lkdGhfbTd1QkJ1IHsKICB3aWR0aDogMTAwJTsKfS5pbnB1dF9NZW1iZXJFc2NhcGVfX19tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfTWVtYmVyVGhlbWVfX19tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfTWVtYmVyQ29tcHV0ZWRfX19tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfTWVtYmVyS2V5X19fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0tleWVkUm93X19wX1wkYWN0aXZlX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9PcHRpbWl6YWJsZV9tN3VCQnUgewogIGNvbG9yOiBvcmFuZ2U7Cn0=";
 const props = {} as any;
 // folds: the class-toggling expression is inlined at the usage
 const IconContainer = /*YAK Extracted CSS:
@@ -31,20 +31,6 @@ const Many = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_p("input_Many_m7uBBu", ({ $variant })=>$variant === "primary" ? /*#__PURE__*/ css("input_Many___m7uBBu") : /*#__PURE__*/ css("input_Many___m7uBBu-01"), ({ $bold })=>$bold && /*#__PURE__*/ css("input_Many__$bold_m7uBBu")), {
     "displayName": "Many"
-});
-// bails: function expressions bind this/arguments, which inlining would
-// rebind to the enclosing component
-const Fn = /*YAK Extracted CSS:
-.input_Fn_m7uBBu {
-  color: gray;
-}
-.input_Fn__\$on_m7uBBu {
-  color: black;
-}
-*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_i("input_Fn_m7uBBu", function({ $on }) {
-    return $on && /*#__PURE__*/ css("input_Fn__$on_m7uBBu");
-}), {
-    "displayName": "Fn"
 });
 // folds: zero-arg expressions reference the outer scope like the css prop
 const isCompact = true;
@@ -151,6 +137,20 @@ const Rested = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_mark("input_Rested_m7uBBu", ({ $size, ...rest })=>$size && rest && /*#__PURE__*/ css("input_Rested___m7uBBu")), {
     "displayName": "Rested"
+});
+// usages bail: a function expression binds this/arguments, which inlining
+// would rebind to the enclosing component
+const Fn = /*YAK Extracted CSS:
+.input_Fn_m7uBBu {
+  color: gray;
+}
+.input_Fn__\$on_m7uBBu {
+  color: black;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_i("input_Fn_m7uBBu", function({ $on }) {
+    return $on && /*#__PURE__*/ css("input_Fn__$on_m7uBBu");
+}), {
+    "displayName": "Fn"
 });
 // folds: non-$ props toggle classes AND stay on the element - the attribute
 // value ends up in the DOM attribute and the className condition
@@ -326,7 +326,6 @@ const Optimizable = ({ active, size, i: i1 }: {
     <p className={"input_Many_m7uBBu" + ("primary" === "primary" ? " input_Many___m7uBBu" : " input_Many___m7uBBu-01") + (true ? " input_Many__$bold_m7uBBu" : "")}>
       two inlined expressions
     </p>
-    <Fn $on={active}>function form</Fn>
     <em className={"input_Scoped_m7uBBu" + (isCompact ? " input_Scoped__isCompact_m7uBBu" : "")}>outer scope condition</em>
     <li className={"input_Twice_m7uBBu" + (size && size === "big" ? " input_Twice___m7uBBu" : "")}>safe to duplicate</li>
     <button disabled={active} className={"input_ActionButton_m7uBBu" + (!active ? " input_ActionButton___m7uBBu" : "")}>kept on the element and inlined</button>
@@ -413,6 +412,7 @@ const NotOptimizable = ()=><>
     <Renamed $size="big">bails: renamed destructuring</Renamed>
     <Defaulted>bails: default value destructuring</Defaulted>
     <Rested $size="big">bails: rest element destructuring</Rested>
+    <Fn $on>bails: function expression condition</Fn>
     { /* spriteFor() would jump both rolls: the namespaced name is the only
         difference from the wrapped `id={...}` case above */ }
     <Sprite $active={props.roll()} xlink:href={props.getSize()} $muted={props.roll()}>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.turbo.prod.tsx
@@ -28,7 +28,8 @@ const Many = /*YAK Extracted CSS:
   font-weight: bold;
 }
 */ /*#__PURE__*/ __yak.__yak_p("ym7uBBu2", ({ $variant })=>$variant === "primary" ? /*#__PURE__*/ css("ym7uBBu3") : /*#__PURE__*/ css("ym7uBBu4"), ({ $bold })=>$bold && /*#__PURE__*/ css("ym7uBBu5"));
-// folds: function expression form with a block body
+// bails: function expressions bind this/arguments, which inlining would
+// rebind to the enclosing component
 const Fn = /*YAK Extracted CSS:
 .ym7uBBu6 {
   color: gray;
@@ -271,7 +272,7 @@ const Optimizable = ({ active, size, i: i1 }: {
     <p className={"ym7uBBu2" + ("primary" === "primary" ? " ym7uBBu3" : " ym7uBBu4") + (true ? " ym7uBBu5" : "")}>
       two inlined expressions
     </p>
-    <i className={"ym7uBBu6" + (active ? " ym7uBBu7" : "")}>function form</i>
+    <Fn $on={active}>function form</Fn>
     <em className={"ym7uBBu8" + (isCompact ? " ym7uBBu9" : "")}>outer scope condition</em>
     <li className={"ym7uBBuA" + (size && size === "big" ? " ym7uBBuB" : "")}>safe to duplicate</li>
     <button disabled={active} className={"ym7uBBuT" + (!active ? " ym7uBBuU" : "")}>kept on the element and inlined</button>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-dynamic-folding/output.turbo.prod.tsx
@@ -1,7 +1,7 @@
 import { css, styled, __yak_unitPostFix, __yak_mergeClassNames } from "next-yak/internal";
 import { ImportedCard } from "./imported-card";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LnltN3VCQnUgewogIGRpc3BsYXk6IGZsZXg7CiAgbWluLWhlaWdodDogMjRweDsKfQoueW03dUJCdTEgewogIG1hcmdpbi1yaWdodDogMTJweDsKfS55bTd1QkJ1MiB7CiAgY29sb3I6IGJsYWNrOwp9Ci55bTd1QkJ1MyB7CiAgY29sb3I6IHJlZDsKfQoueW03dUJCdTQgewogIGNvbG9yOiBibHVlOwp9Ci55bTd1QkJ1NSB7CiAgZm9udC13ZWlnaHQ6IGJvbGQ7Cn0ueW03dUJCdTYgewogIGNvbG9yOiBncmF5Owp9Ci55bTd1QkJ1NyB7CiAgY29sb3I6IGJsYWNrOwp9LnltN3VCQnU4IHsKICBjb2xvcjogZ3JlZW47Cn0KLnltN3VCQnU5IHsKICBsaW5lLWhlaWdodDogMTsKfS55bTd1QkJ1QSB7CiAgcGFkZGluZzogMXB4Owp9Ci55bTd1QkJ1QiB7CiAgcGFkZGluZzogOHB4Owp9LnltN3VCQnVEIHsKICBjb2xvcjogcmVkOwp9LnltN3VCQnVGIHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1SCB7CiAgY29sb3I6IHJlZDsKfQoueW03dUJCdUkgewogIHRvcDogMDsKfS55bTd1QkJ1SyB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1TCB7CiAgcGFkZGluZzogMXB4Owp9Ci55bTd1QkJ1TSB7CiAgcGFkZGluZzogOHB4Owp9LnltN3VCQnVPIHsKICBwYWRkaW5nOiA4cHg7Cn0ueW03dUJCdVEgewogIHBhZGRpbmc6IDhweDsKfS55bTd1QkJ1UyB7CiAgcGFkZGluZzogOHB4Owp9LnltN3VCQnVUIHsKICBjb2xvcjogYmx1ZTsKfQoueW03dUJCdVUgewogIGN1cnNvcjogcG9pbnRlcjsKfS55bTd1QkJ1ViB7CiAgY29sb3I6IGJsYWNrOwp9Ci55bTd1QkJ1VyB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1WSB7CiAgd2lkdGg6IHZhcigtLXltN3VCQnVaKTsKfS55bTd1QkJ1YiB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1ZCB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1ZiB7CiAgY29sb3I6IHJlZDsKfQoueW03dUJCdWcgewogIG9wYWNpdHk6IDAuNTsKfS55bTd1QkJ1aSB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1ayB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1bCB7CiAgZGlzcGxheTogaW5saW5lLWZsZXg7Cn0KLnltN3VCQnVtIHsKICBiYWNrZ3JvdW5kLWNvbG9yOiAjZDFkNWRiOwp9Ci55bTd1QkJ1biB7CiAgYmFja2dyb3VuZC1jb2xvcjogI2YzZjRmNjsKfQoueW03dUJCdW8gewogIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50Owp9Ci55bTd1QkJ1cCB7CiAgd2lkdGg6IDEwMCU7Cn0ueW03dUJCdXIgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdXQgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdXYgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdXggewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdXogewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdS0gewogIGNvbG9yOiBvcmFuZ2U7Cn0=";
+import "data:text/css;base64,LnltN3VCQnUgewogIGRpc3BsYXk6IGZsZXg7CiAgbWluLWhlaWdodDogMjRweDsKfQoueW03dUJCdTEgewogIG1hcmdpbi1yaWdodDogMTJweDsKfS55bTd1QkJ1MiB7CiAgY29sb3I6IGJsYWNrOwp9Ci55bTd1QkJ1MyB7CiAgY29sb3I6IHJlZDsKfQoueW03dUJCdTQgewogIGNvbG9yOiBibHVlOwp9Ci55bTd1QkJ1NSB7CiAgZm9udC13ZWlnaHQ6IGJvbGQ7Cn0ueW03dUJCdTYgewogIGNvbG9yOiBncmVlbjsKfQoueW03dUJCdTcgewogIGxpbmUtaGVpZ2h0OiAxOwp9LnltN3VCQnU4IHsKICBwYWRkaW5nOiAxcHg7Cn0KLnltN3VCQnU5IHsKICBwYWRkaW5nOiA4cHg7Cn0ueW03dUJCdUIgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdUQgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnVGIHsKICBjb2xvcjogcmVkOwp9Ci55bTd1QkJ1RyB7CiAgdG9wOiAwOwp9LnltN3VCQnVJIHsKICBjb2xvcjogcmVkOwp9LnltN3VCQnVKIHsKICBwYWRkaW5nOiAxcHg7Cn0KLnltN3VCQnVLIHsKICBwYWRkaW5nOiA4cHg7Cn0ueW03dUJCdU0gewogIHBhZGRpbmc6IDhweDsKfS55bTd1QkJ1TyB7CiAgcGFkZGluZzogOHB4Owp9LnltN3VCQnVRIHsKICBwYWRkaW5nOiA4cHg7Cn0ueW03dUJCdVIgewogIGNvbG9yOiBncmF5Owp9Ci55bTd1QkJ1UyB7CiAgY29sb3I6IGJsYWNrOwp9LnltN3VCQnVUIHsKICBjb2xvcjogYmx1ZTsKfQoueW03dUJCdVUgewogIGN1cnNvcjogcG9pbnRlcjsKfS55bTd1QkJ1ViB7CiAgY29sb3I6IGJsYWNrOwp9Ci55bTd1QkJ1VyB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1WSB7CiAgd2lkdGg6IHZhcigtLXltN3VCQnVaKTsKfS55bTd1QkJ1YiB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1ZCB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1ZiB7CiAgY29sb3I6IHJlZDsKfQoueW03dUJCdWcgewogIG9wYWNpdHk6IDAuNTsKfS55bTd1QkJ1aSB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1ayB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1bCB7CiAgZGlzcGxheTogaW5saW5lLWZsZXg7Cn0KLnltN3VCQnVtIHsKICBiYWNrZ3JvdW5kLWNvbG9yOiAjZDFkNWRiOwp9Ci55bTd1QkJ1biB7CiAgYmFja2dyb3VuZC1jb2xvcjogI2YzZjRmNjsKfQoueW03dUJCdW8gewogIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50Owp9Ci55bTd1QkJ1cCB7CiAgd2lkdGg6IDEwMCU7Cn0ueW03dUJCdXIgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdXQgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdXYgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdXggewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdXogewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdS0gewogIGNvbG9yOiBvcmFuZ2U7Cn0=";
 const props = {} as any;
 // folds: the class-toggling expression is inlined at the usage
 const IconContainer = /*YAK Extracted CSS:
@@ -28,38 +28,26 @@ const Many = /*YAK Extracted CSS:
   font-weight: bold;
 }
 */ /*#__PURE__*/ __yak.__yak_p("ym7uBBu2", ({ $variant })=>$variant === "primary" ? /*#__PURE__*/ css("ym7uBBu3") : /*#__PURE__*/ css("ym7uBBu4"), ({ $bold })=>$bold && /*#__PURE__*/ css("ym7uBBu5"));
-// bails: function expressions bind this/arguments, which inlining would
-// rebind to the enclosing component
-const Fn = /*YAK Extracted CSS:
-.ym7uBBu6 {
-  color: gray;
-}
-.ym7uBBu7 {
-  color: black;
-}
-*/ /*#__PURE__*/ __yak.__yak_i("ym7uBBu6", function({ $on }) {
-    return $on && /*#__PURE__*/ css("ym7uBBu7");
-});
 // folds: zero-arg expressions reference the outer scope like the css prop
 const isCompact = true;
 const Scoped = /*YAK Extracted CSS:
-.ym7uBBu8 {
+.ym7uBBu6 {
   color: green;
 }
-.ym7uBBu9 {
+.ym7uBBu7 {
   line-height: 1;
 }
-*/ /*#__PURE__*/ __yak.__yak_em("ym7uBBu8", ()=>isCompact && /*#__PURE__*/ css("ym7uBBu9"));
+*/ /*#__PURE__*/ __yak.__yak_em("ym7uBBu6", ()=>isCompact && /*#__PURE__*/ css("ym7uBBu7"));
 // the twice-referenced $size attribute is read at two sites, so an impure
 // value would be evaluated twice - it is bound once instead
 const Twice = /*YAK Extracted CSS:
-.ym7uBBuA {
+.ym7uBBu8 {
   padding: 1px;
 }
-.ym7uBBuB {
+.ym7uBBu9 {
   padding: 8px;
 }
-*/ /*#__PURE__*/ __yak.__yak_li("ym7uBBuA", ({ $size })=>$size && $size === "big" && /*#__PURE__*/ css("ym7uBBuB"));
+*/ /*#__PURE__*/ __yak.__yak_li("ym7uBBu8", ({ $size })=>$size && $size === "big" && /*#__PURE__*/ css("ym7uBBu9"));
 // folds: one read, inside a callback - an impure value would run once per list
 // element, so a single read is enough to bind it
 const sizes = [
@@ -68,64 +56,76 @@ const sizes = [
     3
 ];
 const InCallback = /*YAK Extracted CSS:
-.ym7uBBuD {
+.ym7uBBuB {
   color: red;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuC", ({ $n })=>sizes.some((x)=>x > $n) && /*#__PURE__*/ css("ym7uBBuD"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuA", ({ $n })=>sizes.some((x)=>x > $n) && /*#__PURE__*/ css("ym7uBBuB"));
 // folds: one read, behind a short circuit - an impure value would not run at
 // all when the left side is falsy
 const ShortCircuit = /*YAK Extracted CSS:
-.ym7uBBuF {
+.ym7uBBuD {
   color: blue;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuE", ({ $b })=>isCompact && $b && /*#__PURE__*/ css("ym7uBBuF"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuC", ({ $b })=>isCompact && $b && /*#__PURE__*/ css("ym7uBBuD"));
 // folds: the conditions read $a before $b, the attributes pass $b first - the
 // arguments follow the attributes, not the conditions
 const Pair = /*YAK Extracted CSS:
-.ym7uBBuH {
+.ym7uBBuF {
   color: red;
 }
-.ym7uBBuI {
+.ym7uBBuG {
   top: 0;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuG", ({ $a })=>$a && /*#__PURE__*/ css("ym7uBBuH"), ({ $b })=>$b && /*#__PURE__*/ css("ym7uBBuI"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuE", ({ $a })=>$a && /*#__PURE__*/ css("ym7uBBuF"), ({ $b })=>$b && /*#__PURE__*/ css("ym7uBBuG"));
 // folds: a single condition to pin what counts as safe to inline
 const colors = {
     big: "red"
 } as Record<string, string>;
 const Boxed = /*YAK Extracted CSS:
-.ym7uBBuK {
+.ym7uBBuI {
   color: red;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuJ", ({ $v })=>$v && /*#__PURE__*/ css("ym7uBBuK"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuH", ({ $v })=>$v && /*#__PURE__*/ css("ym7uBBuI"));
 // folds: an arrow returning from a block body is a condition like any other
 const BlockBody = /*YAK Extracted CSS:
-.ym7uBBuL {
+.ym7uBBuJ {
   padding: 1px;
 }
-.ym7uBBuM {
+.ym7uBBuK {
   padding: 8px;
 }
-*/ /*#__PURE__*/ __yak.__yak_aside("ym7uBBuL", ({ $wide })=>{
-    return $wide && /*#__PURE__*/ css("ym7uBBuM");
+*/ /*#__PURE__*/ __yak.__yak_aside("ym7uBBuJ", ({ $wide })=>{
+    return $wide && /*#__PURE__*/ css("ym7uBBuK");
 });
 // usages bail: only plain destructuring substitutes - a rename, a default or a
 // rest element all keep the runtime path
 const Renamed = /*YAK Extracted CSS:
+.ym7uBBuM {
+  padding: 8px;
+}
+*/ /*#__PURE__*/ __yak.__yak_mark("ym7uBBuL", ({ $size: size })=>size && size === "big" && /*#__PURE__*/ css("ym7uBBuM"));
+const Defaulted = /*YAK Extracted CSS:
 .ym7uBBuO {
   padding: 8px;
 }
-*/ /*#__PURE__*/ __yak.__yak_mark("ym7uBBuN", ({ $size: size })=>size && size === "big" && /*#__PURE__*/ css("ym7uBBuO"));
-const Defaulted = /*YAK Extracted CSS:
+*/ /*#__PURE__*/ __yak.__yak_mark("ym7uBBuN", ({ $size = "big" })=>$size === "big" && /*#__PURE__*/ css("ym7uBBuO"));
+const Rested = /*YAK Extracted CSS:
 .ym7uBBuQ {
   padding: 8px;
 }
-*/ /*#__PURE__*/ __yak.__yak_mark("ym7uBBuP", ({ $size = "big" })=>$size === "big" && /*#__PURE__*/ css("ym7uBBuQ"));
-const Rested = /*YAK Extracted CSS:
-.ym7uBBuS {
-  padding: 8px;
+*/ /*#__PURE__*/ __yak.__yak_mark("ym7uBBuP", ({ $size, ...rest })=>$size && rest && /*#__PURE__*/ css("ym7uBBuQ"));
+// usages bail: a function expression binds this/arguments, which inlining
+// would rebind to the enclosing component
+const Fn = /*YAK Extracted CSS:
+.ym7uBBuR {
+  color: gray;
 }
-*/ /*#__PURE__*/ __yak.__yak_mark("ym7uBBuR", ({ $size, ...rest })=>$size && rest && /*#__PURE__*/ css("ym7uBBuS"));
+.ym7uBBuS {
+  color: black;
+}
+*/ /*#__PURE__*/ __yak.__yak_i("ym7uBBuR", function({ $on }) {
+    return $on && /*#__PURE__*/ css("ym7uBBuS");
+});
 // folds: non-$ props toggle classes AND stay on the element - the attribute
 // value ends up in the DOM attribute and the className condition
 const ActionButton = /*YAK Extracted CSS:
@@ -272,69 +272,68 @@ const Optimizable = ({ active, size, i: i1 }: {
     <p className={"ym7uBBu2" + ("primary" === "primary" ? " ym7uBBu3" : " ym7uBBu4") + (true ? " ym7uBBu5" : "")}>
       two inlined expressions
     </p>
-    <Fn $on={active}>function form</Fn>
-    <em className={"ym7uBBu8" + (isCompact ? " ym7uBBu9" : "")}>outer scope condition</em>
-    <li className={"ym7uBBuA" + (size && size === "big" ? " ym7uBBuB" : "")}>safe to duplicate</li>
+    <em className={"ym7uBBu6" + (isCompact ? " ym7uBBu7" : "")}>outer scope condition</em>
+    <li className={"ym7uBBu8" + (size && size === "big" ? " ym7uBBu9" : "")}>safe to duplicate</li>
     <button disabled={active} className={"ym7uBBuT" + (!active ? " ym7uBBuU" : "")}>kept on the element and inlined</button>
     <button disabled className={"ym7uBBuT" + (!true ? " ym7uBBuU" : "")}>bare non-$ prop</button>
     { /* two read sites, so the value is bound once instead of rolled twice -
         the two conditions could otherwise disagree */ }
-    <li className={((__yak_$size)=>"ym7uBBuA" + (__yak_$size && __yak_$size === "big" ? " ym7uBBuB" : ""))(props.getSize())}>bound: read at two sites</li>
+    <li className={((__yak_$size)=>"ym7uBBu8" + (__yak_$size && __yak_$size === "big" ? " ym7uBBu9" : ""))(props.getSize())}>bound: read at two sites</li>
     { /* the attribute stays on the element AND feeds the condition, so binding
         it around the element is the only way to evaluate it once - otherwise
         the button could be disabled while it is styled as enabled */ }
     {((__yak_disabled)=><button disabled={__yak_disabled} className={"ym7uBBuT" + (!__yak_disabled ? " ym7uBBuU" : "")}>bound: element and condition</button>)(props.isBusy())}
     { /* one read, but inside a callback: the value would run once per list
         element */ }
-    <div className={((__yak_$n)=>"ym7uBBuC" + (sizes.some((x)=>x > __yak_$n) ? " ym7uBBuD" : ""))(props.roll())}>bound: read inside a callback</div>
+    <div className={((__yak_$n)=>"ym7uBBuA" + (sizes.some((x)=>x > __yak_$n) ? " ym7uBBuB" : ""))(props.roll())}>bound: read inside a callback</div>
     { /* one read, but behind a short circuit: the value would not run at all */ }
-    <div className={((__yak_$b)=>"ym7uBBuE" + (isCompact && __yak_$b ? " ym7uBBuF" : ""))(props.roll())}>bound: read behind a short circuit</div>
+    <div className={((__yak_$b)=>"ym7uBBuC" + (isCompact && __yak_$b ? " ym7uBBuD" : ""))(props.roll())}>bound: read behind a short circuit</div>
     { /* the allowlist is not "does it contain a call" - none of these is one */ }
-    <div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(i1++)}>bound: update expression</div>
-    <div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(new Date())}>bound: new expression</div>
-    <div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(props.getSize() as number)}>bound: judged under the type cast</div>
+    <div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(i1++)}>bound: update expression</div>
+    <div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(new Date())}>bound: new expression</div>
+    <div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(props.getSize() as number)}>bound: judged under the type cast</div>
     { /* effect free but identity bearing - two reads would be two elements */ }
-    <div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(<i/>)}>bound: jsx element</div>
+    <div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(<i/>)}>bound: jsx element</div>
     { /* an impure builtin is bound like any other call, and stays in argument
         position: React's own purity rule flags it here exactly as it flags it
         in the source */ }
-    <div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(Math.random())}>bound: impure builtin</div>
+    <div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(Math.random())}>bound: impure builtin</div>
     { /* inlined: a computed member over pure operands, and a comparison - the
         most common dynamic prop shapes there are */ }
-    <div className={"ym7uBBuJ" + (colors[size!] ? " ym7uBBuK" : "")}>inlined: computed member</div>
-    <div className={"ym7uBBuJ" + (i1 % 4 !== 0 ? " ym7uBBuK" : "")}>inlined: comparison</div>
+    <div className={"ym7uBBuH" + (colors[size!] ? " ym7uBBuI" : "")}>inlined: computed member</div>
+    <div className={"ym7uBBuH" + (i1 % 4 !== 0 ? " ym7uBBuI" : "")}>inlined: comparison</div>
     { /* the conditions read $a first; the arguments follow the attributes */ }
-    <div className={((__yak_$b, __yak_$a)=>"ym7uBBuG" + (__yak_$a ? " ym7uBBuH" : "") + (__yak_$b ? " ym7uBBuI" : ""))(props.roll(), props.getSize())}>bound: arguments in attribute order</div>
+    <div className={((__yak_$b, __yak_$a)=>"ym7uBBuE" + (__yak_$a ? " ym7uBBuF" : "") + (__yak_$b ? " ym7uBBuG" : ""))(props.roll(), props.getSize())}>bound: arguments in attribute order</div>
     { /* attribute position ran getSize() twice, so binding does too */ }
-    <div className={((__yak_$b, __yak_$a)=>"ym7uBBuG" + (__yak_$a ? " ym7uBBuH" : "") + (__yak_$b ? " ym7uBBuI" : ""))(props.getSize(), props.getSize())}>bound: never deduplicated</div>
+    <div className={((__yak_$b, __yak_$a)=>"ym7uBBuE" + (__yak_$a ? " ym7uBBuF" : "") + (__yak_$b ? " ym7uBBuG" : ""))(props.getSize(), props.getSize())}>bound: never deduplicated</div>
     { /* read by no condition: it never leaves attribute position */ }
-    <div id={props.getSize()} className={"ym7uBBuJ" + (active ? " ym7uBBuK" : "")}>inlined: unread attribute stays put</div>
+    <div id={props.getSize()} className={"ym7uBBuH" + (active ? " ym7uBBuI" : "")}>inlined: unread attribute stays put</div>
     { /* an arrow may move, so an event handler never forces the element-wrap */ }
-    <div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(props.roll())} onClick={()=>props.track()}>bound: handler may move</div>
+    <div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(props.roll())} onClick={()=>props.track()}>bound: handler may move</div>
     { /* the user className composes around the block, after it - which is where
         it already ran */ }
-    <div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(props.roll()) + " user"}>bound: static className merge</div>
-    <div className={__yak_mergeClassNames(((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(props.roll()), size)}>bound: runtime className merge</div>
+    <div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(props.roll()) + " user"}>bound: static className merge</div>
+    <div className={__yak_mergeClassNames(((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(props.roll()), size)}>bound: runtime className merge</div>
     <button className={"ym7uBBul" + (!(i1 % 4 !== 0) ? " ym7uBBum" : "") + ("primary" === "secondary" ? " ym7uBBun" : "") + ("primary" === "ghost" ? " ym7uBBuo" : "") + (i1 % 3 === 0 ? " ym7uBBup" : "")}>
       {i1}
     </button>
     <li key={i1} className={"ym7uBBuy" + (active ? " ym7uBBuz" : "")}>
       key at the call site still folds
     </li>
-    <aside className={"ym7uBBuL" + (active ? " ym7uBBuM" : "")}>block body arrow</aside>
+    <aside className={"ym7uBBuJ" + (active ? " ym7uBBuK" : "")}>block body arrow</aside>
     { /* getSize() ran between the two rolls, and may not jump the parameter
         block, so the whole element is wrapped and captures all three in
         source order */ }
-    {((__yak_$a, __yak_id, __yak_$b)=><div id={__yak_id} className={"ym7uBBuG" + (__yak_$a ? " ym7uBBuH" : "") + (__yak_$b ? " ym7uBBuI" : "")}>
+    {((__yak_$a, __yak_id, __yak_$b)=><div id={__yak_id} className={"ym7uBBuE" + (__yak_$a ? " ym7uBBuF" : "") + (__yak_$b ? " ym7uBBuG" : "")}>
       wrapped: nothing may jump the block
     </div>)(props.roll(), props.getSize(), props.roll())}
     { /* the user className ran BEFORE the roll, and it composes around the
         block, which would run it after - so this escalates too */ }
-    {((__yak_className, __yak_$v)=><div className={__yak_mergeClassNames("ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""), __yak_className)}>wrapped: className ran first</div>)(props.getSize(), props.roll())}
+    {((__yak_className, __yak_$v)=><div className={__yak_mergeClassNames("ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""), __yak_className)}>wrapped: className ran first</div>)(props.getSize(), props.roll())}
     { /* an unread $prop is dropped before the DOM, so its value never runs at
         all - a side effect nobody consumes, which React's purity rule already
         forbids */ }
-    <div className={"ym7uBBuJ" + (active ? " ym7uBBuK" : "")}>elided: unread $prop</div>
+    <div className={"ym7uBBuH" + (active ? " ym7uBBuI" : "")}>elided: unread $prop</div>
     { /* key and children stay normal JSX on the wrapped element */ }
     {sizes.map((it)=>((__yak_disabled)=><button key={it} disabled={__yak_disabled} className={"ym7uBBuT" + (!__yak_disabled ? " ym7uBBuU" : "")}>
         wrapped in a list
@@ -343,7 +342,7 @@ const Optimizable = ({ active, size, i: i1 }: {
 // folds: await is legal in an async server component and impure, so it is
 // bound - which only works because the value never moves out of argument
 // position: awaiting inside the synthesized closure would not even parse
-const AsyncPage = async ()=><div className={((__yak_$v)=>"ym7uBBuJ" + (__yak_$v ? " ym7uBBuK" : ""))(await props.load())}>bound: await stays an argument</div>;
+const AsyncPage = async ()=><div className={((__yak_$v)=>"ym7uBBuH" + (__yak_$v ? " ym7uBBuI" : ""))(await props.load())}>bound: await stays an argument</div>;
 const NotOptimizable = ()=><>
     <IconContainer {...props}>bails: spread</IconContainer>
     <Themed $accent>bails: theme access</Themed>
@@ -359,6 +358,7 @@ const NotOptimizable = ()=><>
     <Renamed $size="big">bails: renamed destructuring</Renamed>
     <Defaulted>bails: default value destructuring</Defaulted>
     <Rested $size="big">bails: rest element destructuring</Rested>
+    <Fn $on>bails: function expression condition</Fn>
     { /* spriteFor() would jump both rolls: the namespaced name is the only
         difference from the wrapped `id={...}` case above */ }
     <Sprite $active={props.roll()} xlink:href={props.getSize()} $muted={props.roll()}>


### PR DESCRIPTION
A `function` expression binds its own `this` and `arguments`. Inlining a condition body deletes that binding, so `${function () { return arguments.length > 1 && css`…`; }}` folded into whatever the enclosing component provides: a ReferenceError under an arrow component, or — worse — silently the component's own `arguments` under a `function` component. Arrows never had this problem, and nobody writes `this`/`arguments` in a style condition on purpose, so this shape isn't worth inlining machinery.

Instead of scanning bodies for `this`/`arguments` references (which would need scope tracking — nested arrows see the outer function's `arguments`), function expressions now simply don't register for folding: `Expr::Fn` is dropped from the registration gate and the now-unreachable inlining arm is deleted, net −10 lines. Their usages keep the runtime path, where both bindings are well-defined and behavior is unchanged.

The `Fn` case in `styled-jsx-dynamic-folding` flips from pinning the fold to pinning the bail; all other snapshots are byte-identical. 365 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)