### PR TITLE
Reject style references in the css prop instead of silently dropping them

### DIFF
--- a/.changeset/cssprop-style-reference-error.md
+++ b/.changeset/cssprop-style-reference-error.md
@@ -1,0 +1,5 @@
+---
+"yak-swc": minor
+---
+
+The css prop now rejects references to styles declared elsewhere (`css={mixin}`, `css={on && mixin}`, `css={on ? mixin : css`…`}`) with a compile error instead of silently dropping the referenced styles — a mixin only compiles its declarations into template consumers, so these usages rendered unstyled without any signal. Wrap the reference in a css template instead: `css={css`${mixin}`}`. Inline templates in ternary and logical arms are unaffected.

--- a/packages/yak-swc/yak_swc/src/utils/css_prop.rs
+++ b/packages/yak-swc/yak_swc/src/utils/css_prop.rs
@@ -1,10 +1,11 @@
+use crate::utils::ast_helper::unwrap_type_casts;
 use crate::utils::class_name_fold::{class_name_attr, expr_attr_value, fold_css_expr};
 use crate::yak_imports::YakImports;
 use swc_core::{
   common::errors::HANDLER,
-  common::{Span, SyntaxContext, DUMMY_SP},
+  common::{Span, Spanned, SyntaxContext, DUMMY_SP},
   ecma::ast::{
-    CallExpr, Callee, Expr, ExprOrSpread, Ident, JSXAttr, JSXAttrName, JSXAttrOrSpread,
+    BinaryOp, CallExpr, Callee, Expr, ExprOrSpread, Ident, JSXAttr, JSXAttrName, JSXAttrOrSpread,
     JSXAttrValue, JSXExpr, JSXExprContainer, JSXOpeningElement, KeyValueProp, Lit, ObjectLit, Prop,
     PropName, PropOrSpread, SpreadElement,
   },
@@ -67,6 +68,9 @@ impl CSSProp {
     let merge_call: Result<Box<Expr>, TransformError> = (|| {
       let css_expr =
         Self::extract_css_expr(&opening_element.attrs[self.index], opening_element.span)?;
+      if let Some(span) = Self::find_style_reference(&css_expr) {
+        return Err(TransformError::StyleReference(span));
+      }
       let mapped_props = self
         .relevant_props
         .iter()
@@ -152,6 +156,35 @@ impl CSSProp {
     };
     opening_element.attrs[self.index] = class_name_attr(expr_attr_value(class_name_expr));
     true
+  }
+
+  /// Finds a reference to styles declared elsewhere (`css={mixin}`,
+  /// `css={styles.padding}`) in a css value position - at the top level or in
+  /// the value arms of ternaries and logical expressions
+  ///
+  /// The css prop only compiles styles in place: a mixin declaration compiles
+  /// to an argument-less `css()` carrying no class and no CSS, on the
+  /// assumption that every consumer inlined the declarations. The css prop
+  /// never inlines, so a reference renders unstyled without any signal -
+  /// rejecting it loudly is the only place this can be caught (the TypeScript
+  /// types cannot distinguish a reference from an inline template)
+  fn find_style_reference(expr: &Expr) -> Option<Span> {
+    match unwrap_type_casts(expr) {
+      Expr::Cond(cond) => {
+        Self::find_style_reference(&cond.cons).or_else(|| Self::find_style_reference(&cond.alt))
+      }
+      // `cond && css` - only the right hand side is a css value
+      Expr::Bin(bin) if bin.op == BinaryOp::LogicalAnd => Self::find_style_reference(&bin.right),
+      // `a || b` and `a ?? b` - both sides are css values
+      Expr::Bin(bin) if matches!(bin.op, BinaryOp::LogicalOr | BinaryOp::NullishCoalescing) => {
+        Self::find_style_reference(&bin.left).or_else(|| Self::find_style_reference(&bin.right))
+      }
+      // `undefined` is a valid falsy css value, any other identifier is a reference
+      Expr::Ident(ident) if ident.sym != "undefined" => Some(ident.span),
+      Expr::Member(member) => Some(member.span()),
+      Expr::OptChain(opt_chain) => Some(opt_chain.span),
+      _ => None,
+    }
   }
 
   /// Extracts the CSS expression from a JSX attribute or spread element.
@@ -273,6 +306,7 @@ pub enum TransformError {
   MissingAttributeValue(Span),
   InvalidJSXEmptyExpr(Span),
   UnsupportedAttributeValue(Span),
+  StyleReference(Span),
   #[cfg(swc_ast_unknown)]
   UnsupportedJSXAttrOrSpread(),
 }
@@ -285,7 +319,8 @@ impl TransformError {
       | TransformError::InvalidJSXAttribute(span)
       | TransformError::MissingAttributeValue(span)
       | TransformError::InvalidJSXEmptyExpr(span)
-      | TransformError::UnsupportedAttributeValue(span) => *span,
+      | TransformError::UnsupportedAttributeValue(span)
+      | TransformError::StyleReference(span) => *span,
       #[cfg(swc_ast_unknown)]
       TransformError::UnsupportedJSXAttrOrSpread() => Span::default(),
     }
@@ -316,6 +351,12 @@ impl TransformError {
             TransformError::UnsupportedAttributeValue(_) =>
                 "Unsupported attribute value type. Use string literals for className, \
                 template literals for css prop, and object literals for style prop.",
+
+            TransformError::StyleReference(_) =>
+                "References to styles declared elsewhere are not supported in the 'css' prop - \
+                the referenced styles are not compiled at this usage and would silently never apply. \
+                Wrap the reference in a css template instead. \
+                Example: css={css`${mixin}`}",
 
             #[cfg(swc_ast_unknown)]
             TransformError::UnsupportedJSXAttrOrSpread() =>

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/input.tsx
@@ -3,10 +3,6 @@
 // the bail-out that keeps it on the runtime path
 import { css } from "next-yak";
 
-const mixin = css`
-  color: red;
-`;
-
 // folds: a top level `&&` becomes `on ? "class" : ""`
 // the fold has to keep the /*YAK Extracted CSS:*/ comment the loader parses,
 // otherwise the component ships unstyled
@@ -67,13 +63,5 @@ const LogicalAndDynamic = ({ on, color }: { on: boolean; color: string }) => (
   />
 );
 
-// bails: the `&&` right hand side is an Expr::Ident, not a css() call
-const LogicalAndMixin = ({ on }: { on: boolean }) => <div css={on && mixin} />;
-
-// bails: a mixin reference is an Expr::Ident, not a css() call
-// this pins a known gap rather than the fold: the css prop does not inline a
-// mixin the way a template consumer `${mixin}` does, so `color: red` never
-// ships and this renders unstyled
-// (teaching the fold Expr::Ident would not change it - a mixin compiles to an
-// argument-less css(), which has no base class to fold)
-const MixinIdentifier = () => <div css={mixin} />;
+// mixin references (`css={mixin}`, `css={on && mixin}`) are rejected with a
+// compile error - see the css-prop-style-reference fixture

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.dev.tsx
@@ -3,7 +3,6 @@
 // the bail-out that keeps it on the runtime path
 import { css, __yak_mergeCssProp } from "next-yak/internal";
 import "./input.yak.module.css!=!./input?./input.yak.module.css";
-const mixin = /*#__PURE__*/ css();
 // folds: a top level `&&` becomes `on ? "class" : ""`
 // the fold has to keep the /*YAK Extracted CSS:*/ comment the loader parses,
 // otherwise the component ships unstyled
@@ -51,15 +50,5 @@ const LogicalAndDynamic = ({ on, color }: {
         "style": {
             "--input_LogicalAndDynamic__color_m7uBBu": ()=>color
         }
-    }, "input_LogicalAndDynamic_m7uBBu"))}/>;
-// bails: the `&&` right hand side is an Expr::Ident, not a css() call
-const LogicalAndMixin = ({ on }: {
-    on: boolean;
-})=><div {...__yak_mergeCssProp({}, on && mixin)}/>;
-// bails: a mixin reference is an Expr::Ident, not a css() call
-// this pins a known gap rather than the fold: the css prop does not inline a
-// mixin the way a template consumer `${mixin}` does, so `color: red` never
-// ships and this renders unstyled
-// (teaching the fold Expr::Ident would not change it - a mixin compiles to an
-// argument-less css(), which has no base class to fold)
-const MixinIdentifier = ()=><div {...__yak_mergeCssProp({}, mixin)}/>;
+    }, "input_LogicalAndDynamic_m7uBBu"))}/>; // mixin references (`css={mixin}`, `css={on && mixin}`) are rejected with a
+ // compile error - see the css-prop-style-reference fixture

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.prod.tsx
@@ -3,40 +3,39 @@
 // the bail-out that keeps it on the runtime path
 import { css, __yak_mergeCssProp } from "next-yak/internal";
 import "./input.yak.module.css!=!./input?./input.yak.module.css";
-const mixin = /*#__PURE__*/ css();
 // folds: a top level `&&` becomes `on ? "class" : ""`
 // the fold has to keep the /*YAK Extracted CSS:*/ comment the loader parses,
 // otherwise the component ships unstyled
 const LogicalAnd = ({ on }: {
     on: boolean;
 })=><div className={/*YAK Extracted CSS:
-:global(.ym7uBBu1) {
+:global(.ym7uBBu) {
   color: blue;
 }
-*/ /*#__PURE__*/ on ? "ym7uBBu1" : ""}/>;
+*/ /*#__PURE__*/ on ? "ym7uBBu" : ""}/>;
 // folds: several condition segments in one template concatenate
 const ManySegments = ({ a, b }: {
     a: boolean;
     b: boolean;
 })=><div className={/*YAK Extracted CSS:
-:global(.ym7uBBu2) {
+:global(.ym7uBBu1) {
   color: black;
 }
-:global(.ym7uBBu3) {
+:global(.ym7uBBu2) {
   color: red;
 }
-:global(.ym7uBBu4) {
+:global(.ym7uBBu3) {
   font-weight: bold;
 }
-*/ /*#__PURE__*/ "ym7uBBu2" + (a ? " ym7uBBu3" : "") + (b ? " ym7uBBu4" : "")}/>;
+*/ /*#__PURE__*/ "ym7uBBu1" + (a ? " ym7uBBu2" : "") + (b ? " ym7uBBu3" : "")}/>;
 // folds: a falsy ternary branch applies no styles and yields no class name
 const TernaryUndefined = ({ on }: {
     on: boolean;
 })=><div className={on ? /*YAK Extracted CSS:
-:global(.ym7uBBu5) {
+:global(.ym7uBBu4) {
   color: blue;
 }
-*/ /*#__PURE__*/ "ym7uBBu5" : ""}/>;
+*/ /*#__PURE__*/ "ym7uBBu4" : ""}/>;
 // bails: the `&&` right hand side carries a runtime css variable, so the css
 // call has more than a single static class argument and stays on the runtime
 // path
@@ -44,22 +43,12 @@ const LogicalAndDynamic = ({ on, color }: {
     on: boolean;
     color: string;
 })=><div {...__yak_mergeCssProp({}, on && /*YAK Extracted CSS:
-:global(.ym7uBBu6) {
-  color: var(--ym7uBBu7);
+:global(.ym7uBBu5) {
+  color: var(--ym7uBBu6);
 }
 */ /*#__PURE__*/ css({
         "style": {
-            "--ym7uBBu7": ()=>color
+            "--ym7uBBu6": ()=>color
         }
-    }, "ym7uBBu6"))}/>;
-// bails: the `&&` right hand side is an Expr::Ident, not a css() call
-const LogicalAndMixin = ({ on }: {
-    on: boolean;
-})=><div {...__yak_mergeCssProp({}, on && mixin)}/>;
-// bails: a mixin reference is an Expr::Ident, not a css() call
-// this pins a known gap rather than the fold: the css prop does not inline a
-// mixin the way a template consumer `${mixin}` does, so `color: red` never
-// ships and this renders unstyled
-// (teaching the fold Expr::Ident would not change it - a mixin compiles to an
-// argument-less css(), which has no base class to fold)
-const MixinIdentifier = ()=><div {...__yak_mergeCssProp({}, mixin)}/>;
+    }, "ym7uBBu5"))}/>; // mixin references (`css={mixin}`, `css={on && mixin}`) are rejected with a
+ // compile error - see the css-prop-style-reference fixture

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.turbo.dev.tsx
@@ -3,7 +3,6 @@
 // the bail-out that keeps it on the runtime path
 import { css, __yak_mergeCssProp } from "next-yak/internal";
 import "data:text/css;base64,LmlucHV0X0xvZ2ljYWxBbmRfbTd1QkJ1IHsKICBjb2xvcjogYmx1ZTsKfS5pbnB1dF9NYW55U2VnbWVudHNfbTd1QkJ1IHsKICBjb2xvcjogYmxhY2s7Cn0KLmlucHV0X01hbnlTZWdtZW50c19fYV9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0KLmlucHV0X01hbnlTZWdtZW50c19fYl9tN3VCQnUgewogIGZvbnQtd2VpZ2h0OiBib2xkOwp9LmlucHV0X1Rlcm5hcnlVbmRlZmluZWRfbTd1QkJ1IHsKICBjb2xvcjogYmx1ZTsKfS5pbnB1dF9Mb2dpY2FsQW5kRHluYW1pY19tN3VCQnUgewogIGNvbG9yOiB2YXIoLS1pbnB1dF9Mb2dpY2FsQW5kRHluYW1pY19fY29sb3JfbTd1QkJ1KTsKfQ==";
-const mixin = /*#__PURE__*/ css();
 // folds: a top level `&&` becomes `on ? "class" : ""`
 // the fold has to keep the /*YAK Extracted CSS:*/ comment the loader parses,
 // otherwise the component ships unstyled
@@ -51,15 +50,5 @@ const LogicalAndDynamic = ({ on, color }: {
         "style": {
             "--input_LogicalAndDynamic__color_m7uBBu": ()=>color
         }
-    }, "input_LogicalAndDynamic_m7uBBu"))}/>;
-// bails: the `&&` right hand side is an Expr::Ident, not a css() call
-const LogicalAndMixin = ({ on }: {
-    on: boolean;
-})=><div {...__yak_mergeCssProp({}, on && mixin)}/>;
-// bails: a mixin reference is an Expr::Ident, not a css() call
-// this pins a known gap rather than the fold: the css prop does not inline a
-// mixin the way a template consumer `${mixin}` does, so `color: red` never
-// ships and this renders unstyled
-// (teaching the fold Expr::Ident would not change it - a mixin compiles to an
-// argument-less css(), which has no base class to fold)
-const MixinIdentifier = ()=><div {...__yak_mergeCssProp({}, mixin)}/>;
+    }, "input_LogicalAndDynamic_m7uBBu"))}/>; // mixin references (`css={mixin}`, `css={on && mixin}`) are rejected with a
+ // compile error - see the css-prop-style-reference fixture

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-fold-bailouts/output.turbo.prod.tsx
@@ -2,41 +2,40 @@
 // ternaries and a top level `&&`, so every shape below pins either the fold or
 // the bail-out that keeps it on the runtime path
 import { css, __yak_mergeCssProp } from "next-yak/internal";
-import "data:text/css;base64,LnltN3VCQnUxIHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1MiB7CiAgY29sb3I6IGJsYWNrOwp9Ci55bTd1QkJ1MyB7CiAgY29sb3I6IHJlZDsKfQoueW03dUJCdTQgewogIGZvbnQtd2VpZ2h0OiBib2xkOwp9LnltN3VCQnU1IHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1NiB7CiAgY29sb3I6IHZhcigtLXltN3VCQnU3KTsKfQ==";
-const mixin = /*#__PURE__*/ css();
+import "data:text/css;base64,LnltN3VCQnUgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnUxIHsKICBjb2xvcjogYmxhY2s7Cn0KLnltN3VCQnUyIHsKICBjb2xvcjogcmVkOwp9Ci55bTd1QkJ1MyB7CiAgZm9udC13ZWlnaHQ6IGJvbGQ7Cn0ueW03dUJCdTQgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnU1IHsKICBjb2xvcjogdmFyKC0teW03dUJCdTYpOwp9";
 // folds: a top level `&&` becomes `on ? "class" : ""`
 // the fold has to keep the /*YAK Extracted CSS:*/ comment the loader parses,
 // otherwise the component ships unstyled
 const LogicalAnd = ({ on }: {
     on: boolean;
 })=><div className={/*YAK Extracted CSS:
-.ym7uBBu1 {
+.ym7uBBu {
   color: blue;
 }
-*/ /*#__PURE__*/ on ? "ym7uBBu1" : ""}/>;
+*/ /*#__PURE__*/ on ? "ym7uBBu" : ""}/>;
 // folds: several condition segments in one template concatenate
 const ManySegments = ({ a, b }: {
     a: boolean;
     b: boolean;
 })=><div className={/*YAK Extracted CSS:
-.ym7uBBu2 {
+.ym7uBBu1 {
   color: black;
 }
-.ym7uBBu3 {
+.ym7uBBu2 {
   color: red;
 }
-.ym7uBBu4 {
+.ym7uBBu3 {
   font-weight: bold;
 }
-*/ /*#__PURE__*/ "ym7uBBu2" + (a ? " ym7uBBu3" : "") + (b ? " ym7uBBu4" : "")}/>;
+*/ /*#__PURE__*/ "ym7uBBu1" + (a ? " ym7uBBu2" : "") + (b ? " ym7uBBu3" : "")}/>;
 // folds: a falsy ternary branch applies no styles and yields no class name
 const TernaryUndefined = ({ on }: {
     on: boolean;
 })=><div className={on ? /*YAK Extracted CSS:
-.ym7uBBu5 {
+.ym7uBBu4 {
   color: blue;
 }
-*/ /*#__PURE__*/ "ym7uBBu5" : ""}/>;
+*/ /*#__PURE__*/ "ym7uBBu4" : ""}/>;
 // bails: the `&&` right hand side carries a runtime css variable, so the css
 // call has more than a single static class argument and stays on the runtime
 // path
@@ -44,22 +43,12 @@ const LogicalAndDynamic = ({ on, color }: {
     on: boolean;
     color: string;
 })=><div {...__yak_mergeCssProp({}, on && /*YAK Extracted CSS:
-.ym7uBBu6 {
-  color: var(--ym7uBBu7);
+.ym7uBBu5 {
+  color: var(--ym7uBBu6);
 }
 */ /*#__PURE__*/ css({
         "style": {
-            "--ym7uBBu7": ()=>color
+            "--ym7uBBu6": ()=>color
         }
-    }, "ym7uBBu6"))}/>;
-// bails: the `&&` right hand side is an Expr::Ident, not a css() call
-const LogicalAndMixin = ({ on }: {
-    on: boolean;
-})=><div {...__yak_mergeCssProp({}, on && mixin)}/>;
-// bails: a mixin reference is an Expr::Ident, not a css() call
-// this pins a known gap rather than the fold: the css prop does not inline a
-// mixin the way a template consumer `${mixin}` does, so `color: red` never
-// ships and this renders unstyled
-// (teaching the fold Expr::Ident would not change it - a mixin compiles to an
-// argument-less css(), which has no base class to fold)
-const MixinIdentifier = ()=><div {...__yak_mergeCssProp({}, mixin)}/>;
+    }, "ym7uBBu5"))}/>; // mixin references (`css={mixin}`, `css={on && mixin}`) are rejected with a
+ // compile error - see the css-prop-style-reference fixture

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.dev.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.dev.stderr
@@ -5,3 +5,10 @@
    :                    ^^^^^^^^^^^^^^^^^^^^^
  5 | const Elem2 = (props: any) => <div css={props} />;
    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+   ,-[input.js:5:1]
+ 4 | const Elem = () => <div css="invalid" />;
+ 5 | const Elem2 = (props: any) => <div css={props} />;
+   :                                         ^^^^^
+   `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.dev.tsx
@@ -1,4 +1,4 @@
 import { css, __yak_mergeCssProp } from "next-yak/internal";
 const styles = /*#__PURE__*/ css();
 const Elem = ()=><div css="invalid"/>;
-const Elem2 = (props: any)=><div {...__yak_mergeCssProp({}, props)}/>;
+const Elem2 = (props: any)=><div css={props}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.prod.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.prod.stderr
@@ -5,3 +5,10 @@
    :                    ^^^^^^^^^^^^^^^^^^^^^
  5 | const Elem2 = (props: any) => <div css={props} />;
    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+   ,-[input.js:5:1]
+ 4 | const Elem = () => <div css="invalid" />;
+ 5 | const Elem2 = (props: any) => <div css={props} />;
+   :                                         ^^^^^
+   `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.prod.tsx
@@ -1,4 +1,4 @@
 import { css, __yak_mergeCssProp } from "next-yak/internal";
 const styles = /*#__PURE__*/ css();
 const Elem = ()=><div css="invalid"/>;
-const Elem2 = (props: any)=><div {...__yak_mergeCssProp({}, props)}/>;
+const Elem2 = (props: any)=><div css={props}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.dev.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.dev.stderr
@@ -5,3 +5,10 @@
    :                    ^^^^^^^^^^^^^^^^^^^^^
  5 | const Elem2 = (props: any) => <div css={props} />;
    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+   ,-[input.js:5:1]
+ 4 | const Elem = () => <div css="invalid" />;
+ 5 | const Elem2 = (props: any) => <div css={props} />;
+   :                                         ^^^^^
+   `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.dev.tsx
@@ -1,4 +1,4 @@
 import { css, __yak_mergeCssProp } from "next-yak/internal";
 const styles = /*#__PURE__*/ css();
 const Elem = ()=><div css="invalid"/>;
-const Elem2 = (props: any)=><div {...__yak_mergeCssProp({}, props)}/>;
+const Elem2 = (props: any)=><div css={props}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.prod.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.prod.stderr
@@ -5,3 +5,10 @@
    :                    ^^^^^^^^^^^^^^^^^^^^^
  5 | const Elem2 = (props: any) => <div css={props} />;
    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+   ,-[input.js:5:1]
+ 4 | const Elem = () => <div css="invalid" />;
+ 5 | const Elem2 = (props: any) => <div css={props} />;
+   :                                         ^^^^^
+   `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.prod.tsx
@@ -1,4 +1,4 @@
 import { css, __yak_mergeCssProp } from "next-yak/internal";
 const styles = /*#__PURE__*/ css();
 const Elem = ()=><div css="invalid"/>;
-const Elem2 = (props: any)=><div {...__yak_mergeCssProp({}, props)}/>;
+const Elem2 = (props: any)=><div css={props}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/input.tsx
@@ -1,0 +1,66 @@
+// References to styles declared elsewhere are rejected with a compile error:
+// a mixin compiles to an argument-less css() carrying no class and no CSS
+// (its declarations are inlined at template consumers), so a css prop
+// reference would render unstyled without any signal.
+// Inline templates in ternary and logical arms keep working - only the
+// reference arms error.
+import { css } from "next-yak";
+import { ellipsis } from "./typography";
+import * as tokens from "./tokens";
+
+const mixin = css`
+  color: red;
+`;
+
+// errors: a same-file mixin reference
+const Direct = () => <div css={mixin} />;
+
+// errors: an imported mixin reference compiles identically
+const Imported = () => <div css={ellipsis} />;
+
+// errors: a member reference
+const Member = () => <div css={tokens.padding} />;
+
+// errors: the `&&` right hand side is a reference
+const LogicalAnd = ({ on }: { on: boolean }) => <div css={on && mixin} />;
+
+// errors: one ternary arm is a reference - the inline arm alone can not save it
+const TernaryArm = ({ compact }: { compact: boolean }) => (
+  <div
+    css={
+      compact
+        ? mixin
+        : css`
+            color: blue;
+          `
+    }
+  />
+);
+
+// keeps working: inline templates in both ternary arms
+const TernaryInline = ({ compact }: { compact: boolean }) => (
+  <div
+    css={
+      compact
+        ? css`
+            line-height: 1;
+          `
+        : css`
+            line-height: 1.5;
+          `
+    }
+  />
+);
+
+// keeps working: `undefined` is a valid falsy arm, not a reference
+const TernaryUndefined = ({ on }: { on: boolean }) => (
+  <div
+    css={
+      on
+        ? css`
+            color: green;
+          `
+        : undefined
+    }
+  />
+);

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.dev.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.dev.stderr
@@ -1,0 +1,36 @@
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:16:1]
+ 15 | // errors: a same-file mixin reference
+ 16 | const Direct = () => <div css={mixin} />;
+    :                                ^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:19:1]
+ 18 | // errors: an imported mixin reference compiles identically
+ 19 | const Imported = () => <div css={ellipsis} />;
+    :                                  ^^^^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:22:1]
+ 21 | // errors: a member reference
+ 22 | const Member = () => <div css={tokens.padding} />;
+    :                                ^^^^^^^^^^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:25:1]
+ 24 | // errors: the `&&` right hand side is a reference
+ 25 | const LogicalAnd = ({ on }: { on: boolean }) => <div css={on && mixin} />;
+    :                                                                 ^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:32:1]
+ 31 |       compact
+ 32 |         ? mixin
+    :           ^^^^^
+ 33 |         : css`
+    `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.dev.tsx
@@ -1,0 +1,49 @@
+// References to styles declared elsewhere are rejected with a compile error:
+// a mixin compiles to an argument-less css() carrying no class and no CSS
+// (its declarations are inlined at template consumers), so a css prop
+// reference would render unstyled without any signal.
+// Inline templates in ternary and logical arms keep working - only the
+// reference arms error.
+import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { ellipsis } from "./typography";
+import * as tokens from "./tokens";
+import "./input.yak.module.css!=!./input?./input.yak.module.css";
+const mixin = /*#__PURE__*/ css();
+// errors: a same-file mixin reference
+const Direct = ()=><div css={mixin}/>;
+// errors: an imported mixin reference compiles identically
+const Imported = ()=><div css={ellipsis}/>;
+// errors: a member reference
+const Member = ()=><div css={tokens.padding}/>;
+// errors: the `&&` right hand side is a reference
+const LogicalAnd = ({ on }: {
+    on: boolean;
+})=><div css={on && mixin}/>;
+// errors: one ternary arm is a reference - the inline arm alone can not save it
+const TernaryArm = ({ compact }: {
+    compact: boolean;
+})=><div css={compact ? mixin : /*YAK Extracted CSS:
+:global(.input_TernaryArm_m7uBBu) {
+  color: blue;
+}
+*/ /*#__PURE__*/ css("input_TernaryArm_m7uBBu")}/>;
+// keeps working: inline templates in both ternary arms
+const TernaryInline = ({ compact }: {
+    compact: boolean;
+})=><div className={compact ? /*YAK Extracted CSS:
+:global(.input_TernaryInline_m7uBBu) {
+  line-height: 1;
+}
+*/ /*#__PURE__*/ "input_TernaryInline_m7uBBu" : /*YAK Extracted CSS:
+:global(.input_TernaryInline_m7uBBu-01) {
+  line-height: 1.5;
+}
+*/ /*#__PURE__*/ "input_TernaryInline_m7uBBu-01"}/>;
+// keeps working: `undefined` is a valid falsy arm, not a reference
+const TernaryUndefined = ({ on }: {
+    on: boolean;
+})=><div className={on ? /*YAK Extracted CSS:
+:global(.input_TernaryUndefined_m7uBBu) {
+  color: green;
+}
+*/ /*#__PURE__*/ "input_TernaryUndefined_m7uBBu" : ""}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.prod.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.prod.stderr
@@ -1,0 +1,36 @@
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:16:1]
+ 15 | // errors: a same-file mixin reference
+ 16 | const Direct = () => <div css={mixin} />;
+    :                                ^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:19:1]
+ 18 | // errors: an imported mixin reference compiles identically
+ 19 | const Imported = () => <div css={ellipsis} />;
+    :                                  ^^^^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:22:1]
+ 21 | // errors: a member reference
+ 22 | const Member = () => <div css={tokens.padding} />;
+    :                                ^^^^^^^^^^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:25:1]
+ 24 | // errors: the `&&` right hand side is a reference
+ 25 | const LogicalAnd = ({ on }: { on: boolean }) => <div css={on && mixin} />;
+    :                                                                 ^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:32:1]
+ 31 |       compact
+ 32 |         ? mixin
+    :           ^^^^^
+ 33 |         : css`
+    `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.prod.tsx
@@ -1,0 +1,49 @@
+// References to styles declared elsewhere are rejected with a compile error:
+// a mixin compiles to an argument-less css() carrying no class and no CSS
+// (its declarations are inlined at template consumers), so a css prop
+// reference would render unstyled without any signal.
+// Inline templates in ternary and logical arms keep working - only the
+// reference arms error.
+import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { ellipsis } from "./typography";
+import * as tokens from "./tokens";
+import "./input.yak.module.css!=!./input?./input.yak.module.css";
+const mixin = /*#__PURE__*/ css();
+// errors: a same-file mixin reference
+const Direct = ()=><div css={mixin}/>;
+// errors: an imported mixin reference compiles identically
+const Imported = ()=><div css={ellipsis}/>;
+// errors: a member reference
+const Member = ()=><div css={tokens.padding}/>;
+// errors: the `&&` right hand side is a reference
+const LogicalAnd = ({ on }: {
+    on: boolean;
+})=><div css={on && mixin}/>;
+// errors: one ternary arm is a reference - the inline arm alone can not save it
+const TernaryArm = ({ compact }: {
+    compact: boolean;
+})=><div css={compact ? mixin : /*YAK Extracted CSS:
+:global(.ym7uBBu1) {
+  color: blue;
+}
+*/ /*#__PURE__*/ css("ym7uBBu1")}/>;
+// keeps working: inline templates in both ternary arms
+const TernaryInline = ({ compact }: {
+    compact: boolean;
+})=><div className={compact ? /*YAK Extracted CSS:
+:global(.ym7uBBu2) {
+  line-height: 1;
+}
+*/ /*#__PURE__*/ "ym7uBBu2" : /*YAK Extracted CSS:
+:global(.ym7uBBu3) {
+  line-height: 1.5;
+}
+*/ /*#__PURE__*/ "ym7uBBu3"}/>;
+// keeps working: `undefined` is a valid falsy arm, not a reference
+const TernaryUndefined = ({ on }: {
+    on: boolean;
+})=><div className={on ? /*YAK Extracted CSS:
+:global(.ym7uBBu4) {
+  color: green;
+}
+*/ /*#__PURE__*/ "ym7uBBu4" : ""}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.turbo.dev.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.turbo.dev.stderr
@@ -1,0 +1,36 @@
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:16:1]
+ 15 | // errors: a same-file mixin reference
+ 16 | const Direct = () => <div css={mixin} />;
+    :                                ^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:19:1]
+ 18 | // errors: an imported mixin reference compiles identically
+ 19 | const Imported = () => <div css={ellipsis} />;
+    :                                  ^^^^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:22:1]
+ 21 | // errors: a member reference
+ 22 | const Member = () => <div css={tokens.padding} />;
+    :                                ^^^^^^^^^^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:25:1]
+ 24 | // errors: the `&&` right hand side is a reference
+ 25 | const LogicalAnd = ({ on }: { on: boolean }) => <div css={on && mixin} />;
+    :                                                                 ^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:32:1]
+ 31 |       compact
+ 32 |         ? mixin
+    :           ^^^^^
+ 33 |         : css`
+    `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.turbo.dev.tsx
@@ -1,0 +1,49 @@
+// References to styles declared elsewhere are rejected with a compile error:
+// a mixin compiles to an argument-less css() carrying no class and no CSS
+// (its declarations are inlined at template consumers), so a css prop
+// reference would render unstyled without any signal.
+// Inline templates in ternary and logical arms keep working - only the
+// reference arms error.
+import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { ellipsis } from "./typography";
+import * as tokens from "./tokens";
+import "data:text/css;base64,LmlucHV0X1Rlcm5hcnlBcm1fbTd1QkJ1IHsKICBjb2xvcjogYmx1ZTsKfS5pbnB1dF9UZXJuYXJ5SW5saW5lX203dUJCdSB7CiAgbGluZS1oZWlnaHQ6IDE7Cn0uaW5wdXRfVGVybmFyeUlubGluZV9tN3VCQnUtMDEgewogIGxpbmUtaGVpZ2h0OiAxLjU7Cn0uaW5wdXRfVGVybmFyeVVuZGVmaW5lZF9tN3VCQnUgewogIGNvbG9yOiBncmVlbjsKfQ==";
+const mixin = /*#__PURE__*/ css();
+// errors: a same-file mixin reference
+const Direct = ()=><div css={mixin}/>;
+// errors: an imported mixin reference compiles identically
+const Imported = ()=><div css={ellipsis}/>;
+// errors: a member reference
+const Member = ()=><div css={tokens.padding}/>;
+// errors: the `&&` right hand side is a reference
+const LogicalAnd = ({ on }: {
+    on: boolean;
+})=><div css={on && mixin}/>;
+// errors: one ternary arm is a reference - the inline arm alone can not save it
+const TernaryArm = ({ compact }: {
+    compact: boolean;
+})=><div css={compact ? mixin : /*YAK Extracted CSS:
+.input_TernaryArm_m7uBBu {
+  color: blue;
+}
+*/ /*#__PURE__*/ css("input_TernaryArm_m7uBBu")}/>;
+// keeps working: inline templates in both ternary arms
+const TernaryInline = ({ compact }: {
+    compact: boolean;
+})=><div className={compact ? /*YAK Extracted CSS:
+.input_TernaryInline_m7uBBu {
+  line-height: 1;
+}
+*/ /*#__PURE__*/ "input_TernaryInline_m7uBBu" : /*YAK Extracted CSS:
+.input_TernaryInline_m7uBBu-01 {
+  line-height: 1.5;
+}
+*/ /*#__PURE__*/ "input_TernaryInline_m7uBBu-01"}/>;
+// keeps working: `undefined` is a valid falsy arm, not a reference
+const TernaryUndefined = ({ on }: {
+    on: boolean;
+})=><div className={on ? /*YAK Extracted CSS:
+.input_TernaryUndefined_m7uBBu {
+  color: green;
+}
+*/ /*#__PURE__*/ "input_TernaryUndefined_m7uBBu" : ""}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.turbo.prod.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.turbo.prod.stderr
@@ -1,0 +1,36 @@
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:16:1]
+ 15 | // errors: a same-file mixin reference
+ 16 | const Direct = () => <div css={mixin} />;
+    :                                ^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:19:1]
+ 18 | // errors: an imported mixin reference compiles identically
+ 19 | const Imported = () => <div css={ellipsis} />;
+    :                                  ^^^^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:22:1]
+ 21 | // errors: a member reference
+ 22 | const Member = () => <div css={tokens.padding} />;
+    :                                ^^^^^^^^^^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:25:1]
+ 24 | // errors: the `&&` right hand side is a reference
+ 25 | const LogicalAnd = ({ on }: { on: boolean }) => <div css={on && mixin} />;
+    :                                                                 ^^^^^
+    `----
+  x References to styles declared elsewhere are not supported in the 'css' prop - the referenced styles are not compiled at this usage and would silently never apply. Wrap the reference in a css
+  | template instead. Example: css={css`${mixin}`}
+    ,-[input.js:32:1]
+ 31 |       compact
+ 32 |         ? mixin
+    :           ^^^^^
+ 33 |         : css`
+    `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.turbo.prod.tsx
@@ -1,0 +1,49 @@
+// References to styles declared elsewhere are rejected with a compile error:
+// a mixin compiles to an argument-less css() carrying no class and no CSS
+// (its declarations are inlined at template consumers), so a css prop
+// reference would render unstyled without any signal.
+// Inline templates in ternary and logical arms keep working - only the
+// reference arms error.
+import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { ellipsis } from "./typography";
+import * as tokens from "./tokens";
+import "data:text/css;base64,LnltN3VCQnUxIHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1MiB7CiAgbGluZS1oZWlnaHQ6IDE7Cn0ueW03dUJCdTMgewogIGxpbmUtaGVpZ2h0OiAxLjU7Cn0ueW03dUJCdTQgewogIGNvbG9yOiBncmVlbjsKfQ==";
+const mixin = /*#__PURE__*/ css();
+// errors: a same-file mixin reference
+const Direct = ()=><div css={mixin}/>;
+// errors: an imported mixin reference compiles identically
+const Imported = ()=><div css={ellipsis}/>;
+// errors: a member reference
+const Member = ()=><div css={tokens.padding}/>;
+// errors: the `&&` right hand side is a reference
+const LogicalAnd = ({ on }: {
+    on: boolean;
+})=><div css={on && mixin}/>;
+// errors: one ternary arm is a reference - the inline arm alone can not save it
+const TernaryArm = ({ compact }: {
+    compact: boolean;
+})=><div css={compact ? mixin : /*YAK Extracted CSS:
+.ym7uBBu1 {
+  color: blue;
+}
+*/ /*#__PURE__*/ css("ym7uBBu1")}/>;
+// keeps working: inline templates in both ternary arms
+const TernaryInline = ({ compact }: {
+    compact: boolean;
+})=><div className={compact ? /*YAK Extracted CSS:
+.ym7uBBu2 {
+  line-height: 1;
+}
+*/ /*#__PURE__*/ "ym7uBBu2" : /*YAK Extracted CSS:
+.ym7uBBu3 {
+  line-height: 1.5;
+}
+*/ /*#__PURE__*/ "ym7uBBu3"}/>;
+// keeps working: `undefined` is a valid falsy arm, not a reference
+const TernaryUndefined = ({ on }: {
+    on: boolean;
+})=><div className={on ? /*YAK Extracted CSS:
+.ym7uBBu4 {
+  color: green;
+}
+*/ /*#__PURE__*/ "ym7uBBu4" : ""}/>;


### PR DESCRIPTION
`css={mixin}` type-checks (the types cannot distinguish a mixin reference from an inline template — both are the css template result type) and renders unstyled with no signal: a mixin compiles to an argument-less `css()` carrying no class and no CSS, because its declarations are only inlined at template consumers, and the css prop never inlines. Same for `css={on && mixin}` and a mixin in a ternary arm. This is a shipped bug on main, unrelated to the folding work — the fold just made it easier to see (it correctly refuses the identifier, so users got neither fold nor styles).

The css prop transform now rejects these with a compile error pointing at the reference, through the same `strictCssProp` gate #574 built. The validator walks only css value positions — ternary arms, `&&` right side, both sides of `||`/`??` — so `css={on ? css`…` : css`…`}` and `css={on && css`…`}` keep folding exactly as before (pinned in the new fixture next to the erroring shapes), and `undefined`/`null`/`false` arms stay valid. With strict mode off the element is left untouched instead of compiling the broken merge, consistent with the other invalid shapes.

The two mixin cases move out of `css-prop-fold-bailouts` (which pins silent folds/bails) into a new `css-prop-style-reference` fixture that pins the diagnostics via stderr snapshots: same-file mixin, imported mixin, member reference, `&&`, and a ternary arm. `css-prop-invalid`'s `css={props}` now errors too instead of emitting `mergeCssProp({}, props)`, which would have crashed at render. 348 native tests green; `test:wasm-fixtures` asserts all four modes surface the error through the real wasm ABI.

Targets #567 because the fixture landscape (`css-prop-fold-bailouts`, falsy-arm support) lives there; the fix itself back-applies to main conceptually but everything ships in the same release anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)