### PR TITLE
Shrink the minified mergeClassNames

### DIFF
--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -232,8 +232,7 @@ const removeNonDomProperties = <T extends Record<string, unknown>>(obj: T): T =>
  * `(undefined, "b")` → `"b"`\
  * `(undefined, undefined)` → `undefined`
  */
-const mergeClassNames = (a?: string, b?: string) =>
-  a && b ? a + " " + b : a || b || undefined;
+const mergeClassNames = (a?: string, b?: string) => (a && b ? a + " " + b : a || b || undefined);
 
 /**
  * merge props and processed props (including class names and styles)

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -224,13 +224,16 @@ const removeNonDomProperties = <T extends Record<string, unknown>>(obj: T): T =>
   return result;
 };
 
-// util function to merge class names, as they are concatenated with a space
-const mergeClassNames = (a?: string, b?: string) => {
-  if (!a && !b) return undefined;
-  if (!a) return b;
-  if (!b) return a;
-  return a + " " + b;
-};
+/**
+ * util function to merge class names, as they are concatenated with a space
+ * e.g.:\
+ * `("a", "b")` → `"a b"`\
+ * `("a", undefined)` → `"a"`\
+ * `(undefined, "b")` → `"b"`\
+ * `(undefined, undefined)` → `undefined`
+ */
+const mergeClassNames = (a?: string, b?: string) =>
+  a && b ? a + " " + b : a || b || undefined;
 
 /**
  * merge props and processed props (including class names and styles)


### PR DESCRIPTION
A minimal optimization to reduce the minified size of `mergeClassNames` (−12 B min / −22 B brotli). Behavior is unchanged, runtime perf is at parity — `mergeClassNames` only runs when class merging is actually needed, not on every render.