### PR TITLE
Shrink the yak component symbol assignment

### DIFF
--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -46,6 +46,16 @@ const styledFactory: StyledFn = (Component) =>
  */
 export const styled = styledFactory as Styled;
 
+// Real shape of the yakComponentSymbol tuple. Public YakComponent keeps it
+// opaque ([unknown, ...]); this internal type lets the write below be
+// type-checked without an `as unknown` cast.
+type YakComponentInternals = [
+  self: React.FunctionComponent,
+  attrsFn: AttrsFunction<any, any, any> | undefined,
+  styleProcessor: RuntimeStyleProcessor<unknown>,
+  target: React.FunctionComponent | string,
+];
+
 const yakStyled: StyledInternal = (Component, attrs) => {
   const isYakComponent = typeof Component !== "string" && yakComponentSymbol in Component;
 
@@ -196,15 +206,12 @@ const yakStyled: StyledInternal = (Component, attrs) => {
       return <Target {...(filteredProps as React.ComponentProps<typeof Target>)} />;
     };
 
-    // Assign the yakComponentSymbol directly without forwardRef
-    return Object.assign(Yak, {
-      [yakComponentSymbol]: [Yak, mergedAttrsFn, runtimeStyleProcessor, targetComponent] as [
-        unknown,
-        unknown,
-        unknown,
-        unknown,
-      ],
-    });
+    // Direct write instead of Object.assign (faster & smaller)
+    const taggedYak = Yak as React.FunctionComponent & {
+      [yakComponentSymbol]: YakComponentInternals;
+    };
+    taggedYak[yakComponentSymbol] = [Yak, mergedAttrsFn, runtimeStyleProcessor, targetComponent];
+    return taggedYak;
   };
 };
 

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -48,7 +48,6 @@ export const styled = styledFactory as Styled;
 
 // Real shape of the yakComponentSymbol tuple. Public YakComponent keeps it
 // opaque ([unknown, ...]); this internal type lets the write below be
-// type-checked without an `as unknown` cast.
 type YakComponentInternals = [
   self: React.FunctionComponent,
   attrsFn: AttrsFunction<any, any, any> | undefined,

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -46,8 +46,8 @@ const styledFactory: StyledFn = (Component) =>
  */
 export const styled = styledFactory as Styled;
 
-// Real shape of the yakComponentSymbol tuple. Public YakComponent keeps it
-// opaque ([unknown, ...]); this internal type lets the write below be
+// Real internal shape of the yakComponentSymbol tuple. Public YakComponent keeps it
+// opaque ([unknown, ...])
 type YakComponentInternals = [
   self: React.FunctionComponent,
   attrsFn: AttrsFunction<any, any, any> | undefined,


### PR DESCRIPTION
Attach the `yakComponentSymbol` tuple with a direct property write instead of `Object.assign` (−22 B min / −22 B brotli). Behavior is unchanged — the symbol is an own enumerable property either way, so `sym in Component`, the chain-merge destructure and selector targeting all still work. It also runs ~11× faster at module-load (no intermediate object), where every styled-component definition hits it once; the render path is untouched.

Type safety is kept via an internal `YakComponentInternals` tuple type, so the write is type-checked with no `as unknown` and the public `YakComponent` contract still exposes the opaque `[unknown, unknown, unknown, unknown]`.