### PR TITLE
Shorten internal render markers via a namespace module

### DIFF
--- a/packages/next-yak/runtime/internals/propMarkers.ts
+++ b/packages/next-yak/runtime/internals/propMarkers.ts
@@ -1,18 +1,4 @@
-/**
- * Internal, render-time markers written onto props (or the merged attrs
- * function) and read back to skip repeated work across a `styled(...)` chain.
- *
- * These are NOT a compiler contract — nothing in yak-swc emits them — and they
- * never appear on the public API. The leading `$` is load-bearing:
- * `removeNonDomProperties` strips `$`-prefixed props, so a marker can never
- * reach the DOM. The `__` on the two prop markers guards against a user's own
- * `$`-prop colliding with one. The values are kept short so the app bundler
- * ships fewer bytes; the descriptive export names are how they read in source.
- *
- * Imported as a namespace (`import * as INTERNAL`) so each use site reads as
- * `INTERNAL.ATTRS_MERGED`; esbuild inlines the `const` values, leaving nothing
- * of the namespace in the shipped bundle.
- */
+/** Internal, render-time markers written onto props */
 
 /**
  * Set on props once the attrs functions have been folded in, so a nested yak

--- a/packages/next-yak/runtime/internals/propMarkers.ts
+++ b/packages/next-yak/runtime/internals/propMarkers.ts
@@ -1,0 +1,34 @@
+/**
+ * Internal, render-time markers written onto props (or the merged attrs
+ * function) and read back to skip repeated work across a `styled(...)` chain.
+ *
+ * These are NOT a compiler contract — nothing in yak-swc emits them — and they
+ * never appear on the public API. The leading `$` is load-bearing:
+ * `removeNonDomProperties` strips `$`-prefixed props, so a marker can never
+ * reach the DOM. The `__` on the two prop markers guards against a user's own
+ * `$`-prop colliding with one. The values are kept short so the app bundler
+ * ships fewer bytes; the descriptive export names are how they read in source.
+ *
+ * Imported as a namespace (`import * as INTERNAL`) so each use site reads as
+ * `INTERNAL.ATTRS_MERGED`; esbuild inlines the `const` values, leaving nothing
+ * of the namespace in the shipped bundle.
+ */
+
+/**
+ * Set on props once the attrs functions have been folded in, so a nested yak
+ * wrapper further out the chain does not merge the same attrs twice.
+ */
+export const ATTRS_MERGED = "$__a" as const;
+
+/**
+ * Set on props once the runtime style processor has run, so an outer yak
+ * component that receives already-processed props skips the collector entirely.
+ */
+export const RUNTIME_STYLES_DONE = "$__r" as const;
+
+/**
+ * Carries the constant `.attrs({...})` object on the merged attrs function,
+ * marking it theme-independent so the fast render path can apply it without
+ * executing anything. Lives on the function, never on props.
+ */
+export const STATIC_ATTRS = "$sa" as const;

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -1,4 +1,5 @@
 import { css, CSSInterpolation, ClassNames, yakComponentSymbol } from "./cssLiteral.js";
+import * as INTERNAL from "./internals/propMarkers.js";
 import React from "react";
 import type {
   Attrs,
@@ -71,7 +72,9 @@ const yakStyled: StyledInternal = (Component, attrs) => {
     | string;
 
   const mergedAttrsFn = buildRuntimeAttrsProcessor(attrs, parentAttrsFn);
-  const staticAttrs = (mergedAttrsFn as StaticAttrsCarrier | undefined)?.$staticAttrs;
+  const staticAttrs = (mergedAttrsFn as StaticAttrsCarrier | undefined)?.[
+    INTERNAL.STATIC_ATTRS
+  ];
 
   return (styles, ...values) => {
     // combine all interpolated logic into a single function
@@ -96,12 +99,12 @@ const yakStyled: StyledInternal = (Component, attrs) => {
         // className, and `source` then aliases `props` — so the class names are
         // written to the fresh, filtered object rather than back into props
         const source = (
-          staticAttrs && !("$__attrs" in props)
+          staticAttrs && !(INTERNAL.ATTRS_MERGED in props)
             ? combineProps(
                 {
                   ...(props as { className?: string; style?: React.CSSProperties }),
                   // mark the props as processed
-                  $__attrs: true,
+                  [INTERNAL.ATTRS_MERGED]: true,
                 },
                 staticAttrs,
               )
@@ -110,7 +113,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
         const filteredProps = removeNonDomProperties(source) as {
           className?: string;
         };
-        if (!("$__runtimeStylesProcessed" in source)) {
+        if (!(INTERNAL.RUNTIME_STYLES_DONE in source)) {
           const classNames = new ClassNames(source.className);
           runtimeStyleProcessor(source, classNames, undefined as unknown as React.CSSProperties);
           filteredProps.className = classNames.value || undefined;
@@ -131,7 +134,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
       // The first components which is not wrapped in a yak component will execute all attrs functions
       // starting from the innermost yak component to the outermost yak component (itself)
       const combinedProps =
-        "$__attrs" in props
+        INTERNAL.ATTRS_MERGED in props
           ? ({
               theme,
               ...props,
@@ -149,7 +152,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
                   style?: React.CSSProperties;
                 }),
                 // mark the props as processed
-                $__attrs: true,
+                [INTERNAL.ATTRS_MERGED]: true,
               },
               mergedAttrsFn?.({ theme, ...(props as any) }),
             );
@@ -159,7 +162,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
       //
       // inner levels of a styled(Component) chain receive already-processed
       // props and skip this entirely — no collector, no style clone
-      if (!("$__runtimeStylesProcessed" in combinedProps)) {
+      if (!(INTERNAL.RUNTIME_STYLES_DONE in combinedProps)) {
         const classNames = new ClassNames(combinedProps.className);
         // static processors never write style values, so the incoming style
         // object can be passed through without a defensive copy
@@ -168,7 +171,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
           : combinedProps.style;
         runtimeStyleProcessor(combinedProps, classNames, styles as React.CSSProperties);
         // @ts-expect-error this is not typed correctly
-        combinedProps.$__runtimeStylesProcessed = true;
+        combinedProps[INTERNAL.RUNTIME_STYLES_DONE] = true;
 
         combinedProps.className = classNames.value || undefined;
         if (styles !== combinedProps.style) {
@@ -185,7 +188,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
 
       // remove all props that start with a $ sign so they reach neither DOM
       // elements nor custom components — this also strips the internal
-      // $__attrs/$__runtimeStylesProcessed markers, which must not cross a
+      // INTERNAL.ATTRS_MERGED/INTERNAL.RUNTIME_STYLES_DONE markers, which must not cross a
       // custom component boundary (a custom component may render another yak
       // component that has to process its own attrs/styles)
       const filteredProps = removeNonDomProperties(propsBeforeFiltering);
@@ -312,7 +315,9 @@ const buildRuntimeAttrsProcessor = <
   // A `styled(StyledWithAttrs).attrs({...})` chain merges its levels per render
   // and is not tagged, which keeps a mutation of an attrs object observable.
   if (ownAttrsFn && typeof attrs !== "function") {
-    return Object.assign(ownAttrsFn, { $staticAttrs: attrs } as StaticAttrsCarrier);
+    return Object.assign(ownAttrsFn, {
+      [INTERNAL.STATIC_ATTRS]: attrs,
+    } as StaticAttrsCarrier);
   }
 
   return ownAttrsFn || parentAttrsFn;
@@ -324,7 +329,7 @@ const buildRuntimeAttrsProcessor = <
  * Kept local to this module — like the `yakComponentSymbol` tuple, it is an
  * implementation detail and must not reach the public `AttrsFunction` type.
  */
-type StaticAttrsCarrier = { $staticAttrs?: object };
+type StaticAttrsCarrier = { [K in typeof INTERNAL.STATIC_ATTRS]?: object };
 
 /**
  * Merges the runtime style function of the current component with the runtime style function of the parent component

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -72,9 +72,7 @@ const yakStyled: StyledInternal = (Component, attrs) => {
     | string;
 
   const mergedAttrsFn = buildRuntimeAttrsProcessor(attrs, parentAttrsFn);
-  const staticAttrs = (mergedAttrsFn as StaticAttrsCarrier | undefined)?.[
-    INTERNAL.STATIC_ATTRS
-  ];
+  const staticAttrs = (mergedAttrsFn as StaticAttrsCarrier | undefined)?.[INTERNAL.STATIC_ATTRS];
 
   return (styles, ...values) => {
     // combine all interpolated logic into a single function


### PR DESCRIPTION
The three render-time marker keys (`$__attrs`, `$__runtimeStylesProcessed`, `$staticAttrs`) are pure internal state on props / the attrs fn — not a compiler contract (nothing in yak-swc emits them), never public. This lifts them into `internals/propMarkers.ts` as short `as const` values and uses them via `import * as INTERNAL`.

esbuild inlines the namespace away, so the app bundle ships only the short literals: **−70 B min / −20 B brotli** vs `perf`. Source reads better (the const name is the doc) and the marker string lives in one place instead of being hand-duplicated across 11 sites.

`$` stays load-bearing (`removeNonDomProperties` strips it); the `__` on the two prop markers keeps them from colliding with a user `$`-prop.

Verified locally: `tsc` clean, 188 runtime tests pass, built bundle contains only the short literals (namespace fully inlined).