### PR TITLE
Simplify atoms() to a class-name string

### DIFF
--- a/e2e/cases/atoms/index.test.ts
+++ b/e2e/cases/atoms/index.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+import { withTestEnv } from "next-yak-e2e";
+
+const atomClasses = async (page: import("@playwright/test").Page, testId: string) =>
+  ((await page.getByTestId(testId).getAttribute("class")) ?? "")
+    .split(" ")
+    .filter((className) => className.startsWith("bg-") || className.startsWith("text-"));
+
+test(
+  "renders atom classes and applies them",
+  withTestEnv("atoms", async (testEnv, page) => {
+    await page.goto(testEnv.url);
+
+    // one multi class string and separate atoms must emit the same classes
+    expect(await atomClasses(page, "joined")).toEqual(["bg-blue", "text-white"]);
+    expect(await atomClasses(page, "separate")).toEqual(["bg-blue", "text-white"]);
+
+    const joined = page.getByTestId("joined");
+    await expect(joined).toHaveCSS("background-color", "rgb(0, 0, 255)");
+    await expect(joined).toHaveCSS("color", "rgb(255, 255, 255)");
+
+    // atoms in a dynamic interpolation still resolve per props
+    expect(await atomClasses(page, "conditional-active")).toEqual(["bg-blue", "text-white"]);
+    expect(await atomClasses(page, "conditional-inactive")).toEqual(["bg-blue"]);
+    await expect(page.getByTestId("conditional-inactive")).toHaveCSS("color", "rgb(0, 0, 0)");
+  }),
+);

--- a/e2e/cases/atoms/index.tsx
+++ b/e2e/cases/atoms/index.tsx
@@ -1,0 +1,33 @@
+import { atoms, styled } from "next-yak";
+
+// utility class names as an atomic CSS framework would emit them
+// (the stylesheet below is hand written, no framework in the e2e app)
+const Joined = styled.div`
+  ${atoms("bg-blue text-white")}
+`;
+
+const Separate = styled.div`
+  ${atoms("bg-blue", "text-white")}
+`;
+
+const Conditional = styled.div<{ $active?: boolean }>`
+  ${atoms("bg-blue")}
+  ${(props) => props.$active && atoms("text-white")}
+`;
+
+export default function App() {
+  return (
+    <>
+      <style>{`
+        .bg-blue { background-color: rgb(0, 0, 255); }
+        .text-white { color: rgb(255, 255, 255); }
+      `}</style>
+      <Joined data-testid="joined">joined</Joined>
+      <Separate data-testid="separate">separate</Separate>
+      <Conditional data-testid="conditional-active" $active>
+        active
+      </Conditional>
+      <Conditional data-testid="conditional-inactive">inactive</Conditional>
+    </>
+  );
+}

--- a/packages/next-yak/runtime/__tests__/atoms.test.tsx
+++ b/packages/next-yak/runtime/__tests__/atoms.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { atoms } from "../atoms";
+import { ClassNames, css } from "../cssLiteral";
+import type { RuntimeStyleProcessor } from "../publicStyledApi";
+
+const classNamesOf = (processor: unknown, props: Record<string, unknown> = {}) => {
+  const classNames = new ClassNames();
+  (processor as RuntimeStyleProcessor<unknown>)(props, classNames, {});
+  return classNames.value;
+};
+
+describe("atoms", () => {
+  it("collects static classes, however they are grouped", () => {
+    expect(classNamesOf(atoms("a b c"))).toBe("a b c");
+    expect(classNamesOf(atoms("a", "b", "c"))).toBe("a b c");
+    expect(classNamesOf(atoms("a b", "c"))).toBe("a b c");
+  });
+
+  it("skips falsy atoms", () => {
+    expect(classNamesOf(atoms("a", false, "b"))).toBe("a b");
+    expect(classNamesOf(atoms(false))).toBe("");
+    expect(classNamesOf(atoms())).toBe("");
+  });
+
+  it("runs dynamic atoms after the static ones", () => {
+    const processor = atoms<{ $active?: boolean }>("a", (props, classNames) => {
+      if (props.$active) classNames.add("active");
+    });
+    expect(classNamesOf(processor, { $active: true })).toBe("a active");
+    expect(classNamesOf(processor, { $active: false })).toBe("a");
+  });
+
+  it("keeps classes a dynamic atom removes removable", () => {
+    const processor = atoms("a b", (_props, classNames) => {
+      classNames.delete("a");
+    });
+    expect(classNamesOf(processor)).toBe("b");
+  });
+
+  it("is static on its own but dynamic once css() wraps it", () => {
+    // styled`` compiles to css("yak123", atoms(...)) and gates its fast path on
+    // the outer processor, which is dynamic because atoms() is a function - so
+    // atoms' own $dynamic is not read today. Pinned to catch a fold of static
+    // atoms into the outer class name, which would make the fast path reachable.
+    expect((atoms("a") as unknown as { $dynamic: boolean }).$dynamic).toBe(false);
+    expect((css("yak123", atoms("a")) as unknown as { $dynamic: boolean }).$dynamic).toBe(true);
+  });
+});

--- a/packages/next-yak/runtime/atoms.tsx
+++ b/packages/next-yak/runtime/atoms.tsx
@@ -1,4 +1,4 @@
-import { ComponentStyles, css } from "./cssLiteral.js";
+import { ClassNames, ComponentStyles, css } from "./cssLiteral.js";
 import { RuntimeStyleProcessor } from "./publicStyledApi.js";
 
 /**
@@ -18,27 +18,19 @@ import { RuntimeStyleProcessor } from "./publicStyledApi.js";
 export const atoms = <T,>(
   ...atoms: (string | RuntimeStyleProcessor<T> | false)[]
 ): ComponentStyles<T> => {
-  const staticClasses: string[] = [];
+  const staticClasses = new ClassNames();
   const dynamicFunctions: RuntimeStyleProcessor<T>[] = [];
 
   for (const atom of atoms) {
     if (typeof atom === "string") {
-      staticClasses.push(...atom.split(" "));
+      staticClasses.add(atom);
     } else if (typeof atom === "function") {
       dynamicFunctions.push(atom);
     }
   }
 
-  const runtimeFunctions: RuntimeStyleProcessor<T>[] =
-    staticClasses.length > 0
-      ? [
-          (_, classNames) => {
-            staticClasses.forEach((cls) => classNames.add(cls));
-          },
-          ...dynamicFunctions,
-        ]
-      : dynamicFunctions;
-
+  // the collected classes are passed as css()'s static class name,
+  // only the dynamic atoms stay functions
   // @ts-expect-error the internal implementation of css is not typed
-  return css(...runtimeFunctions);
+  return css(staticClasses.value, ...dynamicFunctions);
 };


### PR DESCRIPTION
Collects the static classes with the runtime's own `ClassNames` collector and passes them as `css()`'s static class name, instead of wrapping them in a runtime function that re-adds them per render. −54 B min / −41 B brotli, and the factory is ~2.9× faster — which matters because `atoms()` inside a dynamic interpolation (`${props => props.$primary && atoms("shadow-md")}`) re-runs on every render.

Worth knowing: this does **not** reach the styled fast path. `css()` marks any function argument dynamic, and compiled `atoms()` always arrives as a function inside the outer `css()`, so the outer processor stays `$dynamic: true`. Folding a static `atoms()` into the outer class name would unlock that, but `css()` assigns rather than appends `className` and SWC emits both argument orders, so it needs its own change. Pinned by a test so it flips loudly if that lands.

Adds unit tests for the class names `atoms()` emits (incl. the multi-class string / separate-args equivalence, since the per-atom `split(" ")` is gone) and an e2e case verified on vite, next-app-webpack and rsbuild.