### PR TITLE
Decode JSX attribute strings when the fold moves them into expressions

### DIFF
--- a/e2e/cases/foldables/index.test.ts
+++ b/e2e/cases/foldables/index.test.ts
@@ -46,5 +46,12 @@ test(
     const disabled = page.getByTestId("disabled");
     await expect(disabled).toBeDisabled();
     await expect(disabled).toHaveCSS("color", "rgb(0, 0, 0)");
+
+    // entity-spelled attribute strings compare by decoded value, like the runtime path
+    await expect(page.getByTestId("entity")).toHaveCSS("color", "rgb(220, 20, 60)");
+    await expect(page.getByTestId("entity-runtime")).toHaveCSS("color", "rgb(220, 20, 60)");
+
+    // backslashes in JSX attributes stay literal characters when the condition is inlined
+    await expect(page.getByTestId("backslash")).toHaveCSS("color", "rgb(30, 144, 255)");
   }),
 );

--- a/e2e/cases/foldables/index.tsx
+++ b/e2e/cases/foldables/index.tsx
@@ -34,6 +34,27 @@ const Tone = styled.p<{ $variant?: string }>`
         `}
 `;
 
+// string comparison against an attribute that JSX spells with an HTML entity -
+// the fold must compare the decoded value, not the source text
+const Category = styled.li<{ $label?: string }>`
+  color: rgb(105, 105, 105);
+  ${({ $label }) =>
+    $label === "Food & Drink" &&
+    css`
+      color: rgb(220, 20, 60);
+    `}
+`;
+
+// backslashes in JSX attribute strings are literal characters, not JS escapes
+const Shortcut = styled.kbd<{ $keys?: string }>`
+  color: rgb(105, 105, 105);
+  ${({ $keys }) =>
+    $keys === "a\\tb" &&
+    css`
+      color: rgb(30, 144, 255);
+    `}
+`;
+
 // non-$ prop: stays on the element and toggles classes
 const ActionButton = styled.button<{ disabled?: boolean }>`
   color: rgb(0, 0, 0);
@@ -82,6 +103,17 @@ export default function App() {
       <ActionButton data-testid="disabled" disabled>
         disabled
       </ActionButton>
+      {/* entity spelling decodes to "Food & Drink" - must match like the runtime twin below */}
+      <Category data-testid="entity" $label="Food &amp; Drink">
+        Food &amp; Drink
+      </Category>
+      <Category data-testid="entity-runtime" {...{ $label: "Food & Drink" }}>
+        runtime twin
+      </Category>
+      {/* the attribute value is the four characters a \ t b - not a tab */}
+      <Shortcut data-testid="backslash" $keys="a\tb">
+        a\tb
+      </Shortcut>
     </>
   );
 }

--- a/packages/yak-swc/yak_swc/src/utils/styled_jsx_fold.rs
+++ b/packages/yak-swc/yak_swc/src/utils/styled_jsx_fold.rs
@@ -937,7 +937,14 @@ fn attr_value_map(attrs: &[JSXAttrOrSpread]) -> FxHashMap<Atom, PropValue<'_>> {
         span: DUMMY_SP,
         value: true,
       }))),
-      Some(JSXAttrValue::Str(value)) => Cow::Owned(Expr::Lit(Lit::Str(value.clone()))),
+      // Rebuild the literal without `raw`: the JSX source spelling (HTML
+      // entities, literal backslashes) means something else once the string
+      // moves into expression position, so codegen must re-emit the decoded
+      // value with JS escaping
+      Some(JSXAttrValue::Str(value)) => Cow::Owned(Expr::Lit(Lit::Str(str_lit(
+        value.value.clone(),
+        value.span,
+      )))),
       Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
         expr: JSXExpr::Expr(expr),
         ..

--- a/packages/yak-swc/yak_swc/src/utils/styled_jsx_fold.rs
+++ b/packages/yak-swc/yak_swc/src/utils/styled_jsx_fold.rs
@@ -937,10 +937,8 @@ fn attr_value_map(attrs: &[JSXAttrOrSpread]) -> FxHashMap<Atom, PropValue<'_>> {
         span: DUMMY_SP,
         value: true,
       }))),
-      // Rebuild the literal without `raw`: the JSX source spelling (HTML
-      // entities, literal backslashes) means something else once the string
-      // moves into expression position, so codegen must re-emit the decoded
-      // value with JS escaping
+      // don't add `raw` as it would otherwise break cases which
+      // require escaping like `Food &amp; Drink`
       Some(JSXAttrValue::Str(value)) => Cow::Owned(Expr::Lit(Lit::Str(str_lit(
         value.value.clone(),
         value.span,

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/input.tsx
@@ -1,0 +1,29 @@
+import { css, styled } from "next-yak";
+
+// JSX attribute strings are decoded before they reach the condition:
+// entities like &amp; and literal backslashes must compare by value,
+// not by their JSX source spelling
+const Category = styled.li<{ $label?: string }>`
+  color: grey;
+  ${({ $label }) =>
+    $label === "Food & Drink" &&
+    css`
+      color: crimson;
+    `}
+`;
+
+const Shortcut = styled.kbd<{ $keys?: string }>`
+  color: grey;
+  ${({ $keys }) =>
+    $keys === "a\\tb" &&
+    css`
+      color: dodgerblue;
+    `}
+`;
+
+export const Menu = () => (
+  <>
+    <Category $label="Food &amp; Drink">Food &amp; Drink</Category>
+    <Shortcut $keys="a\tb">a\tb</Shortcut>
+  </>
+);

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.dev.tsx
@@ -1,0 +1,30 @@
+import { css, styled } from "next-yak/internal";
+import * as __yak from "next-yak/internal";
+import "./input.yak.module.css!=!./input?./input.yak.module.css";
+// JSX attribute strings are decoded before they reach the condition:
+// entities like &amp; and literal backslashes must compare by value,
+// not by their JSX source spelling
+const Category = /*YAK Extracted CSS:
+:global(.input_Category_m7uBBu) {
+  color: grey;
+}
+:global(.input_Category___m7uBBu) {
+  color: crimson;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_li("input_Category_m7uBBu", ({ $label })=>$label === "Food & Drink" && /*#__PURE__*/ css("input_Category___m7uBBu")), {
+    "displayName": "Category"
+});
+const Shortcut = /*YAK Extracted CSS:
+:global(.input_Shortcut_m7uBBu) {
+  color: grey;
+}
+:global(.input_Shortcut___m7uBBu) {
+  color: dodgerblue;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_kbd("input_Shortcut_m7uBBu", ({ $keys })=>$keys === "a\\tb" && /*#__PURE__*/ css("input_Shortcut___m7uBBu")), {
+    "displayName": "Shortcut"
+});
+export const Menu = ()=><>
+    <li className={"input_Category_m7uBBu" + ("Food & Drink" === "Food & Drink" ? " input_Category___m7uBBu" : "")}>Food &amp; Drink</li>
+    <kbd className={"input_Shortcut_m7uBBu" + ("a\\tb" === "a\\tb" ? " input_Shortcut___m7uBBu" : "")}>a\tb</kbd>
+  </>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.prod.tsx
@@ -1,0 +1,26 @@
+import { css, styled } from "next-yak/internal";
+import * as __yak from "next-yak/internal";
+import "./input.yak.module.css!=!./input?./input.yak.module.css";
+// JSX attribute strings are decoded before they reach the condition:
+// entities like &amp; and literal backslashes must compare by value,
+// not by their JSX source spelling
+const Category = /*YAK Extracted CSS:
+:global(.ym7uBBu) {
+  color: grey;
+}
+:global(.ym7uBBu1) {
+  color: crimson;
+}
+*/ /*#__PURE__*/ __yak.__yak_li("ym7uBBu", ({ $label })=>$label === "Food & Drink" && /*#__PURE__*/ css("ym7uBBu1"));
+const Shortcut = /*YAK Extracted CSS:
+:global(.ym7uBBu2) {
+  color: grey;
+}
+:global(.ym7uBBu3) {
+  color: dodgerblue;
+}
+*/ /*#__PURE__*/ __yak.__yak_kbd("ym7uBBu2", ({ $keys })=>$keys === "a\\tb" && /*#__PURE__*/ css("ym7uBBu3"));
+export const Menu = ()=><>
+    <li className={"ym7uBBu" + ("Food & Drink" === "Food & Drink" ? " ym7uBBu1" : "")}>Food &amp; Drink</li>
+    <kbd className={"ym7uBBu2" + ("a\\tb" === "a\\tb" ? " ym7uBBu3" : "")}>a\tb</kbd>
+  </>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.turbo.dev.tsx
@@ -1,0 +1,30 @@
+import { css, styled } from "next-yak/internal";
+import * as __yak from "next-yak/internal";
+import "data:text/css;base64,LmlucHV0X0NhdGVnb3J5X203dUJCdSB7CiAgY29sb3I6IGdyZXk7Cn0KLmlucHV0X0NhdGVnb3J5X19fbTd1QkJ1IHsKICBjb2xvcjogY3JpbXNvbjsKfS5pbnB1dF9TaG9ydGN1dF9tN3VCQnUgewogIGNvbG9yOiBncmV5Owp9Ci5pbnB1dF9TaG9ydGN1dF9fX203dUJCdSB7CiAgY29sb3I6IGRvZGdlcmJsdWU7Cn0=";
+// JSX attribute strings are decoded before they reach the condition:
+// entities like &amp; and literal backslashes must compare by value,
+// not by their JSX source spelling
+const Category = /*YAK Extracted CSS:
+.input_Category_m7uBBu {
+  color: grey;
+}
+.input_Category___m7uBBu {
+  color: crimson;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_li("input_Category_m7uBBu", ({ $label })=>$label === "Food & Drink" && /*#__PURE__*/ css("input_Category___m7uBBu")), {
+    "displayName": "Category"
+});
+const Shortcut = /*YAK Extracted CSS:
+.input_Shortcut_m7uBBu {
+  color: grey;
+}
+.input_Shortcut___m7uBBu {
+  color: dodgerblue;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_kbd("input_Shortcut_m7uBBu", ({ $keys })=>$keys === "a\\tb" && /*#__PURE__*/ css("input_Shortcut___m7uBBu")), {
+    "displayName": "Shortcut"
+});
+export const Menu = ()=><>
+    <li className={"input_Category_m7uBBu" + ("Food & Drink" === "Food & Drink" ? " input_Category___m7uBBu" : "")}>Food &amp; Drink</li>
+    <kbd className={"input_Shortcut_m7uBBu" + ("a\\tb" === "a\\tb" ? " input_Shortcut___m7uBBu" : "")}>a\tb</kbd>
+  </>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.turbo.prod.tsx
@@ -1,0 +1,26 @@
+import { css, styled } from "next-yak/internal";
+import * as __yak from "next-yak/internal";
+import "data:text/css;base64,LnltN3VCQnUgewogIGNvbG9yOiBncmV5Owp9Ci55bTd1QkJ1MSB7CiAgY29sb3I6IGNyaW1zb247Cn0ueW03dUJCdTIgewogIGNvbG9yOiBncmV5Owp9Ci55bTd1QkJ1MyB7CiAgY29sb3I6IGRvZGdlcmJsdWU7Cn0=";
+// JSX attribute strings are decoded before they reach the condition:
+// entities like &amp; and literal backslashes must compare by value,
+// not by their JSX source spelling
+const Category = /*YAK Extracted CSS:
+.ym7uBBu {
+  color: grey;
+}
+.ym7uBBu1 {
+  color: crimson;
+}
+*/ /*#__PURE__*/ __yak.__yak_li("ym7uBBu", ({ $label })=>$label === "Food & Drink" && /*#__PURE__*/ css("ym7uBBu1"));
+const Shortcut = /*YAK Extracted CSS:
+.ym7uBBu2 {
+  color: grey;
+}
+.ym7uBBu3 {
+  color: dodgerblue;
+}
+*/ /*#__PURE__*/ __yak.__yak_kbd("ym7uBBu2", ({ $keys })=>$keys === "a\\tb" && /*#__PURE__*/ css("ym7uBBu3"));
+export const Menu = ()=><>
+    <li className={"ym7uBBu" + ("Food & Drink" === "Food & Drink" ? " ym7uBBu1" : "")}>Food &amp; Drink</li>
+    <kbd className={"ym7uBBu2" + ("a\\tb" === "a\\tb" ? " ym7uBBu3" : "")}>a\tb</kbd>
+  </>;


### PR DESCRIPTION
JSX attribute strings kept their source spelling (raw) when the fold moved them into expression position, so `<Category $label="Food &amp; Drink" />` compared the entity text instead of the decoded value and never matched, while the runtime path did.

Rebuild the literal without raw in attr_value_map so codegen re-emits the decoded value with JS escaping. No other snapshot changes. Pinned by a new styled-jsx-folding-string-attrs fixture and entity/backslash cases in the foldables e2e (red before the fix, green after).