### PR TITLE
Fix the atoms test type error breaking Vite-Tests

### DIFF
--- a/packages/next-yak/runtime/__tests__/atoms.test.tsx
+++ b/packages/next-yak/runtime/__tests__/atoms.test.tsx
@@ -43,6 +43,7 @@ describe("atoms", () => {
     // atoms' own $dynamic is not read today. Pinned to catch a fold of static
     // atoms into the outer class name, which would make the fast path reachable.
     expect((atoms("a") as unknown as { $dynamic: boolean }).$dynamic).toBe(false);
+    // @ts-expect-error calling with a class name string mimics the compiled css form
     expect((css("yak123", atoms("a")) as unknown as { $dynamic: boolean }).$dynamic).toBe(true);
   });
 });


### PR DESCRIPTION
`test:types:test` has been red on perf since #603.

`atoms.test.tsx` calls `css("yak123", atoms("a"))` to pin that the outer processor is dynamic — that's the shape the SWC plugin emits, so vitest is green, but `css` is typed `TemplateStringsArray` so tsc rejects the string. The result was cast, the argument wasn't.

Added `@ts-expect-error`, same convention as attrs.test.tsx.

`pnpm test:types:test` passes, atoms vitest still 5/5.