### PR TITLE
Split e2e CI into parallel dev and build jobs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   e2e:
-    name: "E2E tests (foldStatic: ${{ matrix.fold-static }})"
+    name: "E2E tests (${{ matrix.phase }}, foldStatic: ${{ matrix.fold-static }})"
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -36,6 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         fold-static: ["on", "off"]
+        phase: ["dev", "build"]
 
     env:
       YAK_E2E_FOLD_STATIC: ${{ matrix.fold-static == 'off' && 'false' || 'true' }}
@@ -90,7 +91,9 @@ jobs:
         run: pnpm --filter next-yak-e2e exec playwright install chromium
 
       - name: Run e2e dev tests
+        if: matrix.phase == 'dev'
         run: pnpm run test:e2e
 
       - name: Run e2e build tests
+        if: matrix.phase == 'build'
         run: pnpm run test:e2e:build


### PR DESCRIPTION
With two fold modes, each CI job runs dev then build tests in sequence (~12 min). A mode × phase matrix runs 4 jobs in parallel instead; wall time drops to the slowest job (dev, ~7 min). Setup steps stay identical per job — no artifact sharing.

🤖 Co-authored-by **Claude Code**