### PR TITLE
Add a foldStatic toggle to the playground

### DIFF
--- a/docs/components/editor.tsx
+++ b/docs/components/editor.tsx
@@ -37,6 +37,7 @@ export default dynamic(
       const compiledPanelRef = useRef<PanelImperativeHandle>(null);
       const [minify, setMinify] = useState(false);
       const [showComments, setShowComments] = useState(true);
+      const [foldStatic, setFoldStatic] = useState(true);
       const initialInput = useMemo(
         () => ({
           mainFile: {
@@ -62,28 +63,32 @@ export default dynamic(
 
       const [transpileResult, transpile] = useTranspile(initialInput);
 
-      const updateCode = useCallback((minify?: boolean, showComments?: boolean) => {
-        const code = modelRefs.current.reduce((acc, model) => {
-          acc[model.uri] = model.getValue();
-          return acc;
-        }, {});
-        transpile({
-          mainFile: {
-            name: "index",
-            content: code["file:///index.tsx"],
-          },
-          additionalFiles: Object.entries(code)
-            .filter(([key]) => key !== "file:///index.tsx")
-            .map(([key, value]) => ({
-              name: key.replace("file:///", "").replace(".tsx", ""),
-              content: String(value),
-            })),
-          options: {
-            minify,
-            showComments,
-          },
-        });
-      }, []);
+      const updateCode = useCallback(
+        (minify?: boolean, showComments?: boolean, foldStatic?: boolean) => {
+          const code = modelRefs.current.reduce((acc, model) => {
+            acc[model.uri] = model.getValue();
+            return acc;
+          }, {});
+          transpile({
+            mainFile: {
+              name: "index",
+              content: code["file:///index.tsx"],
+            },
+            additionalFiles: Object.entries(code)
+              .filter(([key]) => key !== "file:///index.tsx")
+              .map(([key, value]) => ({
+                name: key.replace("file:///", "").replace(".tsx", ""),
+                content: String(value),
+              })),
+            options: {
+              minify,
+              showComments,
+              foldStatic,
+            },
+          });
+        },
+        [],
+      );
 
       const readableTranspiledResult = {
         [transpileResult.transpiledMainFile.name]: transpileResult.transpiledMainFile,
@@ -110,7 +115,7 @@ export default dynamic(
               label="Minify classes"
               checked={minify}
               onCheckedChange={(val) => {
-                updateCode(val, showComments);
+                updateCode(val, showComments, foldStatic);
                 setMinify(val);
               }}
             />
@@ -118,8 +123,16 @@ export default dynamic(
               label="Show comments"
               checked={showComments}
               onCheckedChange={(val) => {
-                updateCode(minify, val);
+                updateCode(minify, val, foldStatic);
                 setShowComments(val);
+              }}
+            />
+            <Toggle
+              label="Fold static"
+              checked={foldStatic}
+              onCheckedChange={(val) => {
+                updateCode(minify, showComments, val);
+                setFoldStatic(val);
               }}
             />
           </div>

--- a/docs/lib/transformation/execute-code.tsx
+++ b/docs/lib/transformation/execute-code.tsx
@@ -96,6 +96,7 @@ export async function transformAll(
   options?: {
     minify?: boolean;
     showComments?: boolean;
+    foldStatic?: boolean;
   },
 ) {
   const otherFilesTransformed: {
@@ -185,6 +186,7 @@ async function transform(
   options?: {
     minify?: boolean;
     showComments?: boolean;
+    foldStatic?: boolean;
   },
 ) {
   const transformedCode = transformCode(
@@ -207,6 +209,7 @@ async function transform(
     },
     {
       minify: options?.minify ?? false, // minify the class names and don't add display names
+      foldStatic: options?.foldStatic ?? true,
     },
   ).code;
 
@@ -227,6 +230,7 @@ async function transform(
     },
     {
       minify: options?.minify ?? false, // minify the class names and don't add display names
+      foldStatic: options?.foldStatic ?? true,
     },
   ).code;
 

--- a/docs/lib/transformation/useTranspile.tsx
+++ b/docs/lib/transformation/useTranspile.tsx
@@ -23,6 +23,7 @@ export type TranspileInput = {
   options?: {
     minify?: boolean;
     showComments?: boolean;
+    foldStatic?: boolean;
   };
 };
 

--- a/docs/playground-wasm/src/lib.rs
+++ b/docs/playground-wasm/src/lib.rs
@@ -108,7 +108,7 @@ fn yak_pass(
                 .into(),
             false, // suppress_deprecation_warnings
             false, // react_refresh_reg
-            true,  // fold_static
+            config.fold_static.unwrap_or(true),
             false, // strict_css_prop
         );
         program.visit_mut_with(&mut transformer);
@@ -190,6 +190,8 @@ pub struct YakConfig {
     #[tsify(optional)]
     minify: Option<bool>,
     #[tsify(optional)]
+    fold_static: Option<bool>,
+    #[tsify(optional)]
     import_mode: Option<CssImportConfig>,
 }
 
@@ -197,6 +199,7 @@ impl Default for YakConfig {
     fn default() -> Self {
         Self {
             minify: Default::default(),
+            fold_static: Default::default(),
             import_mode: Some(CssImportConfig {
                 value:
                     "./{{__BASE_NAME__}}.yak.css!=!./{{__BASE_NAME__}}?./{{__BASE_NAME__}}.yak.css"


### PR DESCRIPTION
The playground hardcodes folding on, so users can't see the runtime output the fold replaces. This threads a `foldStatic` flag from a new "Fold static" toggle through the wasm interface into the transform, like the existing "Minify classes" and "Show comments" toggles. Default on. Fixes #610.

🤖 Co-authored-by **Claude Code**