### PR TITLE
Decode className strings merged by the css prop

### DIFF
--- a/.changeset/cssprop-classname-decoding.md
+++ b/.changeset/cssprop-classname-decoding.md
@@ -1,0 +1,5 @@
+---
+"yak-swc": patch
+---
+
+A `className` string next to a `css` prop kept its JSX encoding: `className="Food &amp; Drink"` rendered the entity into the DOM class, and a backslash class like `before:content-['\2713']` broke the build with a SyntaxError. The value now reaches the DOM exactly as written.

--- a/e2e/cases/css-prop/index.test.ts
+++ b/e2e/cases/css-prop/index.test.ts
@@ -25,9 +25,11 @@ test(
     await expect(entity).toHaveClass(/(^|\s)Food & Drink($|\s)/);
     await expect(entity).toHaveCSS("color", "rgb(0, 0, 255)");
 
-    // Backslash className must reach the DOM as a single literal backslash
+    // Backslash className reaches the DOM as a single literal backslash
+    // (a non-digit after the backslash keeps octal-strict scanners out of play)
     const backslash = page.getByTestId("backslash-classname");
-    await expect(backslash).toHaveClass(/before:content-\['\\2713'\]/);
+    await expect(backslash).toHaveClass(/before:content-\['\\q'\]/);
+    await expect(backslash).not.toHaveClass(/before:content-\['\\\\q'\]/);
     await expect(backslash).toHaveCSS("color", "rgb(0, 0, 255)");
 
     // Spread props (onClick, children) survive mergeCssProp — clicking works

--- a/e2e/cases/css-prop/index.test.ts
+++ b/e2e/cases/css-prop/index.test.ts
@@ -20,6 +20,16 @@ test(
     const child = page.getByTestId("child");
     await expect(child).toHaveCSS("color", "rgb(0, 128, 0)");
 
+    // Entity className is decoded, not left as the JSX-encoded "Food &amp; Drink"
+    const entity = page.getByTestId("entity-classname");
+    await expect(entity).toHaveClass(/(^|\s)Food & Drink($|\s)/);
+    await expect(entity).toHaveCSS("color", "rgb(0, 0, 255)");
+
+    // Backslash className must reach the DOM as a single literal backslash
+    const backslash = page.getByTestId("backslash-classname");
+    await expect(backslash).toHaveClass(/before:content-\['\\2713'\]/);
+    await expect(backslash).toHaveCSS("color", "rgb(0, 0, 255)");
+
     // Spread props (onClick, children) survive mergeCssProp — clicking works
     const spreadButton = page.getByTestId("spread-button");
     await expect(spreadButton).toHaveCSS("padding", "8px");

--- a/e2e/cases/css-prop/index.tsx
+++ b/e2e/cases/css-prop/index.tsx
@@ -55,6 +55,24 @@ export default function App({ dummyBool = true }) {
           Nested child
         </span>
       </div>
+      <div
+        data-testid="entity-classname"
+        className="Food &amp; Drink"
+        css={css`
+          color: blue;
+        `}
+      >
+        Entity className
+      </div>
+      <div
+        data-testid="backslash-classname"
+        className="before:content-['\2713']"
+        css={css`
+          color: blue;
+        `}
+      >
+        Backslash className
+      </div>
       <SpreadButton data-testid="spread-button" onClick={() => setCount((c) => c + 1)}>
         clicks: {count}
       </SpreadButton>

--- a/e2e/cases/css-prop/index.tsx
+++ b/e2e/cases/css-prop/index.tsx
@@ -66,7 +66,7 @@ export default function App({ dummyBool = true }) {
       </div>
       <div
         data-testid="backslash-classname"
-        className="before:content-['\2713']"
+        className="before:content-['\q']"
         css={css`
           color: blue;
         `}

--- a/packages/yak-swc/yak_swc/src/utils/css_prop.rs
+++ b/packages/yak-swc/yak_swc/src/utils/css_prop.rs
@@ -9,7 +9,7 @@ use swc_core::{
   ecma::ast::{
     BinaryOp, CallExpr, Callee, Expr, ExprOrSpread, Ident, JSXAttr, JSXAttrName, JSXAttrOrSpread,
     JSXAttrValue, JSXExpr, JSXExprContainer, JSXOpeningElement, KeyValueProp, Lit, ObjectLit, Prop,
-    PropName, PropOrSpread, SpreadElement,
+    PropName, PropOrSpread, SpreadElement, Str,
   },
 };
 
@@ -255,7 +255,14 @@ impl CSSProp {
       .as_ref()
       .ok_or(TransformError::MissingAttributeValue(span))
       .and_then(|v| match v {
-        JSXAttrValue::Str(str_lit) => Ok(Box::new(Expr::Lit(Lit::Str(str_lit.clone())))),
+        // Drop `raw`: a JSX attribute raw is JSX-encoded text (HTML entities stay
+        // encoded, backslashes are literal). Moved into JS expression position it
+        // would be printed verbatim, so emit from the decoded `value` instead.
+        JSXAttrValue::Str(str_lit) => Ok(Box::new(Expr::Lit(Lit::Str(Str {
+          span: str_lit.span,
+          value: str_lit.value.clone(),
+          raw: None,
+        })))),
         JSXAttrValue::JSXExprContainer(container) => match &container.expr {
           JSXExpr::Expr(expr) => Ok(expr.clone()),
           _ => Err(TransformError::InvalidJSXEmptyExpr(container.span)),

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/input.tsx
@@ -55,6 +55,24 @@ const Elem6 = () => (
   />
 );
 
+const ElemEntity = () => (
+  <div
+    css={css`
+      color: red;
+    `}
+    className="Food &amp; Drink"
+  />
+);
+
+const ElemBackslash = () => (
+  <div
+    css={css`
+      color: red;
+    `}
+    className="before:content-['\2713']"
+  />
+);
+
 const Elem7 = () => <div className="no-css" />;
 
 const Elem8 = () => <div css={css``} className="empty-css" />;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.dev.tsx
@@ -47,6 +47,20 @@ const Elem6 = ()=><div {...__yak_mergeCssProp({
   font-size: 16px;
 }
 */ /*#__PURE__*/ css("input_Elem6_m7uBBu"))}/>;
+const ElemEntity = ()=><div {...__yak_mergeCssProp({
+        className: "Food & Drink"
+    }, /*YAK Extracted CSS:
+:global(.input_ElemEntity_m7uBBu) {
+  color: red;
+}
+*/ /*#__PURE__*/ css("input_ElemEntity_m7uBBu"))}/>;
+const ElemBackslash = ()=><div {...__yak_mergeCssProp({
+        className: "before:content-['\\2713']"
+    }, /*YAK Extracted CSS:
+:global(.input_ElemBackslash_m7uBBu) {
+  color: red;
+}
+*/ /*#__PURE__*/ css("input_ElemBackslash_m7uBBu"))}/>;
 const Elem7 = ()=><div className="no-css"/>;
 const Elem8 = ()=><div className="empty-css"/>;
 const Elem9 = ()=><div/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.prod.tsx
@@ -47,39 +47,53 @@ const Elem6 = ()=><div {...__yak_mergeCssProp({
   font-size: 16px;
 }
 */ /*#__PURE__*/ css("ym7uBBu5"))}/>;
+const ElemEntity = ()=><div {...__yak_mergeCssProp({
+        className: "Food & Drink"
+    }, /*YAK Extracted CSS:
+:global(.ym7uBBu6) {
+  color: red;
+}
+*/ /*#__PURE__*/ css("ym7uBBu6"))}/>;
+const ElemBackslash = ()=><div {...__yak_mergeCssProp({
+        className: "before:content-['\\2713']"
+    }, /*YAK Extracted CSS:
+:global(.ym7uBBu7) {
+  color: red;
+}
+*/ /*#__PURE__*/ css("ym7uBBu7"))}/>;
 const Elem7 = ()=><div className="no-css"/>;
 const Elem8 = ()=><div className="empty-css"/>;
 const Elem9 = ()=><div/>;
 const Elem10 = ({ on }: {
     on: boolean;
 })=><div {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
-:global(.ym7uBBu9) {
-  color: red;
-}
-:global(.ym7uBBuA) {
-  color: blue;
-}
-*/ /*#__PURE__*/ css(()=>on ? /*#__PURE__*/ css("ym7uBBu9") : /*#__PURE__*/ css("ym7uBBuA"), "ym7uBBu8"))}/>;
-const Elem11 = ({ on }: {
-    on: boolean;
-})=><div {...__yak_mergeCssProp({}, on ? /*YAK Extracted CSS:
 :global(.ym7uBBuB) {
   color: red;
 }
-*/ /*#__PURE__*/ css("ym7uBBuB") as any : /*YAK Extracted CSS:
 :global(.ym7uBBuC) {
   color: blue;
 }
-*/ /*#__PURE__*/ css("ym7uBBuC"))}/>;
-const Text = /*YAK Extracted CSS:
+*/ /*#__PURE__*/ css(()=>on ? /*#__PURE__*/ css("ym7uBBuB") : /*#__PURE__*/ css("ym7uBBuC"), "ym7uBBuA"))}/>;
+const Elem11 = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on ? /*YAK Extracted CSS:
 :global(.ym7uBBuD) {
-  font-size: 20px;
-}
-*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuD");
-const StyledComponentWithCSSProp = ()=><Text {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
-:global(.ym7uBBuE) {
   color: red;
 }
-*/ /*#__PURE__*/ css("ym7uBBuE"))}>
+*/ /*#__PURE__*/ css("ym7uBBuD") as any : /*YAK Extracted CSS:
+:global(.ym7uBBuE) {
+  color: blue;
+}
+*/ /*#__PURE__*/ css("ym7uBBuE"))}/>;
+const Text = /*YAK Extracted CSS:
+:global(.ym7uBBuF) {
+  font-size: 20px;
+}
+*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuF");
+const StyledComponentWithCSSProp = ()=><Text {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
+:global(.ym7uBBuG) {
+  color: red;
+}
+*/ /*#__PURE__*/ css("ym7uBBuG"))}>
     test
   </Text>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.turbo.dev.tsx
@@ -1,6 +1,6 @@
 import { css, styled, __yak_mergeCssProp } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LmlucHV0X0VsZW1fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0VsZW0yX203dUJCdSB7CiAgY29sb3I6IGJsdWU7Cn0uaW5wdXRfRWxlbTNfbTd1QkJ1IHsKICBwYWRkaW5nOiAxMHB4Owp9LmlucHV0X0VsZW00X203dUJCdSB7CiAgY29sb3I6IGdyZWVuOwp9LmlucHV0X0VsZW01X203dUJCdSB7CiAgY29sb3I6IHB1cnBsZTsKfS5pbnB1dF9FbGVtNl9tN3VCQnUgewogIGZvbnQtc2l6ZTogMTZweDsKfS5pbnB1dF9FbGVtMTBfX29uX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfQouaW5wdXRfRWxlbTEwX19ub3Rfb25fbTd1QkJ1IHsKICBjb2xvcjogYmx1ZTsKfS5pbnB1dF9FbGVtMTFfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0VsZW0xMV9tN3VCQnUtMDEgewogIGNvbG9yOiBibHVlOwp9LmlucHV0X1RleHRfbTd1QkJ1IHsKICBmb250LXNpemU6IDIwcHg7Cn0uaW5wdXRfU3R5bGVkQ29tcG9uZW50V2l0aENTU1Byb3BfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9";
+import "data:text/css;base64,LmlucHV0X0VsZW1fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0VsZW0yX203dUJCdSB7CiAgY29sb3I6IGJsdWU7Cn0uaW5wdXRfRWxlbTNfbTd1QkJ1IHsKICBwYWRkaW5nOiAxMHB4Owp9LmlucHV0X0VsZW00X203dUJCdSB7CiAgY29sb3I6IGdyZWVuOwp9LmlucHV0X0VsZW01X203dUJCdSB7CiAgY29sb3I6IHB1cnBsZTsKfS5pbnB1dF9FbGVtNl9tN3VCQnUgewogIGZvbnQtc2l6ZTogMTZweDsKfS5pbnB1dF9FbGVtRW50aXR5X203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9FbGVtQmFja3NsYXNoX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9FbGVtMTBfX29uX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfQouaW5wdXRfRWxlbTEwX19ub3Rfb25fbTd1QkJ1IHsKICBjb2xvcjogYmx1ZTsKfS5pbnB1dF9FbGVtMTFfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0VsZW0xMV9tN3VCQnUtMDEgewogIGNvbG9yOiBibHVlOwp9LmlucHV0X1RleHRfbTd1QkJ1IHsKICBmb250LXNpemU6IDIwcHg7Cn0uaW5wdXRfU3R5bGVkQ29tcG9uZW50V2l0aENTU1Byb3BfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9";
 const Elem = ()=><div {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
 .input_Elem_m7uBBu {
   color: red;
@@ -47,6 +47,20 @@ const Elem6 = ()=><div {...__yak_mergeCssProp({
   font-size: 16px;
 }
 */ /*#__PURE__*/ css("input_Elem6_m7uBBu"))}/>;
+const ElemEntity = ()=><div {...__yak_mergeCssProp({
+        className: "Food & Drink"
+    }, /*YAK Extracted CSS:
+.input_ElemEntity_m7uBBu {
+  color: red;
+}
+*/ /*#__PURE__*/ css("input_ElemEntity_m7uBBu"))}/>;
+const ElemBackslash = ()=><div {...__yak_mergeCssProp({
+        className: "before:content-['\\2713']"
+    }, /*YAK Extracted CSS:
+.input_ElemBackslash_m7uBBu {
+  color: red;
+}
+*/ /*#__PURE__*/ css("input_ElemBackslash_m7uBBu"))}/>;
 const Elem7 = ()=><div className="no-css"/>;
 const Elem8 = ()=><div className="empty-css"/>;
 const Elem9 = ()=><div/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.turbo.prod.tsx
@@ -1,6 +1,6 @@
 import { css, styled, __yak_mergeCssProp } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LnltN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdTEgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnUyIHsKICBwYWRkaW5nOiAxMHB4Owp9LnltN3VCQnUzIHsKICBjb2xvcjogZ3JlZW47Cn0ueW03dUJCdTQgewogIGNvbG9yOiBwdXJwbGU7Cn0ueW03dUJCdTUgewogIGZvbnQtc2l6ZTogMTZweDsKfS55bTd1QkJ1OSB7CiAgY29sb3I6IHJlZDsKfQoueW03dUJCdUEgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnVCIHsKICBjb2xvcjogcmVkOwp9LnltN3VCQnVDIHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1RCB7CiAgZm9udC1zaXplOiAyMHB4Owp9LnltN3VCQnVFIHsKICBjb2xvcjogcmVkOwp9";
+import "data:text/css;base64,LnltN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdTEgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnUyIHsKICBwYWRkaW5nOiAxMHB4Owp9LnltN3VCQnUzIHsKICBjb2xvcjogZ3JlZW47Cn0ueW03dUJCdTQgewogIGNvbG9yOiBwdXJwbGU7Cn0ueW03dUJCdTUgewogIGZvbnQtc2l6ZTogMTZweDsKfS55bTd1QkJ1NiB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1NyB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1QiB7CiAgY29sb3I6IHJlZDsKfQoueW03dUJCdUMgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnVEIHsKICBjb2xvcjogcmVkOwp9LnltN3VCQnVFIHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1RiB7CiAgZm9udC1zaXplOiAyMHB4Owp9LnltN3VCQnVHIHsKICBjb2xvcjogcmVkOwp9";
 const Elem = ()=><div {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
 .ym7uBBu {
   color: red;
@@ -47,39 +47,53 @@ const Elem6 = ()=><div {...__yak_mergeCssProp({
   font-size: 16px;
 }
 */ /*#__PURE__*/ css("ym7uBBu5"))}/>;
+const ElemEntity = ()=><div {...__yak_mergeCssProp({
+        className: "Food & Drink"
+    }, /*YAK Extracted CSS:
+.ym7uBBu6 {
+  color: red;
+}
+*/ /*#__PURE__*/ css("ym7uBBu6"))}/>;
+const ElemBackslash = ()=><div {...__yak_mergeCssProp({
+        className: "before:content-['\\2713']"
+    }, /*YAK Extracted CSS:
+.ym7uBBu7 {
+  color: red;
+}
+*/ /*#__PURE__*/ css("ym7uBBu7"))}/>;
 const Elem7 = ()=><div className="no-css"/>;
 const Elem8 = ()=><div className="empty-css"/>;
 const Elem9 = ()=><div/>;
 const Elem10 = ({ on }: {
     on: boolean;
 })=><div {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
-.ym7uBBu9 {
-  color: red;
-}
-.ym7uBBuA {
-  color: blue;
-}
-*/ /*#__PURE__*/ css(()=>on ? /*#__PURE__*/ css("ym7uBBu9") : /*#__PURE__*/ css("ym7uBBuA"), "ym7uBBu8"))}/>;
-const Elem11 = ({ on }: {
-    on: boolean;
-})=><div {...__yak_mergeCssProp({}, on ? /*YAK Extracted CSS:
 .ym7uBBuB {
   color: red;
 }
-*/ /*#__PURE__*/ css("ym7uBBuB") as any : /*YAK Extracted CSS:
 .ym7uBBuC {
   color: blue;
 }
-*/ /*#__PURE__*/ css("ym7uBBuC"))}/>;
-const Text = /*YAK Extracted CSS:
+*/ /*#__PURE__*/ css(()=>on ? /*#__PURE__*/ css("ym7uBBuB") : /*#__PURE__*/ css("ym7uBBuC"), "ym7uBBuA"))}/>;
+const Elem11 = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on ? /*YAK Extracted CSS:
 .ym7uBBuD {
-  font-size: 20px;
-}
-*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuD");
-const StyledComponentWithCSSProp = ()=><Text {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
-.ym7uBBuE {
   color: red;
 }
-*/ /*#__PURE__*/ css("ym7uBBuE"))}>
+*/ /*#__PURE__*/ css("ym7uBBuD") as any : /*YAK Extracted CSS:
+.ym7uBBuE {
+  color: blue;
+}
+*/ /*#__PURE__*/ css("ym7uBBuE"))}/>;
+const Text = /*YAK Extracted CSS:
+.ym7uBBuF {
+  font-size: 20px;
+}
+*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuF");
+const StyledComponentWithCSSProp = ()=><Text {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
+.ym7uBBuG {
+  color: red;
+}
+*/ /*#__PURE__*/ css("ym7uBBuG"))}>
     test
   </Text>;


### PR DESCRIPTION
A `css` prop next to a string `className` merges at runtime through `__yak_mergeCssProp`. The transform cloned the className into the emitted JS with its JSX raw, and JSX raws keep HTML entities encoded and backslashes literal — so real-world class names corrupted silently or broke the build:

```tsx
<div css={css`color: blue;`} className="Food &amp; Drink" />
// before: class="Food &amp; Drink"   (entity reaches the DOM encoded)
// after:  class="Food & Drink"

<div css={css`color: blue;`} className="before:content-['\2713']" />
// before: build failure — every bundler's loader re-parses the emitted JS and
//         rejects the raw \27 as a strict-mode octal escape
// after:  class="before:content-['\2713']"
```

The merge now builds the string from the decoded value (`raw: None`), the same construction every other Str site in the crate uses and the styled fold adopted in #605. The octal-escape build breaker is pinned by the SWC fixture in all four modes; e2e asserts the DOM class and applied style, using a non-digit backslash token because cold JSX dependency scanners (rolldown) reject `\<digit>` in raw source — a bundler limitation unrelated to yak.

🤖 Co-authored-by **Claude Code**