### PR TITLE
Emit folded className merges in expression position

### DIFF
--- a/.changeset/fold-classname-byte-exact.md
+++ b/.changeset/fold-classname-byte-exact.md
@@ -1,0 +1,5 @@
+---
+"yak-swc": patch
+---
+
+A folded `className` merge keeps the user's class name exactly as written: backslashes, HTML entities and emoji reach the DOM byte for byte.

--- a/e2e/cases/foldables/index.test.ts
+++ b/e2e/cases/foldables/index.test.ts
@@ -59,5 +59,16 @@ test(
 
     // backslashes in JSX attributes stay literal characters when the condition is inlined
     await expect(page.getByTestId("backslash")).toHaveCSS("color", "rgb(30, 144, 255)");
+
+    // a static merge with a backslash escape in the user className keeps a single
+    // backslash after the JSX re-parse - a raw attribute string would double it
+    const escape = page.getByTestId("escape");
+    const escapeRuntime = page.getByTestId("escape-runtime");
+    const foldedClass = (await escape.getAttribute("class")) ?? "";
+    const runtimeClass = (await escapeRuntime.getAttribute("class")) ?? "";
+    expect(foldedClass).toContain("before:content-['\\d7']");
+    expect(foldedClass).not.toContain("before:content-['\\\\d7']");
+    // same tokens as the runtime twin, order aside
+    expect(foldedClass.split(" ").sort()).toEqual(runtimeClass.split(" ").sort());
   }),
 );

--- a/e2e/cases/foldables/index.test.ts
+++ b/e2e/cases/foldables/index.test.ts
@@ -70,5 +70,11 @@ test(
     expect(foldedClass).not.toContain("before:content-['\\\\d7']");
     // same tokens as the runtime twin, order aside
     expect(foldedClass.split(" ").sort()).toEqual(runtimeClass.split(" ").sort());
+
+    // an emoji className survives byte-exact through the fold, like its twin
+    const emojiClass = (await page.getByTestId("emoji").getAttribute("class")) ?? "";
+    const emojiRuntimeClass = (await page.getByTestId("emoji-runtime").getAttribute("class")) ?? "";
+    expect(emojiClass).toContain("🔥");
+    expect(emojiClass.split(" ").sort()).toEqual(emojiRuntimeClass.split(" ").sort());
   }),
 );

--- a/e2e/cases/foldables/index.tsx
+++ b/e2e/cases/foldables/index.tsx
@@ -134,6 +134,13 @@ export default function App() {
       <Card data-testid="escape-runtime" {...{ className: "mark before:content-['\\d7']" }}>
         runtime twin
       </Card>
+      {/* an emoji className must reach the DOM byte-exact, matching its twin */}
+      <Card data-testid="emoji" className="🔥 mark">
+        emoji merge
+      </Card>
+      <Card data-testid="emoji-runtime" {...{ className: "🔥 mark" }}>
+        runtime twin
+      </Card>
     </>
   );
 }

--- a/e2e/cases/foldables/index.tsx
+++ b/e2e/cases/foldables/index.tsx
@@ -126,6 +126,17 @@ export default function App() {
       <Shortcut data-testid="backslash" $keys="a\tb">
         a\tb
       </Shortcut>
+      {/* a static merge with a backslash escape in the user className - the
+          folded class attribute must read the same as the runtime twin below */}
+      <Card data-testid="escape" className="mark before:content-['\d7']">
+        escape merge
+      </Card>
+      <Card
+        data-testid="escape-runtime"
+        {...{ className: "mark before:content-['\\d7']" }}
+      >
+        runtime twin
+      </Card>
     </>
   );
 }

--- a/e2e/cases/foldables/index.tsx
+++ b/e2e/cases/foldables/index.tsx
@@ -131,10 +131,7 @@ export default function App() {
       <Card data-testid="escape" className="mark before:content-['\d7']">
         escape merge
       </Card>
-      <Card
-        data-testid="escape-runtime"
-        {...{ className: "mark before:content-['\\d7']" }}
-      >
+      <Card data-testid="escape-runtime" {...{ className: "mark before:content-['\\d7']" }}>
         runtime twin
       </Card>
     </>

--- a/packages/yak-swc/yak_swc/src/utils/fold/css_expr.rs
+++ b/packages/yak-swc/yak_swc/src/utils/fold/css_expr.rs
@@ -9,7 +9,7 @@
 use crate::utils::ast_helper::unwrap_type_casts;
 use crate::yak_imports::YakImports;
 use swc_core::{
-  atoms::Wtf8Atom,
+  atoms::{wtf8::Wtf8Buf, Wtf8Atom},
   common::{Span, Spanned, DUMMY_SP},
   ecma::ast::{
     ArrowExpr, BinExpr, BinaryOp, BlockStmtOrExpr, CallExpr, Callee, CondExpr, Expr, IdentName,
@@ -214,8 +214,16 @@ pub(super) fn is_yak_css_callee(callee: &Callee, yak_imports: &YakImports) -> bo
 }
 
 /// Joins two class names with a single space, e.g. `"a"` and `"b"` -> `"a b"`
+///
+/// Concatenates at the WTF-8 level so a user class name is copied byte for byte:
+/// emoji and any other content survive intact, where a lossy String round-trip
+/// would replace unpaired surrogates with U+FFFD
 pub(super) fn merge_class_names(first: &Wtf8Atom, second: &Wtf8Atom) -> Wtf8Atom {
-  format!("{} {}", first.to_string_lossy(), second.to_string_lossy()).into()
+  let mut buf = Wtf8Buf::with_capacity(first.len() + 1 + second.len());
+  buf.push_wtf8(first);
+  buf.push_str(" ");
+  buf.push_wtf8(second);
+  buf.into()
 }
 
 /// Prefixes a class name with a space so it can be concatenated onto a base
@@ -225,7 +233,10 @@ pub(super) fn with_leading_space(class_name: &Wtf8Atom) -> Wtf8Atom {
   if class_name.is_empty() {
     return "".into();
   }
-  format!(" {}", class_name.to_string_lossy()).into()
+  let mut buf = Wtf8Buf::with_capacity(1 + class_name.len());
+  buf.push_str(" ");
+  buf.push_wtf8(class_name);
+  buf.into()
 }
 
 /// Builds a string literal

--- a/packages/yak-swc/yak_swc/src/utils/fold/css_prop.rs
+++ b/packages/yak-swc/yak_swc/src/utils/fold/css_prop.rs
@@ -139,7 +139,7 @@ impl CSSProp {
   ///
   /// e.g.
   /// ```jsx
-  /// <div css={css("a")} />                        // -> <div className="a" />
+  /// <div css={css("a")} />                        // -> <div className={"a"} />
   /// <div css={css(() => on && css("b"), "a")} />  // -> <div className={"a" + (on ? " b" : "")} />
   /// <div css={on ? css("a") : css("b")} />        // -> <div className={on ? "a" : "b"} />
   /// ```

--- a/packages/yak-swc/yak_swc/src/utils/fold/usage.rs
+++ b/packages/yak-swc/yak_swc/src/utils/fold/usage.rs
@@ -484,8 +484,10 @@ impl FoldVisitor<'_> {
         // backslash or quote: those print differently under JS and JSX. A
         // merge routes through expression position for the same reason
         YakClassName::Static(class_name) => {
+          // scan the raw WTF-8 bytes: `\` and `"` are ASCII, so this never
+          // decodes the value and leaves any emoji or surrogate untouched
           debug_assert!(
-            !class_name.to_string_lossy().contains(['\\', '"']),
+            !class_name.as_bytes().iter().any(|&b| b == b'\\' || b == b'"'),
             "a folded class name must carry no backslash or quote: {class_name:?}"
           );
           JSXAttrValue::Str(str_lit(class_name, DUMMY_SP))
@@ -1065,6 +1067,66 @@ mod tests {
       Expr::JSXElement(element) => element.opening.attrs,
       _ => panic!("`{source}` is not a JSX element"),
     }
+  }
+
+  /// The `className` attribute's string literal value, whether spelled as a
+  /// plain attribute or a `{"..."}` container
+  fn class_name_value(source: &str) -> Wtf8Atom {
+    for attr in attrs_of(source) {
+      let JSXAttrOrSpread::JSXAttr(attr) = attr else {
+        continue;
+      };
+      let JSXAttrName::Ident(name) = &attr.name else {
+        continue;
+      };
+      if name.sym != "className" {
+        continue;
+      }
+      match attr.value.as_ref() {
+        Some(JSXAttrValue::Str(str_lit)) => return str_lit.value.clone(),
+        Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+          expr: JSXExpr::Expr(expr),
+          ..
+        })) => {
+          if let Expr::Lit(Lit::Str(str_lit)) = &**expr {
+            return str_lit.value.clone();
+          }
+        }
+        _ => {}
+      }
+    }
+    panic!("`{source}` has no className string literal");
+  }
+
+  #[test]
+  fn a_merge_copies_the_user_class_name_byte_for_byte() {
+    // emoji are valid UTF-8, so the merge keeps them - to_string_lossy only
+    // replaces unpaired surrogates, which valid UTF-8 never has
+    assert_eq!(
+      merge_class_names(&"yak".into(), &"🔥".into()).as_str(),
+      Some("yak 🔥")
+    );
+  }
+
+  #[test]
+  fn only_a_string_literal_carries_an_unpaired_surrogate() {
+    // a JSX attribute string spells escapes literally: `\uD800` is six
+    // characters and stays valid UTF-8 - a surrogate cannot enter this way
+    assert_eq!(
+      class_name_value(r#"<div className="\uD800" />"#).as_str(),
+      Some(r"\uD800")
+    );
+    // a JS string literal decodes the escape to the surrogate, which as_str()
+    // cannot represent - this is the only path an unpaired surrogate reaches
+    let surrogate = class_name_value(r#"<div className={"\uD800"} />"#);
+    assert_eq!(surrogate.as_str(), None);
+    // the merge keeps it byte-exact instead of collapsing it to U+FFFD
+    let merged = merge_class_names(&"yak".into(), &surrogate);
+    assert_eq!(merged.as_str(), None);
+    assert_eq!(
+      merged.as_bytes(),
+      [b"yak ", surrogate.as_bytes()].concat().as_slice()
+    );
   }
 
   /// The shape a usage takes, given which of its props the style conditions

--- a/packages/yak-swc/yak_swc/src/utils/fold/usage.rs
+++ b/packages/yak-swc/yak_swc/src/utils/fold/usage.rs
@@ -487,7 +487,10 @@ impl FoldVisitor<'_> {
           // scan the raw WTF-8 bytes: `\` and `"` are ASCII, so this never
           // decodes the value and leaves any emoji or surrogate untouched
           debug_assert!(
-            !class_name.as_bytes().iter().any(|&b| b == b'\\' || b == b'"'),
+            !class_name
+              .as_bytes()
+              .iter()
+              .any(|&b| b == b'\\' || b == b'"'),
             "a folded class name must carry no backslash or quote: {class_name:?}"
           );
           JSXAttrValue::Str(str_lit(class_name, DUMMY_SP))

--- a/packages/yak-swc/yak_swc/src/utils/fold/usage.rs
+++ b/packages/yak-swc/yak_swc/src/utils/fold/usage.rs
@@ -480,7 +480,16 @@ impl FoldVisitor<'_> {
     // leave the specifier behind with nothing referencing it
     let Some(index) = class_name_index else {
       let value = match yak_class {
-        YakClassName::Static(class_name) => JSXAttrValue::Str(str_lit(class_name, DUMMY_SP)),
+        // safe as a raw attribute string only while the class name carries no
+        // backslash or quote: those print differently under JS and JSX. A
+        // merge routes through expression position for the same reason
+        YakClassName::Static(class_name) => {
+          debug_assert!(
+            !class_name.to_string_lossy().contains(['\\', '"']),
+            "a folded class name must carry no backslash or quote: {class_name:?}"
+          );
+          JSXAttrValue::Str(str_lit(class_name, DUMMY_SP))
+        }
         YakClassName::Dynamic(expr) => expr_attr_value(expr),
       };
       return Some(FoldPlan {
@@ -509,10 +518,12 @@ impl FoldVisitor<'_> {
     match value {
       // className="user"
       JSXAttrValue::Str(user) => Some(match yak_class {
-        YakClassName::Static(class_name) => JSXAttrValue::Str(str_lit(
-          merge_class_names(&class_name, &user.value),
-          user.span,
-        )),
+        // a JSX attribute string prints with JS escaping but re-parses without
+        // it, so a user backslash would double; the container keeps both
+        // directions in one regime
+        YakClassName::Static(class_name) => expr_attr_value(Box::new(Expr::Lit(Lit::Str(
+          str_lit(merge_class_names(&class_name, &user.value), user.span),
+        )))),
         // `"yX" + (on ? " yY" : "") + " user"`
         YakClassName::Dynamic(expr) => {
           expr_attr_value(append_class_name_str(expr, &user.value, user.span))

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/input.tsx
@@ -73,6 +73,15 @@ const ElemBackslash = () => (
   />
 );
 
+const ElemEmoji = () => (
+  <div
+    css={css`
+      color: red;
+    `}
+    className="🔥 mark"
+  />
+);
+
 const Elem7 = () => <div className="no-css" />;
 
 const Elem8 = () => <div css={css``} className="empty-css" />;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.dev.tsx
@@ -61,6 +61,13 @@ const ElemBackslash = ()=><div {...__yak_mergeCssProp({
   color: red;
 }
 */ /*#__PURE__*/ css("input_ElemBackslash_m7uBBu"))}/>;
+const ElemEmoji = ()=><div {...__yak_mergeCssProp({
+        className: "🔥 mark"
+    }, /*YAK Extracted CSS:
+:global(.input_ElemEmoji_m7uBBu) {
+  color: red;
+}
+*/ /*#__PURE__*/ css("input_ElemEmoji_m7uBBu"))}/>;
 const Elem7 = ()=><div className="no-css"/>;
 const Elem8 = ()=><div className="empty-css"/>;
 const Elem9 = ()=><div/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.prod.tsx
@@ -61,39 +61,46 @@ const ElemBackslash = ()=><div {...__yak_mergeCssProp({
   color: red;
 }
 */ /*#__PURE__*/ css("ym7uBBu7"))}/>;
+const ElemEmoji = ()=><div {...__yak_mergeCssProp({
+        className: "🔥 mark"
+    }, /*YAK Extracted CSS:
+:global(.ym7uBBu8) {
+  color: red;
+}
+*/ /*#__PURE__*/ css("ym7uBBu8"))}/>;
 const Elem7 = ()=><div className="no-css"/>;
 const Elem8 = ()=><div className="empty-css"/>;
 const Elem9 = ()=><div/>;
 const Elem10 = ({ on }: {
     on: boolean;
 })=><div {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
-:global(.ym7uBBuB) {
+:global(.ym7uBBuC) {
   color: red;
 }
-:global(.ym7uBBuC) {
+:global(.ym7uBBuD) {
   color: blue;
 }
-*/ /*#__PURE__*/ css(()=>on ? /*#__PURE__*/ css("ym7uBBuB") : /*#__PURE__*/ css("ym7uBBuC"), "ym7uBBuA"))}/>;
+*/ /*#__PURE__*/ css(()=>on ? /*#__PURE__*/ css("ym7uBBuC") : /*#__PURE__*/ css("ym7uBBuD"), "ym7uBBuB"))}/>;
 const Elem11 = ({ on }: {
     on: boolean;
 })=><div {...__yak_mergeCssProp({}, on ? /*YAK Extracted CSS:
-:global(.ym7uBBuD) {
+:global(.ym7uBBuE) {
   color: red;
 }
-*/ /*#__PURE__*/ css("ym7uBBuD") as any : /*YAK Extracted CSS:
-:global(.ym7uBBuE) {
+*/ /*#__PURE__*/ css("ym7uBBuE") as any : /*YAK Extracted CSS:
+:global(.ym7uBBuF) {
   color: blue;
 }
-*/ /*#__PURE__*/ css("ym7uBBuE"))}/>;
+*/ /*#__PURE__*/ css("ym7uBBuF"))}/>;
 const Text = /*YAK Extracted CSS:
-:global(.ym7uBBuF) {
+:global(.ym7uBBuG) {
   font-size: 20px;
 }
-*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuF");
+*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuG");
 const StyledComponentWithCSSProp = ()=><Text {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
-:global(.ym7uBBuG) {
+:global(.ym7uBBuH) {
   color: red;
 }
-*/ /*#__PURE__*/ css("ym7uBBuG"))}>
+*/ /*#__PURE__*/ css("ym7uBBuH"))}>
     test
   </Text>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.turbo.dev.tsx
@@ -1,6 +1,6 @@
 import { css, styled, __yak_mergeCssProp } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LmlucHV0X0VsZW1fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0VsZW0yX203dUJCdSB7CiAgY29sb3I6IGJsdWU7Cn0uaW5wdXRfRWxlbTNfbTd1QkJ1IHsKICBwYWRkaW5nOiAxMHB4Owp9LmlucHV0X0VsZW00X203dUJCdSB7CiAgY29sb3I6IGdyZWVuOwp9LmlucHV0X0VsZW01X203dUJCdSB7CiAgY29sb3I6IHB1cnBsZTsKfS5pbnB1dF9FbGVtNl9tN3VCQnUgewogIGZvbnQtc2l6ZTogMTZweDsKfS5pbnB1dF9FbGVtRW50aXR5X203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9FbGVtQmFja3NsYXNoX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9FbGVtMTBfX29uX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfQouaW5wdXRfRWxlbTEwX19ub3Rfb25fbTd1QkJ1IHsKICBjb2xvcjogYmx1ZTsKfS5pbnB1dF9FbGVtMTFfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0VsZW0xMV9tN3VCQnUtMDEgewogIGNvbG9yOiBibHVlOwp9LmlucHV0X1RleHRfbTd1QkJ1IHsKICBmb250LXNpemU6IDIwcHg7Cn0uaW5wdXRfU3R5bGVkQ29tcG9uZW50V2l0aENTU1Byb3BfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9";
+import "data:text/css;base64,LmlucHV0X0VsZW1fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0VsZW0yX203dUJCdSB7CiAgY29sb3I6IGJsdWU7Cn0uaW5wdXRfRWxlbTNfbTd1QkJ1IHsKICBwYWRkaW5nOiAxMHB4Owp9LmlucHV0X0VsZW00X203dUJCdSB7CiAgY29sb3I6IGdyZWVuOwp9LmlucHV0X0VsZW01X203dUJCdSB7CiAgY29sb3I6IHB1cnBsZTsKfS5pbnB1dF9FbGVtNl9tN3VCQnUgewogIGZvbnQtc2l6ZTogMTZweDsKfS5pbnB1dF9FbGVtRW50aXR5X203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9FbGVtQmFja3NsYXNoX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9FbGVtRW1vamlfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0VsZW0xMF9fb25fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9Ci5pbnB1dF9FbGVtMTBfX25vdF9vbl9tN3VCQnUgewogIGNvbG9yOiBibHVlOwp9LmlucHV0X0VsZW0xMV9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfRWxlbTExX203dUJCdS0wMSB7CiAgY29sb3I6IGJsdWU7Cn0uaW5wdXRfVGV4dF9tN3VCQnUgewogIGZvbnQtc2l6ZTogMjBweDsKfS5pbnB1dF9TdHlsZWRDb21wb25lbnRXaXRoQ1NTUHJvcF9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0=";
 const Elem = ()=><div {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
 .input_Elem_m7uBBu {
   color: red;
@@ -61,6 +61,13 @@ const ElemBackslash = ()=><div {...__yak_mergeCssProp({
   color: red;
 }
 */ /*#__PURE__*/ css("input_ElemBackslash_m7uBBu"))}/>;
+const ElemEmoji = ()=><div {...__yak_mergeCssProp({
+        className: "🔥 mark"
+    }, /*YAK Extracted CSS:
+.input_ElemEmoji_m7uBBu {
+  color: red;
+}
+*/ /*#__PURE__*/ css("input_ElemEmoji_m7uBBu"))}/>;
 const Elem7 = ()=><div className="no-css"/>;
 const Elem8 = ()=><div className="empty-css"/>;
 const Elem9 = ()=><div/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.turbo.prod.tsx
@@ -1,6 +1,6 @@
 import { css, styled, __yak_mergeCssProp } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LnltN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdTEgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnUyIHsKICBwYWRkaW5nOiAxMHB4Owp9LnltN3VCQnUzIHsKICBjb2xvcjogZ3JlZW47Cn0ueW03dUJCdTQgewogIGNvbG9yOiBwdXJwbGU7Cn0ueW03dUJCdTUgewogIGZvbnQtc2l6ZTogMTZweDsKfS55bTd1QkJ1NiB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1NyB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1QiB7CiAgY29sb3I6IHJlZDsKfQoueW03dUJCdUMgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnVEIHsKICBjb2xvcjogcmVkOwp9LnltN3VCQnVFIHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1RiB7CiAgZm9udC1zaXplOiAyMHB4Owp9LnltN3VCQnVHIHsKICBjb2xvcjogcmVkOwp9";
+import "data:text/css;base64,LnltN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdTEgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnUyIHsKICBwYWRkaW5nOiAxMHB4Owp9LnltN3VCQnUzIHsKICBjb2xvcjogZ3JlZW47Cn0ueW03dUJCdTQgewogIGNvbG9yOiBwdXJwbGU7Cn0ueW03dUJCdTUgewogIGZvbnQtc2l6ZTogMTZweDsKfS55bTd1QkJ1NiB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1NyB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1OCB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1QyB7CiAgY29sb3I6IHJlZDsKfQoueW03dUJCdUQgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnVFIHsKICBjb2xvcjogcmVkOwp9LnltN3VCQnVGIHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1RyB7CiAgZm9udC1zaXplOiAyMHB4Owp9LnltN3VCQnVIIHsKICBjb2xvcjogcmVkOwp9";
 const Elem = ()=><div {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
 .ym7uBBu {
   color: red;
@@ -61,39 +61,46 @@ const ElemBackslash = ()=><div {...__yak_mergeCssProp({
   color: red;
 }
 */ /*#__PURE__*/ css("ym7uBBu7"))}/>;
+const ElemEmoji = ()=><div {...__yak_mergeCssProp({
+        className: "🔥 mark"
+    }, /*YAK Extracted CSS:
+.ym7uBBu8 {
+  color: red;
+}
+*/ /*#__PURE__*/ css("ym7uBBu8"))}/>;
 const Elem7 = ()=><div className="no-css"/>;
 const Elem8 = ()=><div className="empty-css"/>;
 const Elem9 = ()=><div/>;
 const Elem10 = ({ on }: {
     on: boolean;
 })=><div {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
-.ym7uBBuB {
+.ym7uBBuC {
   color: red;
 }
-.ym7uBBuC {
+.ym7uBBuD {
   color: blue;
 }
-*/ /*#__PURE__*/ css(()=>on ? /*#__PURE__*/ css("ym7uBBuB") : /*#__PURE__*/ css("ym7uBBuC"), "ym7uBBuA"))}/>;
+*/ /*#__PURE__*/ css(()=>on ? /*#__PURE__*/ css("ym7uBBuC") : /*#__PURE__*/ css("ym7uBBuD"), "ym7uBBuB"))}/>;
 const Elem11 = ({ on }: {
     on: boolean;
 })=><div {...__yak_mergeCssProp({}, on ? /*YAK Extracted CSS:
-.ym7uBBuD {
+.ym7uBBuE {
   color: red;
 }
-*/ /*#__PURE__*/ css("ym7uBBuD") as any : /*YAK Extracted CSS:
-.ym7uBBuE {
+*/ /*#__PURE__*/ css("ym7uBBuE") as any : /*YAK Extracted CSS:
+.ym7uBBuF {
   color: blue;
 }
-*/ /*#__PURE__*/ css("ym7uBBuE"))}/>;
+*/ /*#__PURE__*/ css("ym7uBBuF"))}/>;
 const Text = /*YAK Extracted CSS:
-.ym7uBBuF {
+.ym7uBBuG {
   font-size: 20px;
 }
-*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuF");
+*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuG");
 const StyledComponentWithCSSProp = ()=><Text {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
-.ym7uBBuG {
+.ym7uBBuH {
   color: red;
 }
-*/ /*#__PURE__*/ css("ym7uBBuG"))}>
+*/ /*#__PURE__*/ css("ym7uBBuH"))}>
     test
   </Text>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/input.tsx
@@ -27,10 +27,16 @@ const Cross = styled.span`
   color: grey;
 `;
 
+// An emoji is valid UTF-8, so a static merge copies it byte for byte
+const Emoji = styled.span`
+  color: grey;
+`;
+
 export const Menu = () => (
   <>
     <Category $label="Food &amp; Drink">Food &amp; Drink</Category>
     <Shortcut $keys="a\tb">a\tb</Shortcut>
     <Cross className="before:content-['\00d7'] icon &amp; more">x</Cross>
+    <Emoji className="🔥 mark">x</Emoji>
   </>
 );

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/input.tsx
@@ -21,9 +21,16 @@ const Shortcut = styled.kbd<{ $keys?: string }>`
     `}
 `;
 
+// A static merge goes through expression position so a backslash escape in the
+// user className survives the JSX re-parse instead of doubling
+const Cross = styled.span`
+  color: grey;
+`;
+
 export const Menu = () => (
   <>
     <Category $label="Food &amp; Drink">Food &amp; Drink</Category>
     <Shortcut $keys="a\tb">a\tb</Shortcut>
+    <Cross className="before:content-['\00d7'] icon &amp; more">x</Cross>
   </>
 );

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.dev.tsx
@@ -33,8 +33,17 @@ const Cross = /*YAK Extracted CSS:
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_span("input_Cross_m7uBBu"), {
     "displayName": "Cross"
 });
+// An emoji is valid UTF-8, so a static merge copies it byte for byte
+const Emoji = /*YAK Extracted CSS:
+:global(.input_Emoji_m7uBBu) {
+  color: grey;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_span("input_Emoji_m7uBBu"), {
+    "displayName": "Emoji"
+});
 export const Menu = ()=><>
     <li className={"input_Category_m7uBBu" + ("Food & Drink" === "Food & Drink" ? " input_Category___m7uBBu" : "")}>Food &amp; Drink</li>
     <kbd className={"input_Shortcut_m7uBBu" + ("a\\tb" === "a\\tb" ? " input_Shortcut___m7uBBu" : "")}>a\tb</kbd>
     <span className={"input_Cross_m7uBBu before:content-['\\00d7'] icon & more"}>x</span>
+    <span className={"input_Emoji_m7uBBu 🔥 mark"}>x</span>
   </>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.dev.tsx
@@ -24,7 +24,17 @@ const Shortcut = /*YAK Extracted CSS:
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_kbd("input_Shortcut_m7uBBu", ({ $keys })=>$keys === "a\\tb" && /*#__PURE__*/ css("input_Shortcut___m7uBBu")), {
     "displayName": "Shortcut"
 });
+// A static merge goes through expression position so a backslash escape in the
+// user className survives the JSX re-parse instead of doubling
+const Cross = /*YAK Extracted CSS:
+:global(.input_Cross_m7uBBu) {
+  color: grey;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_span("input_Cross_m7uBBu"), {
+    "displayName": "Cross"
+});
 export const Menu = ()=><>
     <li className={"input_Category_m7uBBu" + ("Food & Drink" === "Food & Drink" ? " input_Category___m7uBBu" : "")}>Food &amp; Drink</li>
     <kbd className={"input_Shortcut_m7uBBu" + ("a\\tb" === "a\\tb" ? " input_Shortcut___m7uBBu" : "")}>a\tb</kbd>
+    <span className={"input_Cross_m7uBBu before:content-['\\00d7'] icon & more"}>x</span>
   </>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.prod.tsx
@@ -20,7 +20,15 @@ const Shortcut = /*YAK Extracted CSS:
   color: dodgerblue;
 }
 */ /*#__PURE__*/ __yak.__yak_kbd("ym7uBBu2", ({ $keys })=>$keys === "a\\tb" && /*#__PURE__*/ css("ym7uBBu3"));
+// A static merge goes through expression position so a backslash escape in the
+// user className survives the JSX re-parse instead of doubling
+const Cross = /*YAK Extracted CSS:
+:global(.ym7uBBu4) {
+  color: grey;
+}
+*/ /*#__PURE__*/ __yak.__yak_span("ym7uBBu4");
 export const Menu = ()=><>
     <li className={"ym7uBBu" + ("Food & Drink" === "Food & Drink" ? " ym7uBBu1" : "")}>Food &amp; Drink</li>
     <kbd className={"ym7uBBu2" + ("a\\tb" === "a\\tb" ? " ym7uBBu3" : "")}>a\tb</kbd>
+    <span className={"ym7uBBu4 before:content-['\\00d7'] icon & more"}>x</span>
   </>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.prod.tsx
@@ -27,8 +27,15 @@ const Cross = /*YAK Extracted CSS:
   color: grey;
 }
 */ /*#__PURE__*/ __yak.__yak_span("ym7uBBu4");
+// An emoji is valid UTF-8, so a static merge copies it byte for byte
+const Emoji = /*YAK Extracted CSS:
+:global(.ym7uBBu5) {
+  color: grey;
+}
+*/ /*#__PURE__*/ __yak.__yak_span("ym7uBBu5");
 export const Menu = ()=><>
     <li className={"ym7uBBu" + ("Food & Drink" === "Food & Drink" ? " ym7uBBu1" : "")}>Food &amp; Drink</li>
     <kbd className={"ym7uBBu2" + ("a\\tb" === "a\\tb" ? " ym7uBBu3" : "")}>a\tb</kbd>
     <span className={"ym7uBBu4 before:content-['\\00d7'] icon & more"}>x</span>
+    <span className={"ym7uBBu5 🔥 mark"}>x</span>
   </>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.turbo.dev.tsx
@@ -1,6 +1,6 @@
 import { css, styled } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LmlucHV0X0NhdGVnb3J5X203dUJCdSB7CiAgY29sb3I6IGdyZXk7Cn0KLmlucHV0X0NhdGVnb3J5X19fbTd1QkJ1IHsKICBjb2xvcjogY3JpbXNvbjsKfS5pbnB1dF9TaG9ydGN1dF9tN3VCQnUgewogIGNvbG9yOiBncmV5Owp9Ci5pbnB1dF9TaG9ydGN1dF9fX203dUJCdSB7CiAgY29sb3I6IGRvZGdlcmJsdWU7Cn0uaW5wdXRfQ3Jvc3NfbTd1QkJ1IHsKICBjb2xvcjogZ3JleTsKfQ==";
+import "data:text/css;base64,LmlucHV0X0NhdGVnb3J5X203dUJCdSB7CiAgY29sb3I6IGdyZXk7Cn0KLmlucHV0X0NhdGVnb3J5X19fbTd1QkJ1IHsKICBjb2xvcjogY3JpbXNvbjsKfS5pbnB1dF9TaG9ydGN1dF9tN3VCQnUgewogIGNvbG9yOiBncmV5Owp9Ci5pbnB1dF9TaG9ydGN1dF9fX203dUJCdSB7CiAgY29sb3I6IGRvZGdlcmJsdWU7Cn0uaW5wdXRfQ3Jvc3NfbTd1QkJ1IHsKICBjb2xvcjogZ3JleTsKfS5pbnB1dF9FbW9qaV9tN3VCQnUgewogIGNvbG9yOiBncmV5Owp9";
 // JSX attribute strings are decoded before they reach the condition:
 // entities like &amp; and literal backslashes must compare by value,
 // not by their JSX source spelling
@@ -33,8 +33,17 @@ const Cross = /*YAK Extracted CSS:
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_span("input_Cross_m7uBBu"), {
     "displayName": "Cross"
 });
+// An emoji is valid UTF-8, so a static merge copies it byte for byte
+const Emoji = /*YAK Extracted CSS:
+.input_Emoji_m7uBBu {
+  color: grey;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_span("input_Emoji_m7uBBu"), {
+    "displayName": "Emoji"
+});
 export const Menu = ()=><>
     <li className={"input_Category_m7uBBu" + ("Food & Drink" === "Food & Drink" ? " input_Category___m7uBBu" : "")}>Food &amp; Drink</li>
     <kbd className={"input_Shortcut_m7uBBu" + ("a\\tb" === "a\\tb" ? " input_Shortcut___m7uBBu" : "")}>a\tb</kbd>
     <span className={"input_Cross_m7uBBu before:content-['\\00d7'] icon & more"}>x</span>
+    <span className={"input_Emoji_m7uBBu 🔥 mark"}>x</span>
   </>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.turbo.dev.tsx
@@ -1,6 +1,6 @@
 import { css, styled } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LmlucHV0X0NhdGVnb3J5X203dUJCdSB7CiAgY29sb3I6IGdyZXk7Cn0KLmlucHV0X0NhdGVnb3J5X19fbTd1QkJ1IHsKICBjb2xvcjogY3JpbXNvbjsKfS5pbnB1dF9TaG9ydGN1dF9tN3VCQnUgewogIGNvbG9yOiBncmV5Owp9Ci5pbnB1dF9TaG9ydGN1dF9fX203dUJCdSB7CiAgY29sb3I6IGRvZGdlcmJsdWU7Cn0=";
+import "data:text/css;base64,LmlucHV0X0NhdGVnb3J5X203dUJCdSB7CiAgY29sb3I6IGdyZXk7Cn0KLmlucHV0X0NhdGVnb3J5X19fbTd1QkJ1IHsKICBjb2xvcjogY3JpbXNvbjsKfS5pbnB1dF9TaG9ydGN1dF9tN3VCQnUgewogIGNvbG9yOiBncmV5Owp9Ci5pbnB1dF9TaG9ydGN1dF9fX203dUJCdSB7CiAgY29sb3I6IGRvZGdlcmJsdWU7Cn0uaW5wdXRfQ3Jvc3NfbTd1QkJ1IHsKICBjb2xvcjogZ3JleTsKfQ==";
 // JSX attribute strings are decoded before they reach the condition:
 // entities like &amp; and literal backslashes must compare by value,
 // not by their JSX source spelling
@@ -24,7 +24,17 @@ const Shortcut = /*YAK Extracted CSS:
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_kbd("input_Shortcut_m7uBBu", ({ $keys })=>$keys === "a\\tb" && /*#__PURE__*/ css("input_Shortcut___m7uBBu")), {
     "displayName": "Shortcut"
 });
+// A static merge goes through expression position so a backslash escape in the
+// user className survives the JSX re-parse instead of doubling
+const Cross = /*YAK Extracted CSS:
+.input_Cross_m7uBBu {
+  color: grey;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_span("input_Cross_m7uBBu"), {
+    "displayName": "Cross"
+});
 export const Menu = ()=><>
     <li className={"input_Category_m7uBBu" + ("Food & Drink" === "Food & Drink" ? " input_Category___m7uBBu" : "")}>Food &amp; Drink</li>
     <kbd className={"input_Shortcut_m7uBBu" + ("a\\tb" === "a\\tb" ? " input_Shortcut___m7uBBu" : "")}>a\tb</kbd>
+    <span className={"input_Cross_m7uBBu before:content-['\\00d7'] icon & more"}>x</span>
   </>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.turbo.prod.tsx
@@ -1,6 +1,6 @@
 import { css, styled } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LnltN3VCQnUgewogIGNvbG9yOiBncmV5Owp9Ci55bTd1QkJ1MSB7CiAgY29sb3I6IGNyaW1zb247Cn0ueW03dUJCdTIgewogIGNvbG9yOiBncmV5Owp9Ci55bTd1QkJ1MyB7CiAgY29sb3I6IGRvZGdlcmJsdWU7Cn0ueW03dUJCdTQgewogIGNvbG9yOiBncmV5Owp9";
+import "data:text/css;base64,LnltN3VCQnUgewogIGNvbG9yOiBncmV5Owp9Ci55bTd1QkJ1MSB7CiAgY29sb3I6IGNyaW1zb247Cn0ueW03dUJCdTIgewogIGNvbG9yOiBncmV5Owp9Ci55bTd1QkJ1MyB7CiAgY29sb3I6IGRvZGdlcmJsdWU7Cn0ueW03dUJCdTQgewogIGNvbG9yOiBncmV5Owp9LnltN3VCQnU1IHsKICBjb2xvcjogZ3JleTsKfQ==";
 // JSX attribute strings are decoded before they reach the condition:
 // entities like &amp; and literal backslashes must compare by value,
 // not by their JSX source spelling
@@ -27,8 +27,15 @@ const Cross = /*YAK Extracted CSS:
   color: grey;
 }
 */ /*#__PURE__*/ __yak.__yak_span("ym7uBBu4");
+// An emoji is valid UTF-8, so a static merge copies it byte for byte
+const Emoji = /*YAK Extracted CSS:
+.ym7uBBu5 {
+  color: grey;
+}
+*/ /*#__PURE__*/ __yak.__yak_span("ym7uBBu5");
 export const Menu = ()=><>
     <li className={"ym7uBBu" + ("Food & Drink" === "Food & Drink" ? " ym7uBBu1" : "")}>Food &amp; Drink</li>
     <kbd className={"ym7uBBu2" + ("a\\tb" === "a\\tb" ? " ym7uBBu3" : "")}>a\tb</kbd>
     <span className={"ym7uBBu4 before:content-['\\00d7'] icon & more"}>x</span>
+    <span className={"ym7uBBu5 🔥 mark"}>x</span>
   </>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-string-attrs/output.turbo.prod.tsx
@@ -1,6 +1,6 @@
 import { css, styled } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LnltN3VCQnUgewogIGNvbG9yOiBncmV5Owp9Ci55bTd1QkJ1MSB7CiAgY29sb3I6IGNyaW1zb247Cn0ueW03dUJCdTIgewogIGNvbG9yOiBncmV5Owp9Ci55bTd1QkJ1MyB7CiAgY29sb3I6IGRvZGdlcmJsdWU7Cn0=";
+import "data:text/css;base64,LnltN3VCQnUgewogIGNvbG9yOiBncmV5Owp9Ci55bTd1QkJ1MSB7CiAgY29sb3I6IGNyaW1zb247Cn0ueW03dUJCdTIgewogIGNvbG9yOiBncmV5Owp9Ci55bTd1QkJ1MyB7CiAgY29sb3I6IGRvZGdlcmJsdWU7Cn0ueW03dUJCdTQgewogIGNvbG9yOiBncmV5Owp9";
 // JSX attribute strings are decoded before they reach the condition:
 // entities like &amp; and literal backslashes must compare by value,
 // not by their JSX source spelling
@@ -20,7 +20,15 @@ const Shortcut = /*YAK Extracted CSS:
   color: dodgerblue;
 }
 */ /*#__PURE__*/ __yak.__yak_kbd("ym7uBBu2", ({ $keys })=>$keys === "a\\tb" && /*#__PURE__*/ css("ym7uBBu3"));
+// A static merge goes through expression position so a backslash escape in the
+// user className survives the JSX re-parse instead of doubling
+const Cross = /*YAK Extracted CSS:
+.ym7uBBu4 {
+  color: grey;
+}
+*/ /*#__PURE__*/ __yak.__yak_span("ym7uBBu4");
 export const Menu = ()=><>
     <li className={"ym7uBBu" + ("Food & Drink" === "Food & Drink" ? " ym7uBBu1" : "")}>Food &amp; Drink</li>
     <kbd className={"ym7uBBu2" + ("a\\tb" === "a\\tb" ? " ym7uBBu3" : "")}>a\tb</kbd>
+    <span className={"ym7uBBu4 before:content-['\\00d7'] icon & more"}>x</span>
   </>;

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.dev.tsx
@@ -105,10 +105,10 @@ const Cases = ()=><>
     </button>)(cn(x), f())}
 
     { /* static component: a string className merges at compile time */ }
-    <div className="input_Card_m7uBBu user">static merge</div>
+    <div className={"input_Card_m7uBBu user"}>static merge</div>
 
     { /* the chain collapses, so the usage folds to a plain div */ }
-    <div className="input_Card_m7uBBu input_Fancy_m7uBBu extra">wrapper fold</div>
+    <div className={"input_Card_m7uBBu input_Fancy_m7uBBu extra"}>wrapper fold</div>
 
     { /* bails: the spread renders the collapsed Fancy declaration at runtime */ }
     <Fancy {...props}>spread bail</Fancy>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.prod.tsx
@@ -91,10 +91,10 @@ const Cases = ()=><>
     </button>)(cn(x), f())}
 
     { /* static component: a string className merges at compile time */ }
-    <div className="ym7uBBu7 user">static merge</div>
+    <div className={"ym7uBBu7 user"}>static merge</div>
 
     { /* the chain collapses, so the usage folds to a plain div */ }
-    <div className="ym7uBBu7 ym7uBBu8 extra">wrapper fold</div>
+    <div className={"ym7uBBu7 ym7uBBu8 extra"}>wrapper fold</div>
 
     { /* bails: the spread renders the collapsed Fancy declaration at runtime */ }
     <Fancy {...props}>spread bail</Fancy>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.turbo.dev.tsx
@@ -105,10 +105,10 @@ const Cases = ()=><>
     </button>)(cn(x), f())}
 
     { /* static component: a string className merges at compile time */ }
-    <div className="input_Card_m7uBBu user">static merge</div>
+    <div className={"input_Card_m7uBBu user"}>static merge</div>
 
     { /* the chain collapses, so the usage folds to a plain div */ }
-    <div className="input_Card_m7uBBu input_Fancy_m7uBBu extra">wrapper fold</div>
+    <div className={"input_Card_m7uBBu input_Fancy_m7uBBu extra"}>wrapper fold</div>
 
     { /* bails: the spread renders the collapsed Fancy declaration at runtime */ }
     <Fancy {...props}>spread bail</Fancy>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.turbo.prod.tsx
@@ -91,10 +91,10 @@ const Cases = ()=><>
     </button>)(cn(x), f())}
 
     { /* static component: a string className merges at compile time */ }
-    <div className="ym7uBBu7 user">static merge</div>
+    <div className={"ym7uBBu7 user"}>static merge</div>
 
     { /* the chain collapses, so the usage folds to a plain div */ }
-    <div className="ym7uBBu7 ym7uBBu8 extra">wrapper fold</div>
+    <div className={"ym7uBBu7 ym7uBBu8 extra"}>wrapper fold</div>
 
     { /* bails: the spread renders the collapsed Fancy declaration at runtime */ }
     <Fancy {...props}>spread bail</Fancy>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.dev.tsx
@@ -217,7 +217,7 @@ const Optimizable = ({ active }: {
     }} onClick={()=>{}} ref={someRef} data-x="1" className="input_Card_m7uBBu">
       forwards attributes
     </div>
-    <div className="input_Card_m7uBBu user">static class name merge</div>
+    <div className={"input_Card_m7uBBu user"}>static class name merge</div>
     <div className={__yak_mergeClassNames("input_Card_m7uBBu", active && "active")}>runtime class name merge</div>
     <div $foo="forwarded" className="input_Card_m7uBBu">$props are not filtered</div>
     <div className={/*YAK Extracted CSS:
@@ -233,7 +233,7 @@ const Optimizable = ({ active }: {
     <h1 className="input_Title_m7uBBu">folds</h1>
     <div className="input_Cast_m7uBBu">folds through the type cast</div>
     <div className="input_Card_m7uBBu input_Extended_m7uBBu">collapses to a plain div</div>
-    <div className="input_Card_m7uBBu input_Extended_m7uBBu user">collapses and merges the className</div>
+    <div className={"input_Card_m7uBBu input_Extended_m7uBBu user"}>collapses and merges the className</div>
     <div className="input_Card_m7uBBu input_Extended_m7uBBu input_ExtendedTwice_m7uBBu">collapses the whole three-level chain</div>
     <h1 className="input_Title_m7uBBu input_FancyTitle_m7uBBu">collapses the exported chain</h1>
     <ToggleBase className="input_OfDynamic_m7uBBu">folds to the dynamic parent, chain not collapsed</ToggleBase>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.prod.tsx
@@ -169,7 +169,7 @@ const Optimizable = ({ active }: {
     }} onClick={()=>{}} ref={someRef} data-x="1" className="ym7uBBu1">
       forwards attributes
     </div>
-    <div className="ym7uBBu1 user">static class name merge</div>
+    <div className={"ym7uBBu1 user"}>static class name merge</div>
     <div className={__yak_mergeClassNames("ym7uBBu1", active && "active")}>runtime class name merge</div>
     <div $foo="forwarded" className="ym7uBBu1">$props are not filtered</div>
     <div className={/*YAK Extracted CSS:
@@ -185,7 +185,7 @@ const Optimizable = ({ active }: {
     <h1 className="ym7uBBu3">folds</h1>
     <div className="ym7uBBuP">folds through the type cast</div>
     <div className="ym7uBBu1 ym7uBBu7">collapses to a plain div</div>
-    <div className="ym7uBBu1 ym7uBBu7 user">collapses and merges the className</div>
+    <div className={"ym7uBBu1 ym7uBBu7 user"}>collapses and merges the className</div>
     <div className="ym7uBBu1 ym7uBBu7 ym7uBBu8">collapses the whole three-level chain</div>
     <h1 className="ym7uBBu3 ym7uBBu9">collapses the exported chain</h1>
     <ToggleBase className="ym7uBBuD">folds to the dynamic parent, chain not collapsed</ToggleBase>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.dev.tsx
@@ -217,7 +217,7 @@ const Optimizable = ({ active }: {
     }} onClick={()=>{}} ref={someRef} data-x="1" className="input_Card_m7uBBu">
       forwards attributes
     </div>
-    <div className="input_Card_m7uBBu user">static class name merge</div>
+    <div className={"input_Card_m7uBBu user"}>static class name merge</div>
     <div className={__yak_mergeClassNames("input_Card_m7uBBu", active && "active")}>runtime class name merge</div>
     <div $foo="forwarded" className="input_Card_m7uBBu">$props are not filtered</div>
     <div className={/*YAK Extracted CSS:
@@ -233,7 +233,7 @@ const Optimizable = ({ active }: {
     <h1 className="input_Title_m7uBBu">folds</h1>
     <div className="input_Cast_m7uBBu">folds through the type cast</div>
     <div className="input_Card_m7uBBu input_Extended_m7uBBu">collapses to a plain div</div>
-    <div className="input_Card_m7uBBu input_Extended_m7uBBu user">collapses and merges the className</div>
+    <div className={"input_Card_m7uBBu input_Extended_m7uBBu user"}>collapses and merges the className</div>
     <div className="input_Card_m7uBBu input_Extended_m7uBBu input_ExtendedTwice_m7uBBu">collapses the whole three-level chain</div>
     <h1 className="input_Title_m7uBBu input_FancyTitle_m7uBBu">collapses the exported chain</h1>
     <ToggleBase className="input_OfDynamic_m7uBBu">folds to the dynamic parent, chain not collapsed</ToggleBase>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.prod.tsx
@@ -169,7 +169,7 @@ const Optimizable = ({ active }: {
     }} onClick={()=>{}} ref={someRef} data-x="1" className="ym7uBBu1">
       forwards attributes
     </div>
-    <div className="ym7uBBu1 user">static class name merge</div>
+    <div className={"ym7uBBu1 user"}>static class name merge</div>
     <div className={__yak_mergeClassNames("ym7uBBu1", active && "active")}>runtime class name merge</div>
     <div $foo="forwarded" className="ym7uBBu1">$props are not filtered</div>
     <div className={/*YAK Extracted CSS:
@@ -185,7 +185,7 @@ const Optimizable = ({ active }: {
     <h1 className="ym7uBBu3">folds</h1>
     <div className="ym7uBBuP">folds through the type cast</div>
     <div className="ym7uBBu1 ym7uBBu7">collapses to a plain div</div>
-    <div className="ym7uBBu1 ym7uBBu7 user">collapses and merges the className</div>
+    <div className={"ym7uBBu1 ym7uBBu7 user"}>collapses and merges the className</div>
     <div className="ym7uBBu1 ym7uBBu7 ym7uBBu8">collapses the whole three-level chain</div>
     <h1 className="ym7uBBu3 ym7uBBu9">collapses the exported chain</h1>
     <ToggleBase className="ym7uBBuD">folds to the dynamic parent, chain not collapsed</ToggleBase>


### PR DESCRIPTION
The fold merged a user `className` string into a JSX attribute string. swc prints attribute strings with JS escaping, but the JSX-preserve pipelines (Vite, Turbopack, rsbuild) re-parse the printed output — and JSX attribute strings take backslashes literally. A backslash class doubled and silently lost its style:

```tsx
const Card = styled.div`color: red;`;
<Card className="before:content-['\00d7']" />
// before: <div className="yX before:content-['\\00d7']" />  (re-parsed class has two backslashes)
// after:  <div className={"yX before:content-['\\00d7']"} /> (JS re-parse yields one backslash)
```

The merged value now goes through expression position, so print and re-parse share one escaping regime — the same direction the #605 fix established for attribute strings moved into expressions. The remaining attribute-string emission (generated class names only) is guarded by a `debug_assert` that the name carries no backslash or quote.

🤖 Co-authored-by **Claude Code**