### PR TITLE
Collapse fully static styled() chains at the declaration

### DIFF
--- a/.changeset/cssprop-style-reference-error.md
+++ b/.changeset/cssprop-style-reference-error.md
@@ -2,4 +2,4 @@
 "yak-swc": minor
 ---
 
-The css prop now rejects references to styles declared elsewhere (`css={mixin}`, `css={on && mixin}`, `css={on ? mixin : css`…`}`) with a compile error instead of silently dropping the referenced styles — a mixin only compiles its declarations into template consumers, so these usages rendered unstyled without any signal. Wrap the reference in a css template instead: `css={css`${mixin}`}`. Inline templates in ternary and logical arms are unaffected.
+The css prop now rejects a reference to styles declared elsewhere (`css={mixin}`) with a compile error. Wrap the reference in a css template instead: `css={css`${mixin}`}`. Such a reference compiles to nothing at the usage, so it silently rendered unstyled.

--- a/.changeset/styled-jsx-folding.md
+++ b/.changeset/styled-jsx-folding.md
@@ -3,7 +3,7 @@
 "next-yak": minor
 ---
 
-Add JSX folding: usages of styled components declared in the same file are inlined into plain elements at build time, skipping the runtime wrapper component:
+Add JSX folding: a usage of a styled component declared in the same file compiles to a plain element, skipping the runtime wrapper. Rendering gets considerably faster, and nothing needs configuring.
 
 ```tsx
 const Icon = styled.span<{ $active?: boolean }>`
@@ -20,13 +20,14 @@ const App = () => <Icon $active={on} />;
 const App = () => <span className={"yak-icon" + (on ? " yak-icon--active" : "")} />;
 ```
 
-- Fully static components fold to the plain DOM element, `styled(Component)` wrappers fold to the wrapped component (which may be imported).
-- A `styled(Parent)` chain whose parent is a same-file static component collapses to the plain element at any depth, class names merged parent-first. Its declaration flattens too (`const Fancy = __yak.__yak_div("card fancy")`), so an exported chain ships one wrapper and unused base components drop out. A dynamic, `.attrs()`, imported, or `let`-bound parent keeps the runtime chain.
-- Class-toggling expressions (`({ $active }) => $active && css`…`` or `(p) => p.$active && css`…``) are inlined by substituting the props with the attribute values; the `$` attributes are dropped like the runtime drops them.
-- An existing `className` is merged at compile time, or through the new `__yak_mergeClassNames` helper for runtime values.
-- Usages with spread props, `theme`, dynamic css values (css variables) or `.attrs()` keep the runtime path, as do components not declared as top-level `const`.
-- The new `foldStatic: false` option turns this off. It also gates the `css` prop fold, so both folds route through the runtime path when disabled.
+What folds:
 
-Behavioral notes: JSX folding speeds up rendering considerably, but a folded usage is no longer a component. It does not show up in React DevTools or in component stacks, in development too, and `child.type === Icon` checks no longer match it. Foreign `$props` on fully static folded usages are forwarded instead of stripped. The FAQ explains when a usage folds and what that changes.
+- A fully static component folds to its plain element.
+- `styled(Component)` folds to the wrapped component, which may be imported.
+- A fully static `styled(Parent)` chain collapses to the base element, at any depth, with the class names merged parent-first. The declaration flattens too, so an exported chain ships one wrapper and its unused base components drop out.
 
-A folded usage evaluates every prop expression the same number of times, and in the same order, as the unfolded JSX did: a value the fold cannot inline for free is bound once at the usage site and the conditions read the binding. Two exceptions are worth knowing, and both only show up in code React's own purity rule already forbids: a `$prop` no style condition reads is dropped without being evaluated, and a getter on a member read (`$a={obj.x}`) can still fire once per condition.
+What keeps the runtime path: spread props, a `theme` prop, dynamic css values, `.attrs()`, and components not declared as a top-level `const`. A chain also stays a chain when its parent is dynamic, imported, or bound with `let`.
+
+Set `foldStatic: false` to turn folding off; it also gates the css prop fold.
+
+Caveats: a folded usage is no longer a component, so it does not appear in React DevTools or component stacks, and `child.type === Icon` no longer matches it. Foreign `$props` on a folded usage are forwarded to the element, not stripped. Prop expressions still run the same number of times, in the same order, as the original JSX — except in code React's purity rule already forbids: an unread `$prop` is dropped without running, and a getter behind a member read (`$a={obj.x}`) can fire once per condition. The FAQ has the full rules.

--- a/.changeset/styled-jsx-folding.md
+++ b/.changeset/styled-jsx-folding.md
@@ -21,6 +21,7 @@ const App = () => <span className={"yak-icon" + (on ? " yak-icon--active" : "")}
 ```
 
 - Fully static components fold to the plain DOM element, `styled(Component)` wrappers fold to the wrapped component (which may be imported).
+- A `styled(Parent)` chain whose parent is a same-file static component collapses to the plain element at any depth, class names merged parent-first. Its declaration flattens too (`const Fancy = __yak.__yak_div("card fancy")`), so an exported chain ships one wrapper and unused base components drop out. A dynamic, `.attrs()`, imported, or `let`-bound parent keeps the runtime chain.
 - Class-toggling expressions (`({ $active }) => $active && css`…`` or `(p) => p.$active && css`…``) are inlined by substituting the props with the attribute values; the `$` attributes are dropped like the runtime drops them.
 - An existing `className` is merged at compile time, or through the new `__yak_mergeClassNames` helper for runtime values.
 - Usages with spread props, `theme`, dynamic css values (css variables) or `.attrs()` keep the runtime path, as do components not declared as top-level `const`.

--- a/docs/content/docs/how-does-it-work.mdx
+++ b/docs/content/docs/how-does-it-work.mdx
@@ -375,6 +375,35 @@ const Nav = ({ active }) => (
 </div>
 </SideBySide>
 
+When the wrapped component is itself a same-file static styled component, the whole chain collapses to the plain element, at any depth. The class names merge parent-first, and the declaration flattens with them, so an exported chain ships a single wrapper and its base components drop out once nothing else uses them:
+
+<SideBySide>
+<div>
+
+```tsx title="input"
+const Card = styled.div`
+  color: green;
+`;
+
+export const Fancy = styled(Card)`
+  padding: 4px;
+`;
+```
+
+</div>
+<div>
+
+```tsx title="output"
+export const Fancy = /*#__PURE__*/ __yak.__yak_div(
+  "input_Card_m7uBBu input_Fancy_m7uBBu",
+);
+```
+
+</div>
+</SideBySide>
+
+The chain does not collapse when the parent is dynamic, uses `.attrs()`, or comes from another file - the usage still folds into the wrapped component instead of the plain element. A `let`-bound parent can be reassigned, so its usages keep the runtime path entirely.
+
 Folding only happens when the plugin can prove that the folded element behaves exactly like the styled component. It bails for example on spread attributes (`<Card {...props} />`), a `theme` prop, `.attrs()` chains, HOC wrappers like `memo(...)` and style expressions that read the theme or set css variables. Bailing is never a problem, the usage simply renders through the styled component at runtime, exactly as if folding did not exist.
 
 <Callout type="warn">

--- a/docs/content/docs/how-does-it-work.mdx
+++ b/docs/content/docs/how-does-it-work.mdx
@@ -394,9 +394,7 @@ export const Fancy = styled(Card)`
 <div>
 
 ```tsx title="output"
-export const Fancy = /*#__PURE__*/ __yak.__yak_div(
-  "input_Card_m7uBBu input_Fancy_m7uBBu",
-);
+export const Fancy = /*#__PURE__*/ __yak.__yak_div("input_Card_m7uBBu input_Fancy_m7uBBu");
 ```
 
 </div>

--- a/e2e/cases/foldables/index.test.ts
+++ b/e2e/cases/foldables/index.test.ts
@@ -14,6 +14,12 @@ test(
     await expect(extended).toHaveCSS("color", "rgb(0, 128, 0)");
     await expect(extended).toHaveCSS("background-color", "rgb(255, 255, 0)");
 
+    // a three-level chain keeps every level's style
+    const chain = page.getByTestId("chain");
+    await expect(chain).toHaveCSS("color", "rgb(0, 0, 139)");
+    await expect(chain).toHaveCSS("background-color", "rgb(173, 216, 230)");
+    await expect(chain).toHaveCSS("border-color", "rgb(255, 20, 147)");
+
     // inlined class-toggling conditions
     await expect(page.getByTestId("toggle-on")).toHaveCSS("color", "rgb(255, 0, 0)");
     await expect(page.getByTestId("toggle-off")).toHaveCSS("color", "rgb(0, 0, 255)");

--- a/e2e/cases/foldables/index.tsx
+++ b/e2e/cases/foldables/index.tsx
@@ -12,6 +12,17 @@ const Extended = styled(Card)`
   background-color: rgb(255, 255, 0);
 `;
 
+// three-level chain - every level's style applies with foldStatic on and off
+const Button = styled.button`
+  color: rgb(0, 0, 139);
+`;
+const PrimaryButton = styled(Button)`
+  background-color: rgb(173, 216, 230);
+`;
+const FullWidthButton = styled(PrimaryButton)`
+  border-color: rgb(255, 20, 147);
+`;
+
 // class-toggling $prop - foldable usages inline the condition
 const Toggle = styled.span<{ $active?: boolean }>`
   color: rgb(0, 0, 255);
@@ -72,6 +83,7 @@ export default function App() {
     <>
       <Card data-testid="static">static fold</Card>
       <Extended data-testid="extended">static styled(Component) fold</Extended>
+      <FullWidthButton data-testid="chain">three-level chain</FullWidthButton>
       <Toggle data-testid="toggle-on" $active>
         on
       </Toggle>

--- a/packages/next-yak/runtime/__tests__/foldedJsxParity.test.tsx
+++ b/packages/next-yak/runtime/__tests__/foldedJsxParity.test.tsx
@@ -22,6 +22,9 @@ const Toggle = styledFn("span")("toggleBase", ({ $active }) => $active && cssFn(
 const Base = (props) => <p {...props} />;
 const Extended = styledFn(Base)("extendedClass");
 const ExtendedCard = styledFn(Card)("extendedCardClass");
+// A styled(Card) chain of same-file static components collapses to a plain
+// element carrying every class, parent-first
+const ExtendedCardTwice = styledFn(ExtendedCard)("extendedTwiceClass");
 
 const renderedHtml = (element) => render(element).container.innerHTML;
 // sorted because the runtime puts the incoming className first while the
@@ -68,6 +71,24 @@ it("renders the same DOM as the wrapped component with the static class", () => 
 it("renders the same class names as a wrapped yak component", () => {
   expect(renderedClassNames(<Card className="extendedCardClass">hi</Card>)).toEqual(
     renderedClassNames(<ExtendedCard>hi</ExtendedCard>),
+  );
+});
+
+it("renders the same class names as a collapsed chain", () => {
+  expect(renderedClassNames(<div className="yakClass extendedCardClass">hi</div>)).toEqual(
+    renderedClassNames(<ExtendedCard>hi</ExtendedCard>),
+  );
+});
+
+it("renders the same class names as a collapsed three-level chain", () => {
+  expect(
+    renderedClassNames(<div className="yakClass extendedCardClass extendedTwiceClass">hi</div>),
+  ).toEqual(renderedClassNames(<ExtendedCardTwice>hi</ExtendedCardTwice>));
+});
+
+it("merges a className into a collapsed chain", () => {
+  expect(renderedClassNames(<div className="yakClass extendedCardClass user" />)).toEqual(
+    renderedClassNames(<ExtendedCard className="user" />),
   );
 });
 

--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -19,8 +19,8 @@ use utils::ast_helper::{
   extract_ident_and_parts, is_valid_tagged_tpl, unwrap_type_casts, TemplateIterator,
 };
 use utils::cross_file_selectors::ImportType;
-use utils::css_prop::HasCSSProp;
-use utils::styled_jsx_fold::StyledJsxFold;
+use utils::fold::css_prop::HasCSSProp;
+use utils::fold::StyledFold;
 
 mod variable_visitor;
 use variable_visitor::{ScopedVariableReference, VariableVisitor};
@@ -36,13 +36,10 @@ use math_evaluate::try_evaluate;
 mod utils {
   pub(crate) mod add_suffix_to_expr;
   pub(crate) mod ast_helper;
-  pub(crate) mod class_name_fold;
   pub(crate) mod cross_file_selectors;
   pub(crate) mod css_hash;
-  pub(crate) mod css_prop;
+  pub(crate) mod fold;
   pub(crate) mod native_elements;
-  pub(crate) mod purity;
-  pub(crate) mod styled_jsx_fold;
 }
 pub mod naming_convention;
 use naming_convention::{CssImportConfig, ImportModeEncoding, NamingConvention, TranspilationMode};
@@ -217,7 +214,7 @@ where
   exported_styled_names: Vec<String>,
   /// Registry of fully static styled components whose JSX usages
   /// are folded into plain DOM elements in a deferred pass
-  styled_jsx_fold: StyledJsxFold,
+  styled_fold: StyledFold,
   /// Fold statically known styles into plain elements: static styled component
   /// JSX usages and static `css` props skip their runtime wrapper and merge calls
   fold_static: bool,
@@ -276,7 +273,7 @@ where
       inside_runtime_expression: false,
       react_refresh_reg,
       exported_styled_names: Vec::new(),
-      styled_jsx_fold: StyledJsxFold::default(),
+      styled_fold: StyledFold::default(),
       fold_static,
       inside_global_style: false,
       has_global_style: false,
@@ -760,8 +757,8 @@ where
 
     // Must run before the utility imports below are collected
     self
-      .styled_jsx_fold
-      .fold_jsx_usages(module, self.yak_library_imports.as_mut().unwrap());
+      .styled_fold
+      .fold_module(module, self.yak_library_imports.as_mut().unwrap());
 
     // Add the css module import to the top of the file
     // if any yak imports are used
@@ -1297,7 +1294,7 @@ where
       && self.current_declarator_init_span == Some(n.span)
     {
       if let Some(class_name) = transform.get_component_class_name() {
-        self.styled_jsx_fold.try_register(
+        self.styled_fold.try_register(
           self.current_variable_name.as_ref(),
           &n.tag,
           class_name,

--- a/packages/yak-swc/yak_swc/src/utils/fold/css_expr.rs
+++ b/packages/yak-swc/yak_swc/src/utils/fold/css_expr.rs
@@ -1,8 +1,10 @@
-//! Folds compiled `css(...)` expressions into static `className` string
-//! concatenations, e.g. `css(() => on && css("b"), "a")` into
-//! `"a" + (on ? " b" : "")`
+//! The shared primitive of the fold: turns a compiled `css(...)` expression
+//! into the static `className` value it stands for, e.g.
+//! `css(() => on && css("b"), "a")` into `"a" + (on ? " b" : "")`
 //!
-//! Shared by the css prop fold and the styled component JSX fold
+//! Both fold paths - the [`css` prop](super::css_prop) and the
+//! [styled component usage](super::usage) - build on it, together with the
+//! small string and JSX attribute builders at the bottom of the module
 
 use crate::utils::ast_helper::unwrap_type_casts;
 use crate::yak_imports::YakImports;
@@ -17,11 +19,11 @@ use swc_core::{
 
 /// A conditional class name segment: the condition expression, the class name
 /// for the truthy branch and an optional class name for the falsy branch
-pub(crate) type ConditionSegment = (Box<Expr>, Wtf8Atom, Option<Wtf8Atom>);
+pub(super) type ConditionSegment = (Box<Expr>, Wtf8Atom, Option<Wtf8Atom>);
 
 /// Folds a compiled css expression into a className expression
 /// Returns `None` if the expression is not statically foldable
-pub(crate) fn fold_css_expr(expr: &Expr, yak_imports: &YakImports) -> Option<Box<Expr>> {
+pub(super) fn fold_css_expr(expr: &Expr, yak_imports: &YakImports) -> Option<Box<Expr>> {
   match unwrap_type_casts(expr) {
     Expr::Call(call) => fold_css_call(call, yak_imports),
     Expr::Cond(cond) => {
@@ -119,7 +121,7 @@ fn fold_css_call(call: &CallExpr, yak_imports: &YakImports) -> Option<Box<Expr>>
 
 /// Appends one conditional class name segment to a className expression:
 /// `<expr> + (cond ? " a" : "")` or `<expr> + (cond ? " b" : " c")`
-pub(crate) fn append_condition_segment(
+pub(super) fn append_condition_segment(
   class_name_expr: Box<Expr>,
   (condition, cons_class, alt_class): ConditionSegment,
 ) -> Box<Expr> {
@@ -156,7 +158,7 @@ fn fold_condition_arrow(arrow: &ArrowExpr, yak_imports: &YakImports) -> Option<C
 /// Matches the condition shapes `cond && css("x")` and
 /// `cond ? css("x") : css("y")` and returns the condition expression
 /// plus the static class name(s)
-pub(crate) fn fold_condition_body(
+pub(super) fn fold_condition_body(
   body: &Expr,
   yak_imports: &YakImports,
 ) -> Option<ConditionSegment> {
@@ -175,7 +177,7 @@ pub(crate) fn fold_condition_body(
 }
 
 /// Matches a `css("x")` call carrying exactly one static class string
-pub(crate) fn pure_static_css_class(expr: &Expr, yak_imports: &YakImports) -> Option<Wtf8Atom> {
+pub(super) fn pure_static_css_class(expr: &Expr, yak_imports: &YakImports) -> Option<Wtf8Atom> {
   let Expr::Call(call) = unwrap_type_casts(expr) else {
     return None;
   };
@@ -201,7 +203,7 @@ pub(crate) fn pure_static_css_class(expr: &Expr, yak_imports: &YakImports) -> Op
 }
 
 /// Matches a callee that resolves to a yak `css` import
-pub(crate) fn is_yak_css_callee(callee: &Callee, yak_imports: &YakImports) -> bool {
+pub(super) fn is_yak_css_callee(callee: &Callee, yak_imports: &YakImports) -> bool {
   match callee {
     Callee::Expr(expr) => match unwrap_type_casts(expr) {
       Expr::Ident(ident) => yak_imports.yak_css_idents().contains(&ident.to_id()),
@@ -211,9 +213,14 @@ pub(crate) fn is_yak_css_callee(callee: &Callee, yak_imports: &YakImports) -> bo
   }
 }
 
+/// Joins two class names with a single space, e.g. `"a"` and `"b"` -> `"a b"`
+pub(super) fn merge_class_names(first: &Wtf8Atom, second: &Wtf8Atom) -> Wtf8Atom {
+  format!("{} {}", first.to_string_lossy(), second.to_string_lossy()).into()
+}
+
 /// Prefixes a class name with a space so it can be concatenated onto a base
 /// class, e.g. `"a"` -> `" a"`
-pub(crate) fn with_leading_space(class_name: &Wtf8Atom) -> Wtf8Atom {
+pub(super) fn with_leading_space(class_name: &Wtf8Atom) -> Wtf8Atom {
   // an empty class name (from an empty `css``) contributes nothing
   if class_name.is_empty() {
     return "".into();
@@ -222,7 +229,7 @@ pub(crate) fn with_leading_space(class_name: &Wtf8Atom) -> Wtf8Atom {
 }
 
 /// Builds a string literal
-pub(crate) fn str_lit(value: Wtf8Atom, span: Span) -> Str {
+pub(super) fn str_lit(value: Wtf8Atom, span: Span) -> Str {
   Str {
     span,
     value,
@@ -231,12 +238,12 @@ pub(crate) fn str_lit(value: Wtf8Atom, span: Span) -> Str {
 }
 
 /// Builds a string literal expression with a dummy span
-pub(crate) fn str_expr(value: Wtf8Atom) -> Box<Expr> {
+pub(super) fn str_expr(value: Wtf8Atom) -> Box<Expr> {
   Box::new(Expr::Lit(Lit::Str(str_lit(value, DUMMY_SP))))
 }
 
 /// Wraps an expression into a `{...}` JSX attribute value
-pub(crate) fn expr_attr_value(expr: Box<Expr>) -> JSXAttrValue {
+pub(super) fn expr_attr_value(expr: Box<Expr>) -> JSXAttrValue {
   JSXAttrValue::JSXExprContainer(JSXExprContainer {
     span: DUMMY_SP,
     expr: JSXExpr::Expr(expr),
@@ -244,7 +251,7 @@ pub(crate) fn expr_attr_value(expr: Box<Expr>) -> JSXAttrValue {
 }
 
 /// Builds a `className` JSX attribute
-pub(crate) fn class_name_attr(value: JSXAttrValue) -> JSXAttrOrSpread {
+pub(super) fn class_name_attr(value: JSXAttrValue) -> JSXAttrOrSpread {
   JSXAttrOrSpread::JSXAttr(JSXAttr {
     span: DUMMY_SP,
     name: JSXAttrName::Ident(IdentName::new("className".into(), DUMMY_SP)),

--- a/packages/yak-swc/yak_swc/src/utils/fold/css_prop.rs
+++ b/packages/yak-swc/yak_swc/src/utils/fold/css_prop.rs
@@ -1,5 +1,8 @@
+//! Folds a static `css` prop into a plain `className`, skipping the runtime
+//! `mergeCssProp` spread
+
 use crate::utils::ast_helper::unwrap_type_casts;
-use crate::utils::class_name_fold::{
+use crate::utils::fold::css_expr::{
   class_name_attr, expr_attr_value, fold_css_expr, is_yak_css_callee,
 };
 use crate::yak_imports::YakImports;

--- a/packages/yak-swc/yak_swc/src/utils/fold/mod.rs
+++ b/packages/yak-swc/yak_swc/src/utils/fold/mod.rs
@@ -1,0 +1,539 @@
+//! Compile-time folding of next-yak's runtime wrappers into plain markup
+//!
+//! next-yak normally emits a runtime component for every styled component and a
+//! runtime merge call for every `css` prop. When the styles are fully known at
+//! build time both can be skipped, and the element keeps only the class names it
+//! would have received at runtime. Folding is opt-in through `foldStatic`.
+//!
+//! The feature is built from four parts:
+//!
+//! - [`css_expr`] turns a compiled `css(...)` expression into the `className`
+//!   value it stands for. Both fold paths build on it.
+//! - [`purity`] grades how freely a prop value may be moved, which the usage
+//!   rewrite needs to keep inlining unobservable.
+//! - [`css_prop`] folds a static `css` prop into a plain `className`.
+//! - This module folds styled components: a JSX usage of a same-file static
+//!   component becomes the plain element it wraps, and a `styled(Parent)` chain
+//!   of same-file static components collapses to that element.
+//!
+//! ## The styled component fold in three phases
+//!
+//! 1. **Register.** [`StyledFold::try_register`] runs during the main transform
+//!    pass and records every declaration whose usages could be folded. A usage
+//!    may appear before its declaration (inside a hoisted function), so the
+//!    rewrite is deferred until the whole module has been seen.
+//! 2. **Resolve.** [`StyledFold::resolve`] collapses the `styled(Parent)` chains
+//!    and drops the components that turned out not to be foldable.
+//! 3. **Rewrite.** [`StyledFold::fold_module`] rewrites every foldable JSX usage
+//!    into its plain element (see [`usage`]) and each collapsed chain's
+//!    declaration into the same element (see [`collapse_declarations`]).
+//!
+//! A component that only folds at its usages keeps its declaration - it is
+//! `/*#__PURE__*/` annotated so the minifier removes it once every usage folded
+//! and it is not exported. A collapsed chain's declaration is rewritten in place,
+//! so an exported chain ships one flat wrapper and its base components stay
+//! minifier-removable.
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use swc_core::{
+  atoms::{Atom, Wtf8Atom},
+  common::SyntaxContext,
+  ecma::ast::{
+    CallExpr, Callee, Decl, Expr, ExprOrSpread, Id, Ident, ImportSpecifier, Lit, MemberProp,
+    Module, ModuleDecl, ModuleItem, Pat, Stmt, VarDecl, VarDeclKind,
+  },
+  ecma::visit::{VisitMut, VisitMutWith},
+};
+
+use crate::utils::fold::css_expr::{merge_class_names, str_expr};
+use crate::utils::native_elements::VALID_ELEMENTS;
+use crate::variable_visitor::ScopedVariableReference;
+use crate::yak_imports::YakImports;
+
+mod css_expr;
+pub(crate) mod css_prop;
+mod purity;
+mod usage;
+
+/// What a foldable JSX usage is rewritten to
+#[derive(Debug, PartialEq)]
+enum FoldTarget {
+  /// A native DOM element, e.g. `div` for `styled.div`
+  Native(Atom),
+  /// The wrapped component, e.g. `Card` for `styled(Card)`
+  Component(Ident),
+}
+
+/// A styled component whose JSX usages can be folded into their [`FoldTarget`]
+#[derive(Debug)]
+struct FoldableComponent {
+  target: FoldTarget,
+  /// The generated static class name, e.g. `"ym7uBBu"`
+  class_name: Wtf8Atom,
+  /// The compiled class-toggling expressions over props,
+  /// e.g. `({ $active }) => $active && css("ym7uBBu1")`.
+  /// Empty for fully static components; usages of dynamic components only fold
+  /// if these can be inlined by substituting the props with the JSX attribute
+  /// values
+  runtime_expressions: Vec<Expr>,
+}
+
+/// The registry of foldable styled components and the driver of their fold
+///
+/// See the module documentation for the register -> resolve -> rewrite phases.
+#[derive(Debug, Default)]
+pub struct StyledFold {
+  components: FxHashMap<Id, FoldableComponent>,
+}
+
+impl StyledFold {
+  /// Registers a styled component if its JSX usages are foldable:
+  /// - `declaration` is a plain variable, e.g. `Card` in
+  ///   `const Card = styled.div`...``
+  /// - `tag` (the original tagged template tag) is `styled.element`,
+  ///   `styled("element")` with a native DOM element or `styled(Component)` -
+  ///   these shapes exclude `.attrs(...)` chains
+  /// - `class_name` is the static class name the compiled call carries as its
+  ///   first argument
+  /// - `runtime_expressions` must all be class-toggling arrows over props -
+  ///   anything else keeps the runtime path. Function expressions bail too:
+  ///   they bind `this`/`arguments`, which inlining would silently rebind to
+  ///   the enclosing component
+  pub fn try_register(
+    &mut self,
+    declaration: Option<&ScopedVariableReference>,
+    tag: &Expr,
+    class_name: &str,
+    runtime_expressions: &[Expr],
+  ) {
+    let Some(declaration) = declaration else {
+      return;
+    };
+    if declaration.parts.len() != 1 {
+      return;
+    }
+    let Some(target) = Self::fold_target(tag) else {
+      return;
+    };
+    if !runtime_expressions
+      .iter()
+      .all(|expr| matches!(expr, Expr::Arrow(_)))
+    {
+      return;
+    }
+    // dynamic styled(Component) wrappers keep the runtime path - the $prop
+    // forwarding semantics depend on the wrapped component
+    if !runtime_expressions.is_empty() && matches!(target, FoldTarget::Component(_)) {
+      return;
+    }
+    let previous = self.components.insert(
+      declaration.id.clone(),
+      FoldableComponent {
+        target,
+        class_name: class_name.into(),
+        runtime_expressions: runtime_expressions.to_vec(),
+      },
+    );
+    // a binding can only hold one styled component - a second registration
+    // would mean the whole-initializer check in the visitor broke
+    debug_assert!(previous.is_none());
+  }
+
+  /// Resolves the registry, then applies it to the module
+  ///
+  /// Must run before the utility import specifiers are collected as it may
+  /// request the `mergeClassNames` utility or a native element import
+  pub fn fold_module(&mut self, module: &mut Module, yak_imports: &mut YakImports) {
+    if self.components.is_empty() {
+      return;
+    }
+    let collapses = self.resolve(module);
+    if self.components.is_empty() {
+      return;
+    }
+    if !collapses.is_empty() {
+      collapse_declarations(module, &collapses, yak_imports);
+    }
+    usage::fold(module, &self.components, yak_imports);
+  }
+
+  /// Drops the components that can not be folded and collapses the
+  /// `styled(Parent)` chains
+  ///
+  /// Only components declared as a top level `const` are safe to fold (`const`
+  /// rules out reassignment). A component fold target must be an immutable
+  /// binding as well so it still references the styled component's wrapped value
+  /// at every usage
+  fn resolve(&mut self, module: &Module) -> Vec<Collapse> {
+    let immutable = Self::immutable_bindings(module);
+    let collapses = self.collapse_chains(&immutable);
+    self.components.retain(|id, component| {
+      immutable.contains_key(id)
+        && match &component.target {
+          FoldTarget::Native(_) => true,
+          FoldTarget::Component(target) => immutable.contains_key(&target.to_id()),
+        }
+    });
+    collapses
+  }
+
+  /// Collapses every `styled(Parent)` chain whose parent is a same-file, fully
+  /// static component into the native element it resolves to
+  ///
+  /// The collapsed component's registry entry becomes a native target carrying
+  /// the whole chain's class names, so its usages fold to that element like any
+  /// other static component. The returned list drives the matching declaration
+  /// rewrite
+  fn collapse_chains(&mut self, immutable: &FxHashMap<Id, u32>) -> Vec<Collapse> {
+    let mut collapses = Vec::new();
+    for (id, component) in &self.components {
+      let FoldTarget::Component(parent) = &component.target else {
+        continue;
+      };
+      let mut seen = FxHashSet::default();
+      if let Some((element, class_name)) = resolve_chain(&self.components, immutable, id, &mut seen)
+      {
+        collapses.push(Collapse {
+          id: id.clone(),
+          parent: parent.to_id(),
+          element,
+          class_name,
+        });
+      }
+    }
+    for collapse in &collapses {
+      if let Some(component) = self.components.get_mut(&collapse.id) {
+        component.target = FoldTarget::Native(collapse.element.clone());
+        component.class_name = collapse.class_name.clone();
+      }
+    }
+    collapses
+  }
+
+  /// Matches the tag shapes a JSX usage can be folded for:
+  /// - `styled.element` and `styled("element")` with a native DOM element
+  /// - `styled(Component)` with an uppercase component reference - a
+  ///   lowercase name would be parsed as an intrinsic element in JSX
+  ///
+  /// `.attrs(...)` chains don't have any of these shapes
+  fn fold_target(tag: &Expr) -> Option<FoldTarget> {
+    match tag {
+      Expr::Member(member) => {
+        if !member.obj.is_ident() {
+          return None;
+        }
+        let MemberProp::Ident(element) = &member.prop else {
+          return None;
+        };
+        VALID_ELEMENTS
+          .contains(element.sym.as_ref())
+          .then(|| FoldTarget::Native(element.sym.clone()))
+      }
+      Expr::Call(call) => {
+        if !matches!(&call.callee, Callee::Expr(callee) if callee.is_ident()) {
+          return None;
+        }
+        let [arg] = call.args.as_slice() else {
+          return None;
+        };
+        if arg.spread.is_some() {
+          return None;
+        }
+        match &*arg.expr {
+          Expr::Lit(Lit::Str(element)) => {
+            let element = element.value.as_str()?;
+            VALID_ELEMENTS
+              .contains(element)
+              .then(|| FoldTarget::Native(Atom::from(element)))
+          }
+          Expr::Ident(component) => component
+            .sym
+            .starts_with(|c: char| c.is_ascii_uppercase())
+            .then(|| FoldTarget::Component(component.clone())),
+          _ => None,
+        }
+      }
+      _ => None,
+    }
+  }
+
+  /// Maps every module scope binding which can not be reassigned to its source
+  /// declaration order: top level `const X = ...` (including `export const`) and
+  /// import bindings
+  ///
+  /// The order lets a chain require its parent to be declared first, so an
+  /// out-of-order `styled(Parent)` - a const temporal dead zone error at module
+  /// eval - is never collapsed into silently working output
+  fn immutable_bindings(module: &Module) -> FxHashMap<Id, u32> {
+    let mut bindings = FxHashMap::default();
+    let mut order: u32 = 0;
+    for item in &module.body {
+      let var: &VarDecl = match item {
+        ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,
+        ModuleItem::ModuleDecl(ModuleDecl::Import(import)) => {
+          for specifier in &import.specifiers {
+            let local = match specifier {
+              ImportSpecifier::Named(named) => &named.local,
+              ImportSpecifier::Default(default) => &default.local,
+              ImportSpecifier::Namespace(namespace) => &namespace.local,
+              #[cfg(swc_ast_unknown)]
+              _ => continue,
+            };
+            bindings.insert(local.to_id(), order);
+            order += 1;
+          }
+          continue;
+        }
+        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export)) => {
+          let Decl::Var(var) = &export.decl else {
+            continue;
+          };
+          var
+        }
+        _ => continue,
+      };
+      if var.kind != VarDeclKind::Const {
+        continue;
+      }
+      for declarator in &var.decls {
+        if let Pat::Ident(name) = &declarator.name {
+          bindings.insert(name.to_id(), order);
+          order += 1;
+        }
+      }
+    }
+    bindings
+  }
+}
+
+/// A `styled(Parent)` chain that collapses to a plain element: its declaration
+/// and every usage carry the whole chain's class names directly
+struct Collapse {
+  /// the collapsing component's binding
+  id: Id,
+  /// the direct parent the declaration wraps, e.g. `Card` in `styled(Card)` -
+  /// locates the `styled(Card)(...)` call in the compiled declaration
+  parent: Id,
+  /// the native element the whole chain resolves to
+  element: Atom,
+  /// the whole chain's class names
+  class_name: Wtf8Atom,
+}
+
+/// Resolves a chain of `styled(Parent)` components to the native element and
+/// merged class names it collapses into, parent-first
+///
+/// Returns `None` unless every link is a same-file, immutable, fully static
+/// foldable component ending in a native element - a dynamic link keeps the
+/// runtime chain, whose class-toggling conditions are not merged in
+fn resolve_chain(
+  components: &FxHashMap<Id, FoldableComponent>,
+  immutable: &FxHashMap<Id, u32>,
+  id: &Id,
+  seen: &mut FxHashSet<Id>,
+) -> Option<(Atom, Wtf8Atom)> {
+  // a binding reachable twice would be a cycle - the const temporal dead zone
+  // rules it out, but the guard keeps the recursion total
+  if !immutable.contains_key(id) || !seen.insert(id.clone()) {
+    return None;
+  }
+  let component = components.get(id)?;
+  if !component.runtime_expressions.is_empty() {
+    return None;
+  }
+  match &component.target {
+    FoldTarget::Native(element) => Some((element.clone(), component.class_name.clone())),
+    FoldTarget::Component(parent) => {
+      let parent_id = parent.to_id();
+      // a parent declared after the child hits the const temporal dead zone at
+      // module eval - collapsing it would mask that `ReferenceError`
+      if let (Some(child_order), Some(parent_order)) =
+        (immutable.get(id), immutable.get(&parent_id))
+      {
+        if parent_order >= child_order {
+          return None;
+        }
+      }
+      let (element, parent_class) = resolve_chain(components, immutable, &parent_id, seen)?;
+      Some((
+        element,
+        merge_class_names(&parent_class, &component.class_name),
+      ))
+    }
+  }
+}
+
+/// Rewrites each collapsed component's compiled declaration from its
+/// `styled(Parent)(...)` chain call into the plain `__yak.__yak_<element>(...)`
+/// call carrying the whole chain's class names, matching a native styled
+/// component
+fn collapse_declarations(
+  module: &mut Module,
+  collapses: &[Collapse],
+  yak_imports: &mut YakImports,
+) {
+  let by_id: FxHashMap<Id, &Collapse> = collapses
+    .iter()
+    .map(|collapse| (collapse.id.clone(), collapse))
+    .collect();
+  for item in &mut module.body {
+    let var = match item {
+      ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,
+      ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export)) => {
+        let Decl::Var(var) = &mut export.decl else {
+          continue;
+        };
+        var
+      }
+      _ => continue,
+    };
+    for declarator in &mut var.decls {
+      let Pat::Ident(name) = &declarator.name else {
+        continue;
+      };
+      let Some(collapse) = by_id.get(&name.to_id()) else {
+        continue;
+      };
+      let Some(init) = declarator.init.as_deref_mut() else {
+        continue;
+      };
+      let callee = yak_imports
+        .get_yak_component_import(collapse.element.as_ref())
+        .expect("a resolved chain element is a valid native element");
+      init.visit_mut_with(&mut RewriteChainCall {
+        parent: &collapse.parent,
+        class_name: &collapse.class_name,
+        callee: Some(callee),
+      });
+    }
+  }
+}
+
+/// Replaces the `styled(Parent)(...)` call of a collapsed declaration with the
+/// native `__yak.__yak_<element>("<chain classes>")` call, keeping the original
+/// call's span so its `/*#__PURE__*/` and extracted-css comments stay attached
+struct RewriteChainCall<'a> {
+  parent: &'a Id,
+  class_name: &'a Wtf8Atom,
+  /// the `__yak.__yak_<element>` callee, taken once the chain call is found
+  callee: Option<Box<Expr>>,
+}
+
+impl VisitMut for RewriteChainCall<'_> {
+  fn visit_mut_expr(&mut self, expr: &mut Expr) {
+    let Some(callee) = self.callee.take() else {
+      return;
+    };
+    if let Expr::Call(call) = expr {
+      if is_chain_call(call, self.parent) {
+        *expr = Expr::Call(CallExpr {
+          span: call.span,
+          ctxt: SyntaxContext::empty(),
+          callee: Callee::Expr(callee),
+          args: vec![ExprOrSpread {
+            spread: None,
+            expr: str_expr(self.class_name.clone()),
+          }],
+          type_args: None,
+        });
+        return;
+      }
+    }
+    // put the callee back and keep looking - only the chain call consumes it
+    self.callee = Some(callee);
+    expr.visit_mut_children_with(self);
+  }
+}
+
+/// Matches the compiled `styled(Parent)(...)` call: a call whose callee is
+/// itself a call taking the single wrapped-component argument `Parent`
+fn is_chain_call(call: &CallExpr, parent: &Id) -> bool {
+  let Callee::Expr(callee) = &call.callee else {
+    return false;
+  };
+  let Expr::Call(inner) = &**callee else {
+    return false;
+  };
+  let [arg] = inner.args.as_slice() else {
+    return false;
+  };
+  arg.spread.is_none() && matches!(&*arg.expr, Expr::Ident(ident) if ident.to_id() == *parent)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::utils::fold::css_expr::str_lit;
+  use swc_core::common::{SyntaxContext, DUMMY_SP};
+  use swc_core::ecma::ast::{CallExpr, ExprOrSpread, IdentName};
+
+  fn call(callee: Expr, args: Vec<Expr>) -> Expr {
+    Expr::Call(CallExpr {
+      span: DUMMY_SP,
+      callee: Callee::Expr(Box::new(callee)),
+      args: args
+        .into_iter()
+        .map(|expr| ExprOrSpread {
+          spread: None,
+          expr: Box::new(expr),
+        })
+        .collect(),
+      ctxt: SyntaxContext::empty(),
+      type_args: None,
+    })
+  }
+
+  fn member(obj: &str, prop: &str) -> Expr {
+    Expr::Member(swc_core::ecma::ast::MemberExpr {
+      span: DUMMY_SP,
+      obj: Box::new(Expr::Ident(Ident::new(
+        obj.into(),
+        DUMMY_SP,
+        SyntaxContext::empty(),
+      ))),
+      prop: MemberProp::Ident(IdentName::new(prop.into(), DUMMY_SP)),
+    })
+  }
+
+  fn str_lit_expr(value: &str) -> Expr {
+    Expr::Lit(Lit::Str(str_lit(value.into(), DUMMY_SP)))
+  }
+
+  fn ident(name: &str) -> Expr {
+    Expr::Ident(Ident::new(name.into(), DUMMY_SP, SyntaxContext::empty()))
+  }
+
+  #[test]
+  fn fold_target_matches_native_elements_and_components() {
+    // styled.div
+    assert_eq!(
+      StyledFold::fold_target(&member("styled", "div")),
+      Some(FoldTarget::Native("div".into()))
+    );
+    // styled("section")
+    assert_eq!(
+      StyledFold::fold_target(&call(ident("styled"), vec![str_lit_expr("section")])),
+      Some(FoldTarget::Native("section".into()))
+    );
+    // styled(Component)
+    assert!(matches!(
+      StyledFold::fold_target(&call(ident("styled"), vec![ident("Component")])),
+      Some(FoldTarget::Component(component)) if component.sym == *"Component"
+    ));
+    // styled.customElement
+    assert_eq!(
+      StyledFold::fold_target(&member("styled", "customElement")),
+      None
+    );
+    // styled(lowercase) - would be parsed as an intrinsic element in JSX
+    assert_eq!(
+      StyledFold::fold_target(&call(ident("styled"), vec![ident("lowercase")])),
+      None
+    );
+    // styled.div.attrs({ ... })
+    assert_eq!(
+      StyledFold::fold_target(&call(member("styled.div", "attrs"), vec![])),
+      None
+    );
+  }
+}

--- a/packages/yak-swc/yak_swc/src/utils/fold/purity.rs
+++ b/packages/yak-swc/yak_swc/src/utils/fold/purity.rs
@@ -11,7 +11,7 @@ use swc_core::ecma::ast::*;
 /// How freely the fold may treat a value's evaluation - each level includes
 /// everything the levels below it allow
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum Purity {
+pub(super) enum Purity {
   /// observable effects (calls, `new`, `i++`, assignments, `await`): evaluated
   /// exactly once, exactly where attribute position evaluated it
   Impure,
@@ -35,7 +35,7 @@ pub(crate) enum Purity {
 /// observe the extra reads. Gating them would turn `$c={colors[status]}` - one
 /// of the most common prop shapes there is - into an IIFE, and an effectful
 /// getter during render already violates React's own purity rule
-pub(crate) fn purity(expr: &Expr) -> Purity {
+pub(super) fn purity(expr: &Expr) -> Purity {
   match unwrap_type_casts(expr) {
     Expr::Lit(_) | Expr::Ident(_) => Purity::Dup,
     Expr::Member(member) => member_purity(member),

--- a/packages/yak-swc/yak_swc/src/utils/fold/usage.rs
+++ b/packages/yak-swc/yak_swc/src/utils/fold/usage.rs
@@ -1,3 +1,41 @@
+//! The rewrite phase of the styled component fold: rewrites every foldable JSX
+//! usage of a registered component into the plain element it wraps
+//!
+//! e.g.
+//! ```jsx
+//! const Card = styled.div`color: red;`;
+//! <Card>Hello</Card>
+//! ```
+//! becomes
+//! ```jsx
+//! const Card = __yak.__yak_div("yX");
+//! <div className="yX">Hello</div>
+//! ```
+//!
+//! A fully static `styled(Component)` wrapper folds to the wrapped component
+//! instead - the target component may come from another file:
+//! ```jsx
+//! const Extended = styled(Card)`padding: 4px;`;
+//! <Extended>Hello</Extended>
+//! ```
+//! becomes
+//! ```jsx
+//! <Card className="yE">Hello</Card>
+//! ```
+//!
+//! Class-toggling expressions over props are inlined at the usage by
+//! substituting the destructured props with the attribute values:
+//! ```jsx
+//! const Box = styled.div`${({ $active }) => $active && css`color: red;`}`;
+//! <Box $active={on}>Hello</Box>
+//! ```
+//! becomes
+//! ```jsx
+//! <div className={"yB" + (on ? " yA" : "")}>Hello</div>
+//! ```
+//! (no constant folding for literal values like `<Box $active>` - the minifier
+//! simplifies `"yB" + (true ? " yA" : "")` in production)
+
 use std::borrow::Cow;
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -6,263 +44,32 @@ use swc_core::{
   common::{SyntaxContext, DUMMY_SP},
   ecma::ast::{
     ArrowExpr, AssignPatProp, BinExpr, BinaryOp, BlockStmt, BlockStmtOrExpr, Bool, CallExpr,
-    Callee, Decl, Expr, ExprOrSpread, Id, Ident, IdentName, ImportSpecifier, Invalid, JSXAttr,
-    JSXAttrName, JSXAttrOrSpread, JSXAttrValue, JSXElement, JSXElementChild, JSXElementName,
-    JSXEmptyExpr, JSXExpr, JSXExprContainer, KeyValueProp, Lit, MemberProp, Module, ModuleDecl,
-    ModuleItem, Number, ObjectPatProp, Pat, Prop, PropName, Stmt, UnaryExpr, UnaryOp, VarDecl,
-    VarDeclKind,
+    Callee, Expr, ExprOrSpread, Id, Ident, IdentName, Invalid, JSXAttr, JSXAttrName,
+    JSXAttrOrSpread, JSXAttrValue, JSXElement, JSXElementChild, JSXElementName, JSXEmptyExpr,
+    JSXExpr, JSXExprContainer, KeyValueProp, Lit, MemberProp, Module, Number, ObjectPatProp, Pat,
+    Prop, PropName, Stmt, UnaryExpr, UnaryOp,
   },
   ecma::visit::{VisitMut, VisitMutWith},
 };
 
-use crate::utils::class_name_fold::{
-  append_condition_segment, class_name_attr, expr_attr_value, fold_condition_body, str_expr,
-  str_lit, with_leading_space, ConditionSegment,
+use super::{FoldTarget, FoldableComponent};
+use crate::utils::fold::css_expr::{
+  append_condition_segment, class_name_attr, expr_attr_value, fold_condition_body,
+  merge_class_names, str_expr, str_lit, with_leading_space, ConditionSegment,
 };
-use crate::utils::native_elements::VALID_ELEMENTS;
-use crate::utils::purity::{purity, Purity};
-use crate::variable_visitor::ScopedVariableReference;
+use crate::utils::fold::purity::{purity, Purity};
 use crate::yak_imports::YakImports;
 
-/// What a foldable JSX usage is rewritten to
-#[derive(Debug, PartialEq)]
-enum FoldTarget {
-  /// A native DOM element e.g. "div" for styled.div
-  Native(Atom),
-  /// The wrapped component e.g. Card for styled(Card)
-  Component(Ident),
-}
-
-/// A styled component whose JSX usages can be folded into their fold target
-#[derive(Debug)]
-struct FoldableComponent {
-  target: FoldTarget,
-  /// The generated static class name e.g. "ym7uBBu"
-  class_name: Wtf8Atom,
-  /// The compiled class-toggling expressions over props
-  /// e.g. `({ $active }) => $active && css("ym7uBBu1")`
-  /// Empty for fully static components; usages of dynamic components only
-  /// fold if these can be inlined by substituting the props with the
-  /// JSX attribute values
-  runtime_expressions: Vec<Expr>,
-}
-
-/// Folds JSX usages of fully static styled components declared in the same
-/// file into plain DOM elements to skip the runtime wrapper component
-///
-/// e.g.
-/// ```jsx
-/// const Card = styled.div`color: red;`;
-/// <Card>Hello</Card>
-/// ```
-/// becomes
-/// ```jsx
-/// const Card = __yak.__yak_div("yX");
-/// <div className="yX">Hello</div>
-/// ```
-///
-/// A fully static `styled(Component)` wrapper folds to the wrapped component
-/// instead - the target component may come from another file:
-/// ```jsx
-/// const Extended = styled(Card)`padding: 4px;`;
-/// <Extended>Hello</Extended>
-/// ```
-/// becomes
-/// ```jsx
-/// <Card className="yE">Hello</Card>
-/// ```
-///
-/// Class-toggling expressions over props are inlined at the usage by
-/// substituting the destructured props with the attribute values:
-/// ```jsx
-/// const Box = styled.div`${({ $active }) => $active && css`color: red;`}`;
-/// <Box $active={on}>Hello</Box>
-/// ```
-/// becomes
-/// ```jsx
-/// <div className={"yB" + (on ? " yA" : "")}>Hello</div>
-/// ```
-/// (no constant folding for literal values like `<Box $active>` - the
-/// minifier simplifies `"yB" + (true ? " yA" : "")` in production)
-///
-/// The declaration is kept untouched - it is /*#__PURE__*/ annotated so the
-/// minifier removes it if all usages could be folded and it is not exported
-///
-/// Foldable components are registered during the main transform pass and the
-/// usages are rewritten in a deferred pass over the module, as a usage may
-/// appear before the declaration (e.g. inside a hoisted function)
-#[derive(Debug, Default)]
-pub struct StyledJsxFold {
-  components: FxHashMap<Id, FoldableComponent>,
-}
-
-impl StyledJsxFold {
-  /// Registers a styled component if its JSX usages are foldable:
-  /// - `declaration` is a plain variable e.g. Card in const Card = styled.div`...`
-  /// - `tag` (the original tagged template tag) is styled.element,
-  ///   styled("element") with a native DOM element or styled(Component) -
-  ///   these shapes exclude .attrs(...) chains
-  /// - `class_name` is the static class name the compiled call carries as
-  ///   its first argument
-  /// - `runtime_expressions` must all be class-toggling arrows over props -
-  ///   anything else keeps the runtime path. Function expressions bail too:
-  ///   they bind `this`/`arguments`, which inlining would silently rebind to
-  ///   the enclosing component
-  pub fn try_register(
-    &mut self,
-    declaration: Option<&ScopedVariableReference>,
-    tag: &Expr,
-    class_name: &str,
-    runtime_expressions: &[Expr],
-  ) {
-    let Some(declaration) = declaration else {
-      return;
-    };
-    if declaration.parts.len() != 1 {
-      return;
-    }
-    let Some(target) = Self::fold_target(tag) else {
-      return;
-    };
-    if !runtime_expressions
-      .iter()
-      .all(|expr| matches!(expr, Expr::Arrow(_)))
-    {
-      return;
-    }
-    // dynamic styled(Component) wrappers keep the runtime path - the $prop
-    // forwarding semantics depend on the wrapped component
-    if !runtime_expressions.is_empty() && matches!(target, FoldTarget::Component(_)) {
-      return;
-    }
-    let previous = self.components.insert(
-      declaration.id.clone(),
-      FoldableComponent {
-        target,
-        class_name: class_name.into(),
-        runtime_expressions: runtime_expressions.to_vec(),
-      },
-    );
-    // a binding can only hold one styled component - a second registration
-    // would mean the whole-initializer check in the visitor broke
-    debug_assert!(previous.is_none());
-  }
-
-  /// Rewrites all foldable JSX usages of the registered components
-  /// Must run before the utility import specifiers are collected as it may
-  /// request the mergeClassNames utility
-  pub fn fold_jsx_usages(&mut self, module: &mut Module, yak_imports: &mut YakImports) {
-    if self.components.is_empty() {
-      return;
-    }
-    // only components declared as top level const are safe to fold
-    // (const rules out reassignment) - a component fold target must be an
-    // immutable binding as well so it still references the styled component's
-    // wrapped value at every usage
-    let immutable = Self::immutable_bindings(module);
-    self.components.retain(|id, component| {
-      immutable.contains(id)
-        && match &component.target {
-          FoldTarget::Native(_) => true,
-          FoldTarget::Component(target) => immutable.contains(&target.to_id()),
-        }
-    });
-    if self.components.is_empty() {
-      return;
-    }
-    module.visit_mut_with(&mut FoldVisitor {
-      components: &self.components,
-      yak_imports,
-    });
-  }
-
-  /// Matches the tag shapes a JSX usage can be folded for:
-  /// - `styled.element` and `styled("element")` with a native DOM element
-  /// - `styled(Component)` with an uppercase component reference - a
-  ///   lowercase name would be parsed as an intrinsic element in JSX
-  ///
-  /// .attrs(...) chains don't have any of these shapes
-  fn fold_target(tag: &Expr) -> Option<FoldTarget> {
-    match tag {
-      Expr::Member(member) => {
-        if !member.obj.is_ident() {
-          return None;
-        }
-        let MemberProp::Ident(element) = &member.prop else {
-          return None;
-        };
-        VALID_ELEMENTS
-          .contains(element.sym.as_ref())
-          .then(|| FoldTarget::Native(element.sym.clone()))
-      }
-      Expr::Call(call) => {
-        if !matches!(&call.callee, Callee::Expr(callee) if callee.is_ident()) {
-          return None;
-        }
-        let [arg] = call.args.as_slice() else {
-          return None;
-        };
-        if arg.spread.is_some() {
-          return None;
-        }
-        match &*arg.expr {
-          Expr::Lit(Lit::Str(element)) => {
-            let element = element.value.as_str()?;
-            VALID_ELEMENTS
-              .contains(element)
-              .then(|| FoldTarget::Native(Atom::from(element)))
-          }
-          Expr::Ident(component) => component
-            .sym
-            .starts_with(|c: char| c.is_ascii_uppercase())
-            .then(|| FoldTarget::Component(component.clone())),
-          _ => None,
-        }
-      }
-      _ => None,
-    }
-  }
-
-  /// Collects the module scope bindings which can not be reassigned:
-  /// top level `const X = ...` declarations (including `export const`)
-  /// and import bindings
-  fn immutable_bindings(module: &Module) -> FxHashSet<Id> {
-    let mut bindings = FxHashSet::default();
-    for item in &module.body {
-      let var: &VarDecl = match item {
-        ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,
-        ModuleItem::ModuleDecl(ModuleDecl::Import(import)) => {
-          for specifier in &import.specifiers {
-            let local = match specifier {
-              ImportSpecifier::Named(named) => &named.local,
-              ImportSpecifier::Default(default) => &default.local,
-              ImportSpecifier::Namespace(namespace) => &namespace.local,
-              #[cfg(swc_ast_unknown)]
-              _ => continue,
-            };
-            bindings.insert(local.to_id());
-          }
-          continue;
-        }
-        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export)) => {
-          let Decl::Var(var) = &export.decl else {
-            continue;
-          };
-          var
-        }
-        _ => continue,
-      };
-      if var.kind != VarDeclKind::Const {
-        continue;
-      }
-      for declarator in &var.decls {
-        if let Pat::Ident(name) = &declarator.name {
-          bindings.insert(name.to_id());
-        }
-      }
-    }
-    bindings
-  }
+/// Rewrites every foldable JSX usage of the registered components in the module
+pub(super) fn fold(
+  module: &mut Module,
+  components: &FxHashMap<Id, FoldableComponent>,
+  yak_imports: &mut YakImports,
+) {
+  module.visit_mut_with(&mut FoldVisitor {
+    components,
+    yak_imports,
+  });
 }
 
 /// The deferred pass which rewrites foldable JSX usages
@@ -703,7 +510,7 @@ impl FoldVisitor<'_> {
       // className="user"
       JSXAttrValue::Str(user) => Some(match yak_class {
         YakClassName::Static(class_name) => JSXAttrValue::Str(str_lit(
-          merged_class_names(&class_name, &user.value),
+          merge_class_names(&class_name, &user.value),
           user.span,
         )),
         // `"yX" + (on ? " yY" : "") + " user"`
@@ -720,7 +527,7 @@ impl FoldVisitor<'_> {
           // /*YAK Extracted CSS:*/ comment from a folded css prop survives
           Expr::Lit(Lit::Str(user)) => match yak_class {
             YakClassName::Static(class_name) => Box::new(Expr::Lit(Lit::Str(str_lit(
-              merged_class_names(&class_name, &user.value),
+              merge_class_names(&class_name, &user.value),
               user.span,
             )))),
             YakClassName::Dynamic(expr) => append_class_name_str(expr, &user.value, user.span),
@@ -1220,15 +1027,6 @@ fn append_class_name_str(
   }))
 }
 
-fn merged_class_names(yak_class_name: &Wtf8Atom, user_class_name: &Wtf8Atom) -> Wtf8Atom {
-  format!(
-    "{} {}",
-    yak_class_name.to_string_lossy(),
-    user_class_name.to_string_lossy()
-  )
-  .into()
-}
-
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -1236,77 +1034,6 @@ mod tests {
   use swc_core::common::{FileName, SourceMap};
   use swc_core::ecma::ast::EsVersion;
   use swc_core::ecma::parser::{lexer::Lexer, Parser, StringInput, Syntax, TsSyntax};
-
-  fn call(callee: Expr, args: Vec<Expr>) -> Expr {
-    Expr::Call(CallExpr {
-      span: DUMMY_SP,
-      callee: Callee::Expr(Box::new(callee)),
-      args: args
-        .into_iter()
-        .map(|expr| ExprOrSpread {
-          spread: None,
-          expr: Box::new(expr),
-        })
-        .collect(),
-      ctxt: SyntaxContext::empty(),
-      type_args: None,
-    })
-  }
-
-  fn member(obj: &str, prop: &str) -> Expr {
-    Expr::Member(swc_core::ecma::ast::MemberExpr {
-      span: DUMMY_SP,
-      obj: Box::new(Expr::Ident(Ident::new(
-        obj.into(),
-        DUMMY_SP,
-        SyntaxContext::empty(),
-      ))),
-      prop: MemberProp::Ident(IdentName::new(prop.into(), DUMMY_SP)),
-    })
-  }
-
-  fn str_lit_expr(value: &str) -> Expr {
-    Expr::Lit(Lit::Str(str_lit(value.into(), DUMMY_SP)))
-  }
-
-  fn ident(name: &str) -> Expr {
-    Expr::Ident(Ident::new(name.into(), DUMMY_SP, SyntaxContext::empty()))
-  }
-
-  #[test]
-  fn fold_target_matches_native_elements_and_components() {
-    // styled.div
-    assert_eq!(
-      StyledJsxFold::fold_target(&member("styled", "div")),
-      Some(FoldTarget::Native("div".into()))
-    );
-    // styled("section")
-    assert_eq!(
-      StyledJsxFold::fold_target(&call(ident("styled"), vec![str_lit_expr("section")])),
-      Some(FoldTarget::Native("section".into()))
-    );
-    // styled(Component)
-    assert!(matches!(
-      StyledJsxFold::fold_target(&call(ident("styled"), vec![ident("Component")])),
-      Some(FoldTarget::Component(component)) if component.sym == *"Component"
-    ));
-    // styled.customElement
-    assert_eq!(
-      StyledJsxFold::fold_target(&member("styled", "customElement")),
-      None
-    );
-    // styled(lowercase) - would be parsed as an intrinsic element in JSX
-    assert_eq!(
-      StyledJsxFold::fold_target(&call(ident("styled"), vec![ident("lowercase")])),
-      None
-    );
-    // styled.div.attrs({ ... })
-    assert_eq!(
-      StyledJsxFold::fold_target(&call(member("styled.div", "attrs"), vec![])),
-      None
-    );
-  }
-
   /// The attributes of a parsed `<Row … />`
   fn attrs_of(source: &str) -> Vec<JSXAttrOrSpread> {
     let cm: Lrc<SourceMap> = Default::default();

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/input.tsx
@@ -47,7 +47,7 @@ const Card = styled.div`
   color: green;
 `;
 
-// styled(Component) wrapper folds to the wrapped component
+// collapses: parent Card is a same-file static component
 const Fancy = styled(Card)`
   padding: 4px;
 `;
@@ -97,8 +97,11 @@ const Cases = () => (
     {/* static component: a string className merges at compile time */}
     <Card className="user">static merge</Card>
 
-    {/* styled(Component) usage folds to Card with the merged class */}
+    {/* the chain collapses, so the usage folds to a plain div */}
     <Fancy className="extra">wrapper fold</Fancy>
+
+    {/* bails: the spread renders the collapsed Fancy declaration at runtime */}
+    <Fancy {...props}>spread bail</Fancy>
 
     {/* bails: a spread after className may carry className/style at runtime */}
     <Card className="x" {...props}>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.dev.tsx
@@ -47,12 +47,12 @@ const Card = /*YAK Extracted CSS:
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Card_m7uBBu"), {
     "displayName": "Card"
 });
-// styled(Component) wrapper folds to the wrapped component
+// collapses: parent Card is a same-file static component
 const Fancy = /*YAK Extracted CSS:
 :global(.input_Fancy_m7uBBu) {
   padding: 4px;
 }
-*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(Card)("input_Fancy_m7uBBu"), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Card_m7uBBu input_Fancy_m7uBBu"), {
     "displayName": "Fancy"
 });
 // bails: an .attrs() chain is never registered as foldable
@@ -107,8 +107,11 @@ const Cases = ()=><>
     { /* static component: a string className merges at compile time */ }
     <div className="input_Card_m7uBBu user">static merge</div>
 
-    { /* styled(Component) usage folds to Card with the merged class */ }
-    <Card className="input_Fancy_m7uBBu extra">wrapper fold</Card>
+    { /* the chain collapses, so the usage folds to a plain div */ }
+    <div className="input_Card_m7uBBu input_Fancy_m7uBBu extra">wrapper fold</div>
+
+    { /* bails: the spread renders the collapsed Fancy declaration at runtime */ }
+    <Fancy {...props}>spread bail</Fancy>
 
     { /* bails: a spread after className may carry className/style at runtime */ }
     <Card className="x" {...props}>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.prod.tsx
@@ -39,12 +39,12 @@ const Card = /*YAK Extracted CSS:
   color: green;
 }
 */ /*#__PURE__*/ __yak.__yak_div("ym7uBBu7");
-// styled(Component) wrapper folds to the wrapped component
+// collapses: parent Card is a same-file static component
 const Fancy = /*YAK Extracted CSS:
 :global(.ym7uBBu8) {
   padding: 4px;
 }
-*/ /*#__PURE__*/ styled(Card)("ym7uBBu8");
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBu7 ym7uBBu8");
 // bails: an .attrs() chain is never registered as foldable
 const WithAttrs = /*YAK Extracted CSS:
 :global(.ym7uBBu9) {
@@ -93,8 +93,11 @@ const Cases = ()=><>
     { /* static component: a string className merges at compile time */ }
     <div className="ym7uBBu7 user">static merge</div>
 
-    { /* styled(Component) usage folds to Card with the merged class */ }
-    <Card className="ym7uBBu8 extra">wrapper fold</Card>
+    { /* the chain collapses, so the usage folds to a plain div */ }
+    <div className="ym7uBBu7 ym7uBBu8 extra">wrapper fold</div>
+
+    { /* bails: the spread renders the collapsed Fancy declaration at runtime */ }
+    <Fancy {...props}>spread bail</Fancy>
 
     { /* bails: a spread after className may carry className/style at runtime */ }
     <Card className="x" {...props}>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.turbo.dev.tsx
@@ -47,12 +47,12 @@ const Card = /*YAK Extracted CSS:
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Card_m7uBBu"), {
     "displayName": "Card"
 });
-// styled(Component) wrapper folds to the wrapped component
+// collapses: parent Card is a same-file static component
 const Fancy = /*YAK Extracted CSS:
 .input_Fancy_m7uBBu {
   padding: 4px;
 }
-*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(Card)("input_Fancy_m7uBBu"), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Card_m7uBBu input_Fancy_m7uBBu"), {
     "displayName": "Fancy"
 });
 // bails: an .attrs() chain is never registered as foldable
@@ -107,8 +107,11 @@ const Cases = ()=><>
     { /* static component: a string className merges at compile time */ }
     <div className="input_Card_m7uBBu user">static merge</div>
 
-    { /* styled(Component) usage folds to Card with the merged class */ }
-    <Card className="input_Fancy_m7uBBu extra">wrapper fold</Card>
+    { /* the chain collapses, so the usage folds to a plain div */ }
+    <div className="input_Card_m7uBBu input_Fancy_m7uBBu extra">wrapper fold</div>
+
+    { /* bails: the spread renders the collapsed Fancy declaration at runtime */ }
+    <Fancy {...props}>spread bail</Fancy>
 
     { /* bails: a spread after className may carry className/style at runtime */ }
     <Card className="x" {...props}>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.turbo.prod.tsx
@@ -39,12 +39,12 @@ const Card = /*YAK Extracted CSS:
   color: green;
 }
 */ /*#__PURE__*/ __yak.__yak_div("ym7uBBu7");
-// styled(Component) wrapper folds to the wrapped component
+// collapses: parent Card is a same-file static component
 const Fancy = /*YAK Extracted CSS:
 .ym7uBBu8 {
   padding: 4px;
 }
-*/ /*#__PURE__*/ styled(Card)("ym7uBBu8");
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBu7 ym7uBBu8");
 // bails: an .attrs() chain is never registered as foldable
 const WithAttrs = /*YAK Extracted CSS:
 .ym7uBBu9 {
@@ -93,8 +93,11 @@ const Cases = ()=><>
     { /* static component: a string className merges at compile time */ }
     <div className="ym7uBBu7 user">static merge</div>
 
-    { /* styled(Component) usage folds to Card with the merged class */ }
-    <Card className="ym7uBBu8 extra">wrapper fold</Card>
+    { /* the chain collapses, so the usage folds to a plain div */ }
+    <div className="ym7uBBu7 ym7uBBu8 extra">wrapper fold</div>
+
+    { /* bails: the spread renders the collapsed Fancy declaration at runtime */ }
+    <Fancy {...props}>spread bail</Fancy>
 
     { /* bails: a spread after className may carry className/style at runtime */ }
     <Card className="x" {...props}>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/input.tsx
@@ -33,14 +33,43 @@ const WithAttrs = styled.button.attrs({ type: "button" })`
   color: green;
 `;
 
-// folds to the wrapped component: <Extended> becomes <Card className="...">
+// collapses: parent is a same-file static component
 const Extended = styled(Card)`
   color: yellow;
 `;
 
-// folds although the wrapped component comes from another file
+// collapses: three-level chain, classes merged parent-first
+const ExtendedTwice = styled(Extended)`
+  color: coral;
+`;
+
+// collapses: exported chain keeps its folded declaration
+export const FancyTitle = styled(Title)`
+  letter-spacing: 1px;
+`;
+
+// folds to the wrapped component: a cross-file parent never collapses
 const ExtendedImport = styled(ImportedCard)`
   color: silver;
+`;
+
+// dynamic: class-toggling condition
+const ToggleBase = styled.button<{ $on?: boolean }>`
+  ${({ $on }) =>
+    $on &&
+    css`
+      color: red;
+    `}
+`;
+
+// folds to the wrapped component: a dynamic parent never collapses
+const OfDynamic = styled(ToggleBase)`
+  color: teal;
+`;
+
+// folds to the wrapped component: an attrs parent never collapses
+const OfAttrs = styled(WithAttrs)`
+  color: maroon;
 `;
 
 // bails: a lowercase name would be parsed as an intrinsic element in JSX
@@ -58,6 +87,20 @@ const ExtendedMutable = styled(MutableTarget)`
 // bails: let declaration
 let Mutable = styled.div`
   color: pink;
+`;
+
+// bails: a let parent keeps the whole chain on the runtime path
+const OfLet = styled(Mutable)`
+  color: khaki;
+`;
+
+// bails: parent declared after the child (const temporal dead zone) - collapsing
+// would turn the guaranteed ReferenceError into silently working output
+const OfLater = styled(Later)`
+  color: wheat;
+`;
+const Later = styled.div`
+  color: linen;
 `;
 
 // bails: var redeclaration - both declarations share a single binding
@@ -110,8 +153,13 @@ const Optimizable = ({ active }: { active?: boolean }) => (
     </Card>
     <Title>folds</Title>
     <Cast>folds through the type cast</Cast>
-    <Extended>folds to the wrapped component</Extended>
-    <Extended className="user">merges into the wrapped component</Extended>
+    <Extended>collapses to a plain div</Extended>
+    <Extended className="user">collapses and merges the className</Extended>
+    <ExtendedTwice>collapses the whole three-level chain</ExtendedTwice>
+    <FancyTitle>collapses the exported chain</FancyTitle>
+    <OfDynamic>folds to the dynamic parent, chain not collapsed</OfDynamic>
+    <OfAttrs>folds to the attrs parent, chain not collapsed</OfAttrs>
+    <OfLater>folds to the later-declared parent, chain not collapsed</OfLater>
     <ExtendedImport>folds to the imported component</ExtendedImport>
     <BoxWithMixin>folds with mixin</BoxWithMixin>
   </>
@@ -140,6 +188,7 @@ const NotOptimizable = () => (
     <ExtendedLowercase>bails: lowercase wrapped component</ExtendedLowercase>
     <ExtendedMutable>bails: reassignable wrapped component</ExtendedMutable>
     <Mutable>bails</Mutable>
+    <OfLet>bails: reassignable parent keeps the runtime chain</OfLet>
     <Redeclared>bails: var redeclaration</Redeclared>
     <Memoized>bails: HOC wrapper</Memoized>
     <ReactMemoized>bails: HOC wrapper</ReactMemoized>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.dev.tsx
@@ -54,21 +54,61 @@ const WithAttrs = /*YAK Extracted CSS:
 })("input_WithAttrs_m7uBBu"), {
     "displayName": "WithAttrs"
 });
-// folds to the wrapped component: <Extended> becomes <Card className="...">
+// collapses: parent is a same-file static component
 const Extended = /*YAK Extracted CSS:
 :global(.input_Extended_m7uBBu) {
   color: yellow;
 }
-*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(Card)("input_Extended_m7uBBu"), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Card_m7uBBu input_Extended_m7uBBu"), {
     "displayName": "Extended"
 });
-// folds although the wrapped component comes from another file
+// collapses: three-level chain, classes merged parent-first
+const ExtendedTwice = /*YAK Extracted CSS:
+:global(.input_ExtendedTwice_m7uBBu) {
+  color: coral;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Card_m7uBBu input_Extended_m7uBBu input_ExtendedTwice_m7uBBu"), {
+    "displayName": "ExtendedTwice"
+});
+// collapses: exported chain keeps its folded declaration
+export const FancyTitle = /*YAK EXPORTED STYLED:FancyTitle:input_FancyTitle_m7uBBu*//*YAK Extracted CSS:
+:global(.input_FancyTitle_m7uBBu) {
+  letter-spacing: 1px;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_h1("input_Title_m7uBBu input_FancyTitle_m7uBBu"), {
+    "displayName": "FancyTitle"
+});
+// folds to the wrapped component: a cross-file parent never collapses
 const ExtendedImport = /*YAK Extracted CSS:
 :global(.input_ExtendedImport_m7uBBu) {
   color: silver;
 }
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(ImportedCard)("input_ExtendedImport_m7uBBu"), {
     "displayName": "ExtendedImport"
+});
+// dynamic: class-toggling condition
+const ToggleBase = /*YAK Extracted CSS:
+:global(.input_ToggleBase__\$on_m7uBBu) {
+  color: red;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button("input_ToggleBase_m7uBBu", ({ $on })=>$on && /*#__PURE__*/ css("input_ToggleBase__$on_m7uBBu")), {
+    "displayName": "ToggleBase"
+});
+// folds to the wrapped component: a dynamic parent never collapses
+const OfDynamic = /*YAK Extracted CSS:
+:global(.input_OfDynamic_m7uBBu) {
+  color: teal;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(ToggleBase)("input_OfDynamic_m7uBBu"), {
+    "displayName": "OfDynamic"
+});
+// folds to the wrapped component: an attrs parent never collapses
+const OfAttrs = /*YAK Extracted CSS:
+:global(.input_OfAttrs_m7uBBu) {
+  color: maroon;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(WithAttrs)("input_OfAttrs_m7uBBu"), {
+    "displayName": "OfAttrs"
 });
 // bails: a lowercase name would be parsed as an intrinsic element in JSX
 const lowercaseComponent = (p: any)=><i {...p}/>;
@@ -95,6 +135,30 @@ let Mutable = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Mutable_m7uBBu"), {
     "displayName": "Mutable"
+});
+// bails: a let parent keeps the whole chain on the runtime path
+const OfLet = /*YAK Extracted CSS:
+:global(.input_OfLet_m7uBBu) {
+  color: khaki;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(Mutable)("input_OfLet_m7uBBu"), {
+    "displayName": "OfLet"
+});
+// bails: parent declared after the child (const temporal dead zone) - collapsing
+// would turn the guaranteed ReferenceError into silently working output
+const OfLater = /*YAK Extracted CSS:
+:global(.input_OfLater_m7uBBu) {
+  color: wheat;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(Later)("input_OfLater_m7uBBu"), {
+    "displayName": "OfLater"
+});
+const Later = /*YAK Extracted CSS:
+:global(.input_Later_m7uBBu) {
+  color: linen;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Later_m7uBBu"), {
+    "displayName": "Later"
 });
 // bails: var redeclaration - both declarations share a single binding
 var Redeclared = /*YAK Extracted CSS:
@@ -168,8 +232,13 @@ const Optimizable = ({ active }: {
     </div>
     <h1 className="input_Title_m7uBBu">folds</h1>
     <div className="input_Cast_m7uBBu">folds through the type cast</div>
-    <Card className="input_Extended_m7uBBu">folds to the wrapped component</Card>
-    <Card className="input_Extended_m7uBBu user">merges into the wrapped component</Card>
+    <div className="input_Card_m7uBBu input_Extended_m7uBBu">collapses to a plain div</div>
+    <div className="input_Card_m7uBBu input_Extended_m7uBBu user">collapses and merges the className</div>
+    <div className="input_Card_m7uBBu input_Extended_m7uBBu input_ExtendedTwice_m7uBBu">collapses the whole three-level chain</div>
+    <h1 className="input_Title_m7uBBu input_FancyTitle_m7uBBu">collapses the exported chain</h1>
+    <ToggleBase className="input_OfDynamic_m7uBBu">folds to the dynamic parent, chain not collapsed</ToggleBase>
+    <WithAttrs className="input_OfAttrs_m7uBBu">folds to the attrs parent, chain not collapsed</WithAttrs>
+    <Later className="input_OfLater_m7uBBu">folds to the later-declared parent, chain not collapsed</Later>
     <ImportedCard className="input_ExtendedImport_m7uBBu">folds to the imported component</ImportedCard>
     <div className="input_BoxWithMixin_m7uBBu">folds with mixin</div>
   </>;
@@ -203,6 +272,7 @@ const NotOptimizable = ()=><>
     <ExtendedLowercase>bails: lowercase wrapped component</ExtendedLowercase>
     <ExtendedMutable>bails: reassignable wrapped component</ExtendedMutable>
     <Mutable>bails</Mutable>
+    <OfLet>bails: reassignable parent keeps the runtime chain</OfLet>
     <Redeclared>bails: var redeclaration</Redeclared>
     <Memoized>bails: HOC wrapper</Memoized>
     <ReactMemoized>bails: HOC wrapper</ReactMemoized>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.prod.tsx
@@ -44,74 +44,122 @@ const WithAttrs = /*YAK Extracted CSS:
 */ /*#__PURE__*/ __yak.__yak_button.attrs({
     type: "button"
 })("ym7uBBu6");
-// folds to the wrapped component: <Extended> becomes <Card className="...">
+// collapses: parent is a same-file static component
 const Extended = /*YAK Extracted CSS:
 :global(.ym7uBBu7) {
   color: yellow;
 }
-*/ /*#__PURE__*/ styled(Card)("ym7uBBu7");
-// folds although the wrapped component comes from another file
-const ExtendedImport = /*YAK Extracted CSS:
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBu1 ym7uBBu7");
+// collapses: three-level chain, classes merged parent-first
+const ExtendedTwice = /*YAK Extracted CSS:
 :global(.ym7uBBu8) {
+  color: coral;
+}
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBu1 ym7uBBu7 ym7uBBu8");
+// collapses: exported chain keeps its folded declaration
+export const FancyTitle = /*YAK EXPORTED STYLED:FancyTitle:ym7uBBu9*//*YAK Extracted CSS:
+:global(.ym7uBBu9) {
+  letter-spacing: 1px;
+}
+*/ /*#__PURE__*/ __yak.__yak_h1("ym7uBBu3 ym7uBBu9");
+// folds to the wrapped component: a cross-file parent never collapses
+const ExtendedImport = /*YAK Extracted CSS:
+:global(.ym7uBBuA) {
   color: silver;
 }
-*/ /*#__PURE__*/ styled(ImportedCard)("ym7uBBu8");
+*/ /*#__PURE__*/ styled(ImportedCard)("ym7uBBuA");
+// dynamic: class-toggling condition
+const ToggleBase = /*YAK Extracted CSS:
+:global(.ym7uBBuC) {
+  color: red;
+}
+*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBuB", ({ $on })=>$on && /*#__PURE__*/ css("ym7uBBuC"));
+// folds to the wrapped component: a dynamic parent never collapses
+const OfDynamic = /*YAK Extracted CSS:
+:global(.ym7uBBuD) {
+  color: teal;
+}
+*/ /*#__PURE__*/ styled(ToggleBase)("ym7uBBuD");
+// folds to the wrapped component: an attrs parent never collapses
+const OfAttrs = /*YAK Extracted CSS:
+:global(.ym7uBBuE) {
+  color: maroon;
+}
+*/ /*#__PURE__*/ styled(WithAttrs)("ym7uBBuE");
 // bails: a lowercase name would be parsed as an intrinsic element in JSX
 const lowercaseComponent = (p: any)=><i {...p}/>;
 const ExtendedLowercase = /*YAK Extracted CSS:
-:global(.ym7uBBu9) {
+:global(.ym7uBBuF) {
   color: gold;
 }
-*/ /*#__PURE__*/ styled(lowercaseComponent)("ym7uBBu9");
+*/ /*#__PURE__*/ styled(lowercaseComponent)("ym7uBBuF");
 // bails: the wrapped component binding can be reassigned
 let MutableTarget = (p: any)=><b {...p}/>;
 const ExtendedMutable = /*YAK Extracted CSS:
-:global(.ym7uBBuA) {
+:global(.ym7uBBuG) {
   color: ivory;
 }
-*/ /*#__PURE__*/ styled(MutableTarget)("ym7uBBuA");
+*/ /*#__PURE__*/ styled(MutableTarget)("ym7uBBuG");
 // bails: let declaration
 let Mutable = /*YAK Extracted CSS:
-:global(.ym7uBBuB) {
+:global(.ym7uBBuH) {
   color: pink;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuB");
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuH");
+// bails: a let parent keeps the whole chain on the runtime path
+const OfLet = /*YAK Extracted CSS:
+:global(.ym7uBBuI) {
+  color: khaki;
+}
+*/ /*#__PURE__*/ styled(Mutable)("ym7uBBuI");
+// bails: parent declared after the child (const temporal dead zone) - collapsing
+// would turn the guaranteed ReferenceError into silently working output
+const OfLater = /*YAK Extracted CSS:
+:global(.ym7uBBuJ) {
+  color: wheat;
+}
+*/ /*#__PURE__*/ styled(Later)("ym7uBBuJ");
+const Later = /*YAK Extracted CSS:
+:global(.ym7uBBuK) {
+  color: linen;
+}
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuK");
 // bails: var redeclaration - both declarations share a single binding
 var Redeclared = /*YAK Extracted CSS:
-:global(.ym7uBBuC) {
+:global(.ym7uBBuL) {
   color: peru;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuC");
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuL");
 var Redeclared = /*YAK Extracted CSS:
-:global(.ym7uBBuD) {
+:global(.ym7uBBuM) {
   color: plum;
 }
-*/ /*#__PURE__*/ __yak.__yak_span("ym7uBBuD");
+*/ /*#__PURE__*/ __yak.__yak_span("ym7uBBuM");
 // folds although the declaration comes after the usage
-const Early = ()=><p className="ym7uBBuE">before declaration</p>;
+const Early = ()=><p className="ym7uBBuN">before declaration</p>;
 const Late = /*YAK Extracted CSS:
-:global(.ym7uBBuE) {
+:global(.ym7uBBuN) {
   color: gray;
 }
-*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuE");
+*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuN");
 // bails: wrapped in an HOC - folding would drop the wrapper
 const Memoized = memo(/*YAK Extracted CSS:
-:global(.ym7uBBuF) {
+:global(.ym7uBBuO) {
   color: teal;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuF"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuO"));
 // folds: type casts are unwrapped
 const Cast = /*YAK Extracted CSS:
-:global(.ym7uBBuG) {
+:global(.ym7uBBuP) {
   color: brown;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuG") as unknown as typeof Card;
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuP") as unknown as typeof Card;
 const BoxWithMixin = /*YAK Extracted CSS:
-:global(.ym7uBBuH) {
+:global(.ym7uBBuQ) {
   background: white;
   color: red;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuH");
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuQ");
 const Optimizable = ({ active }: {
     active?: boolean;
 })=><>
@@ -125,38 +173,43 @@ const Optimizable = ({ active }: {
     <div className={__yak_mergeClassNames("ym7uBBu1", active && "active")}>runtime class name merge</div>
     <div $foo="forwarded" className="ym7uBBu1">$props are not filtered</div>
     <div className={/*YAK Extracted CSS:
-:global(.ym7uBBuI) {
+:global(.ym7uBBuR) {
   color: orange;
 }
-*/ /*#__PURE__*/ "ym7uBBu1 ym7uBBuI"}>
+*/ /*#__PURE__*/ "ym7uBBu1 ym7uBBuR"}>
       css prop merge
     </div>
     <div className="ym7uBBu1">
       <section className="ym7uBBu2"/>
     </div>
     <h1 className="ym7uBBu3">folds</h1>
-    <div className="ym7uBBuG">folds through the type cast</div>
-    <Card className="ym7uBBu7">folds to the wrapped component</Card>
-    <Card className="ym7uBBu7 user">merges into the wrapped component</Card>
-    <ImportedCard className="ym7uBBu8">folds to the imported component</ImportedCard>
-    <div className="ym7uBBuH">folds with mixin</div>
+    <div className="ym7uBBuP">folds through the type cast</div>
+    <div className="ym7uBBu1 ym7uBBu7">collapses to a plain div</div>
+    <div className="ym7uBBu1 ym7uBBu7 user">collapses and merges the className</div>
+    <div className="ym7uBBu1 ym7uBBu7 ym7uBBu8">collapses the whole three-level chain</div>
+    <h1 className="ym7uBBu3 ym7uBBu9">collapses the exported chain</h1>
+    <ToggleBase className="ym7uBBuD">folds to the dynamic parent, chain not collapsed</ToggleBase>
+    <WithAttrs className="ym7uBBuE">folds to the attrs parent, chain not collapsed</WithAttrs>
+    <Later className="ym7uBBuJ">folds to the later-declared parent, chain not collapsed</Later>
+    <ImportedCard className="ym7uBBuA">folds to the imported component</ImportedCard>
+    <div className="ym7uBBuQ">folds with mixin</div>
   </>;
 // bails: wrapped in React.memo - the HOC result must not fold to a bare DOM element
 const ReactMemoized = React.memo(/*YAK Extracted CSS:
-:global(.ym7uBBuJ) {
+:global(.ym7uBBuS) {
   color: olive;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuJ"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuS"));
 // bails: conditional initializer - the branch is only known at runtime
 const Conditional = props.flag ? /*YAK Extracted CSS:
-:global(.ym7uBBuK) {
+:global(.ym7uBBuT) {
   color: crimson;
 }
-*/ /*#__PURE__*/ __yak.__yak_a("ym7uBBuK") : /*YAK Extracted CSS:
-:global(.ym7uBBuL) {
+*/ /*#__PURE__*/ __yak.__yak_a("ym7uBBuT") : /*YAK Extracted CSS:
+:global(.ym7uBBuU) {
   color: navy;
 }
-*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBuL");
+*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBuU");
 const NotOptimizable = ()=><>
     <Card {...props}>bails: spread</Card>
     <Card theme={props.theme}>bails: theme</Card>
@@ -165,6 +218,7 @@ const NotOptimizable = ()=><>
     <ExtendedLowercase>bails: lowercase wrapped component</ExtendedLowercase>
     <ExtendedMutable>bails: reassignable wrapped component</ExtendedMutable>
     <Mutable>bails</Mutable>
+    <OfLet>bails: reassignable parent keeps the runtime chain</OfLet>
     <Redeclared>bails: var redeclaration</Redeclared>
     <Memoized>bails: HOC wrapper</Memoized>
     <ReactMemoized>bails: HOC wrapper</ReactMemoized>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.dev.tsx
@@ -2,7 +2,7 @@ import React, { memo } from "react";
 import { css, styled, __yak_mergeClassNames } from "next-yak/internal";
 import { ImportedCard } from "./imported-card";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LmlucHV0X0NhcmRfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0JveF9tN3VCQnUgewogIGNvbG9yOiBibHVlOwp9LmlucHV0X1RpdGxlX203dUJCdSB7CiAgZm9udC1zaXplOiAycmVtOwp9LmlucHV0X0R5bmFtaWNfbTd1QkJ1IHsKICBjb2xvcjogdmFyKC0taW5wdXRfRHluYW1pY19fY29sb3JfbTd1QkJ1KTsKfS5pbnB1dF9XaXRoQXR0cnNfbTd1QkJ1IHsKICBjb2xvcjogZ3JlZW47Cn0uaW5wdXRfRXh0ZW5kZWRfbTd1QkJ1IHsKICBjb2xvcjogeWVsbG93Owp9LmlucHV0X0V4dGVuZGVkSW1wb3J0X203dUJCdSB7CiAgY29sb3I6IHNpbHZlcjsKfS5pbnB1dF9FeHRlbmRlZExvd2VyY2FzZV9tN3VCQnUgewogIGNvbG9yOiBnb2xkOwp9LmlucHV0X0V4dGVuZGVkTXV0YWJsZV9tN3VCQnUgewogIGNvbG9yOiBpdm9yeTsKfS5pbnB1dF9NdXRhYmxlX203dUJCdSB7CiAgY29sb3I6IHBpbms7Cn0uaW5wdXRfUmVkZWNsYXJlZF9tN3VCQnUgewogIGNvbG9yOiBwZXJ1Owp9LmlucHV0X1JlZGVjbGFyZWRfbTd1QkJ1LTAxIHsKICBjb2xvcjogcGx1bTsKfS5pbnB1dF9MYXRlX203dUJCdSB7CiAgY29sb3I6IGdyYXk7Cn0uaW5wdXRfTWVtb2l6ZWRfbTd1QkJ1IHsKICBjb2xvcjogdGVhbDsKfS5pbnB1dF9DYXN0X203dUJCdSB7CiAgY29sb3I6IGJyb3duOwp9LmlucHV0X0JveFdpdGhNaXhpbl9tN3VCQnUgewogIGJhY2tncm91bmQ6IHdoaXRlOwogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfT3B0aW1pemFibGVfbTd1QkJ1IHsKICBjb2xvcjogb3JhbmdlOwp9LmlucHV0X1JlYWN0TWVtb2l6ZWRfbTd1QkJ1IHsKICBjb2xvcjogb2xpdmU7Cn0uaW5wdXRfQ29uZGl0aW9uYWxfbTd1QkJ1IHsKICBjb2xvcjogY3JpbXNvbjsKfS5pbnB1dF9Db25kaXRpb25hbF9tN3VCQnUtMDEgewogIGNvbG9yOiBuYXZ5Owp9";
+import "data:text/css;base64,LmlucHV0X0NhcmRfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0JveF9tN3VCQnUgewogIGNvbG9yOiBibHVlOwp9LmlucHV0X1RpdGxlX203dUJCdSB7CiAgZm9udC1zaXplOiAycmVtOwp9LmlucHV0X0R5bmFtaWNfbTd1QkJ1IHsKICBjb2xvcjogdmFyKC0taW5wdXRfRHluYW1pY19fY29sb3JfbTd1QkJ1KTsKfS5pbnB1dF9XaXRoQXR0cnNfbTd1QkJ1IHsKICBjb2xvcjogZ3JlZW47Cn0uaW5wdXRfRXh0ZW5kZWRfbTd1QkJ1IHsKICBjb2xvcjogeWVsbG93Owp9LmlucHV0X0V4dGVuZGVkVHdpY2VfbTd1QkJ1IHsKICBjb2xvcjogY29yYWw7Cn0uaW5wdXRfRmFuY3lUaXRsZV9tN3VCQnUgewogIGxldHRlci1zcGFjaW5nOiAxcHg7Cn0uaW5wdXRfRXh0ZW5kZWRJbXBvcnRfbTd1QkJ1IHsKICBjb2xvcjogc2lsdmVyOwp9LmlucHV0X1RvZ2dsZUJhc2VfX1wkb25fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X09mRHluYW1pY19tN3VCQnUgewogIGNvbG9yOiB0ZWFsOwp9LmlucHV0X09mQXR0cnNfbTd1QkJ1IHsKICBjb2xvcjogbWFyb29uOwp9LmlucHV0X0V4dGVuZGVkTG93ZXJjYXNlX203dUJCdSB7CiAgY29sb3I6IGdvbGQ7Cn0uaW5wdXRfRXh0ZW5kZWRNdXRhYmxlX203dUJCdSB7CiAgY29sb3I6IGl2b3J5Owp9LmlucHV0X011dGFibGVfbTd1QkJ1IHsKICBjb2xvcjogcGluazsKfS5pbnB1dF9PZkxldF9tN3VCQnUgewogIGNvbG9yOiBraGFraTsKfS5pbnB1dF9PZkxhdGVyX203dUJCdSB7CiAgY29sb3I6IHdoZWF0Owp9LmlucHV0X0xhdGVyX203dUJCdSB7CiAgY29sb3I6IGxpbmVuOwp9LmlucHV0X1JlZGVjbGFyZWRfbTd1QkJ1IHsKICBjb2xvcjogcGVydTsKfS5pbnB1dF9SZWRlY2xhcmVkX203dUJCdS0wMSB7CiAgY29sb3I6IHBsdW07Cn0uaW5wdXRfTGF0ZV9tN3VCQnUgewogIGNvbG9yOiBncmF5Owp9LmlucHV0X01lbW9pemVkX203dUJCdSB7CiAgY29sb3I6IHRlYWw7Cn0uaW5wdXRfQ2FzdF9tN3VCQnUgewogIGNvbG9yOiBicm93bjsKfS5pbnB1dF9Cb3hXaXRoTWl4aW5fbTd1QkJ1IHsKICBiYWNrZ3JvdW5kOiB3aGl0ZTsKICBjb2xvcjogcmVkOwp9LmlucHV0X09wdGltaXphYmxlX203dUJCdSB7CiAgY29sb3I6IG9yYW5nZTsKfS5pbnB1dF9SZWFjdE1lbW9pemVkX203dUJCdSB7CiAgY29sb3I6IG9saXZlOwp9LmlucHV0X0NvbmRpdGlvbmFsX203dUJCdSB7CiAgY29sb3I6IGNyaW1zb247Cn0uaW5wdXRfQ29uZGl0aW9uYWxfbTd1QkJ1LTAxIHsKICBjb2xvcjogbmF2eTsKfQ==";
 const someRef = {
     current: null
 } as any;
@@ -54,21 +54,61 @@ const WithAttrs = /*YAK Extracted CSS:
 })("input_WithAttrs_m7uBBu"), {
     "displayName": "WithAttrs"
 });
-// folds to the wrapped component: <Extended> becomes <Card className="...">
+// collapses: parent is a same-file static component
 const Extended = /*YAK Extracted CSS:
 .input_Extended_m7uBBu {
   color: yellow;
 }
-*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(Card)("input_Extended_m7uBBu"), {
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Card_m7uBBu input_Extended_m7uBBu"), {
     "displayName": "Extended"
 });
-// folds although the wrapped component comes from another file
+// collapses: three-level chain, classes merged parent-first
+const ExtendedTwice = /*YAK Extracted CSS:
+.input_ExtendedTwice_m7uBBu {
+  color: coral;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Card_m7uBBu input_Extended_m7uBBu input_ExtendedTwice_m7uBBu"), {
+    "displayName": "ExtendedTwice"
+});
+// collapses: exported chain keeps its folded declaration
+export const FancyTitle = /*YAK EXPORTED STYLED:FancyTitle:input_FancyTitle_m7uBBu*//*YAK Extracted CSS:
+.input_FancyTitle_m7uBBu {
+  letter-spacing: 1px;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_h1("input_Title_m7uBBu input_FancyTitle_m7uBBu"), {
+    "displayName": "FancyTitle"
+});
+// folds to the wrapped component: a cross-file parent never collapses
 const ExtendedImport = /*YAK Extracted CSS:
 .input_ExtendedImport_m7uBBu {
   color: silver;
 }
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(ImportedCard)("input_ExtendedImport_m7uBBu"), {
     "displayName": "ExtendedImport"
+});
+// dynamic: class-toggling condition
+const ToggleBase = /*YAK Extracted CSS:
+.input_ToggleBase__\$on_m7uBBu {
+  color: red;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button("input_ToggleBase_m7uBBu", ({ $on })=>$on && /*#__PURE__*/ css("input_ToggleBase__$on_m7uBBu")), {
+    "displayName": "ToggleBase"
+});
+// folds to the wrapped component: a dynamic parent never collapses
+const OfDynamic = /*YAK Extracted CSS:
+.input_OfDynamic_m7uBBu {
+  color: teal;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(ToggleBase)("input_OfDynamic_m7uBBu"), {
+    "displayName": "OfDynamic"
+});
+// folds to the wrapped component: an attrs parent never collapses
+const OfAttrs = /*YAK Extracted CSS:
+.input_OfAttrs_m7uBBu {
+  color: maroon;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(WithAttrs)("input_OfAttrs_m7uBBu"), {
+    "displayName": "OfAttrs"
 });
 // bails: a lowercase name would be parsed as an intrinsic element in JSX
 const lowercaseComponent = (p: any)=><i {...p}/>;
@@ -95,6 +135,30 @@ let Mutable = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Mutable_m7uBBu"), {
     "displayName": "Mutable"
+});
+// bails: a let parent keeps the whole chain on the runtime path
+const OfLet = /*YAK Extracted CSS:
+.input_OfLet_m7uBBu {
+  color: khaki;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(Mutable)("input_OfLet_m7uBBu"), {
+    "displayName": "OfLet"
+});
+// bails: parent declared after the child (const temporal dead zone) - collapsing
+// would turn the guaranteed ReferenceError into silently working output
+const OfLater = /*YAK Extracted CSS:
+.input_OfLater_m7uBBu {
+  color: wheat;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ styled(Later)("input_OfLater_m7uBBu"), {
+    "displayName": "OfLater"
+});
+const Later = /*YAK Extracted CSS:
+.input_Later_m7uBBu {
+  color: linen;
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_div("input_Later_m7uBBu"), {
+    "displayName": "Later"
 });
 // bails: var redeclaration - both declarations share a single binding
 var Redeclared = /*YAK Extracted CSS:
@@ -168,8 +232,13 @@ const Optimizable = ({ active }: {
     </div>
     <h1 className="input_Title_m7uBBu">folds</h1>
     <div className="input_Cast_m7uBBu">folds through the type cast</div>
-    <Card className="input_Extended_m7uBBu">folds to the wrapped component</Card>
-    <Card className="input_Extended_m7uBBu user">merges into the wrapped component</Card>
+    <div className="input_Card_m7uBBu input_Extended_m7uBBu">collapses to a plain div</div>
+    <div className="input_Card_m7uBBu input_Extended_m7uBBu user">collapses and merges the className</div>
+    <div className="input_Card_m7uBBu input_Extended_m7uBBu input_ExtendedTwice_m7uBBu">collapses the whole three-level chain</div>
+    <h1 className="input_Title_m7uBBu input_FancyTitle_m7uBBu">collapses the exported chain</h1>
+    <ToggleBase className="input_OfDynamic_m7uBBu">folds to the dynamic parent, chain not collapsed</ToggleBase>
+    <WithAttrs className="input_OfAttrs_m7uBBu">folds to the attrs parent, chain not collapsed</WithAttrs>
+    <Later className="input_OfLater_m7uBBu">folds to the later-declared parent, chain not collapsed</Later>
     <ImportedCard className="input_ExtendedImport_m7uBBu">folds to the imported component</ImportedCard>
     <div className="input_BoxWithMixin_m7uBBu">folds with mixin</div>
   </>;
@@ -203,6 +272,7 @@ const NotOptimizable = ()=><>
     <ExtendedLowercase>bails: lowercase wrapped component</ExtendedLowercase>
     <ExtendedMutable>bails: reassignable wrapped component</ExtendedMutable>
     <Mutable>bails</Mutable>
+    <OfLet>bails: reassignable parent keeps the runtime chain</OfLet>
     <Redeclared>bails: var redeclaration</Redeclared>
     <Memoized>bails: HOC wrapper</Memoized>
     <ReactMemoized>bails: HOC wrapper</ReactMemoized>

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.prod.tsx
@@ -2,7 +2,7 @@ import React, { memo } from "react";
 import { css, styled, __yak_mergeClassNames } from "next-yak/internal";
 import { ImportedCard } from "./imported-card";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LnltN3VCQnUxIHsKICBjb2xvcjogcmVkOwp9LnltN3VCQnUyIHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1MyB7CiAgZm9udC1zaXplOiAycmVtOwp9LnltN3VCQnU0IHsKICBjb2xvcjogdmFyKC0teW03dUJCdTUpOwp9LnltN3VCQnU2IHsKICBjb2xvcjogZ3JlZW47Cn0ueW03dUJCdTcgewogIGNvbG9yOiB5ZWxsb3c7Cn0ueW03dUJCdTggewogIGNvbG9yOiBzaWx2ZXI7Cn0ueW03dUJCdTkgewogIGNvbG9yOiBnb2xkOwp9LnltN3VCQnVBIHsKICBjb2xvcjogaXZvcnk7Cn0ueW03dUJCdUIgewogIGNvbG9yOiBwaW5rOwp9LnltN3VCQnVDIHsKICBjb2xvcjogcGVydTsKfS55bTd1QkJ1RCB7CiAgY29sb3I6IHBsdW07Cn0ueW03dUJCdUUgewogIGNvbG9yOiBncmF5Owp9LnltN3VCQnVGIHsKICBjb2xvcjogdGVhbDsKfS55bTd1QkJ1RyB7CiAgY29sb3I6IGJyb3duOwp9LnltN3VCQnVIIHsKICBiYWNrZ3JvdW5kOiB3aGl0ZTsKICBjb2xvcjogcmVkOwp9LnltN3VCQnVJIHsKICBjb2xvcjogb3JhbmdlOwp9LnltN3VCQnVKIHsKICBjb2xvcjogb2xpdmU7Cn0ueW03dUJCdUsgewogIGNvbG9yOiBjcmltc29uOwp9LnltN3VCQnVMIHsKICBjb2xvcjogbmF2eTsKfQ==";
+import "data:text/css;base64,LnltN3VCQnUxIHsKICBjb2xvcjogcmVkOwp9LnltN3VCQnUyIHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1MyB7CiAgZm9udC1zaXplOiAycmVtOwp9LnltN3VCQnU0IHsKICBjb2xvcjogdmFyKC0teW03dUJCdTUpOwp9LnltN3VCQnU2IHsKICBjb2xvcjogZ3JlZW47Cn0ueW03dUJCdTcgewogIGNvbG9yOiB5ZWxsb3c7Cn0ueW03dUJCdTggewogIGNvbG9yOiBjb3JhbDsKfS55bTd1QkJ1OSB7CiAgbGV0dGVyLXNwYWNpbmc6IDFweDsKfS55bTd1QkJ1QSB7CiAgY29sb3I6IHNpbHZlcjsKfS55bTd1QkJ1QyB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1RCB7CiAgY29sb3I6IHRlYWw7Cn0ueW03dUJCdUUgewogIGNvbG9yOiBtYXJvb247Cn0ueW03dUJCdUYgewogIGNvbG9yOiBnb2xkOwp9LnltN3VCQnVHIHsKICBjb2xvcjogaXZvcnk7Cn0ueW03dUJCdUggewogIGNvbG9yOiBwaW5rOwp9LnltN3VCQnVJIHsKICBjb2xvcjoga2hha2k7Cn0ueW03dUJCdUogewogIGNvbG9yOiB3aGVhdDsKfS55bTd1QkJ1SyB7CiAgY29sb3I6IGxpbmVuOwp9LnltN3VCQnVMIHsKICBjb2xvcjogcGVydTsKfS55bTd1QkJ1TSB7CiAgY29sb3I6IHBsdW07Cn0ueW03dUJCdU4gewogIGNvbG9yOiBncmF5Owp9LnltN3VCQnVPIHsKICBjb2xvcjogdGVhbDsKfS55bTd1QkJ1UCB7CiAgY29sb3I6IGJyb3duOwp9LnltN3VCQnVRIHsKICBiYWNrZ3JvdW5kOiB3aGl0ZTsKICBjb2xvcjogcmVkOwp9LnltN3VCQnVSIHsKICBjb2xvcjogb3JhbmdlOwp9LnltN3VCQnVTIHsKICBjb2xvcjogb2xpdmU7Cn0ueW03dUJCdVQgewogIGNvbG9yOiBjcmltc29uOwp9LnltN3VCQnVVIHsKICBjb2xvcjogbmF2eTsKfQ==";
 const someRef = {
     current: null
 } as any;
@@ -44,74 +44,122 @@ const WithAttrs = /*YAK Extracted CSS:
 */ /*#__PURE__*/ __yak.__yak_button.attrs({
     type: "button"
 })("ym7uBBu6");
-// folds to the wrapped component: <Extended> becomes <Card className="...">
+// collapses: parent is a same-file static component
 const Extended = /*YAK Extracted CSS:
 .ym7uBBu7 {
   color: yellow;
 }
-*/ /*#__PURE__*/ styled(Card)("ym7uBBu7");
-// folds although the wrapped component comes from another file
-const ExtendedImport = /*YAK Extracted CSS:
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBu1 ym7uBBu7");
+// collapses: three-level chain, classes merged parent-first
+const ExtendedTwice = /*YAK Extracted CSS:
 .ym7uBBu8 {
+  color: coral;
+}
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBu1 ym7uBBu7 ym7uBBu8");
+// collapses: exported chain keeps its folded declaration
+export const FancyTitle = /*YAK EXPORTED STYLED:FancyTitle:ym7uBBu9*//*YAK Extracted CSS:
+.ym7uBBu9 {
+  letter-spacing: 1px;
+}
+*/ /*#__PURE__*/ __yak.__yak_h1("ym7uBBu3 ym7uBBu9");
+// folds to the wrapped component: a cross-file parent never collapses
+const ExtendedImport = /*YAK Extracted CSS:
+.ym7uBBuA {
   color: silver;
 }
-*/ /*#__PURE__*/ styled(ImportedCard)("ym7uBBu8");
+*/ /*#__PURE__*/ styled(ImportedCard)("ym7uBBuA");
+// dynamic: class-toggling condition
+const ToggleBase = /*YAK Extracted CSS:
+.ym7uBBuC {
+  color: red;
+}
+*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBuB", ({ $on })=>$on && /*#__PURE__*/ css("ym7uBBuC"));
+// folds to the wrapped component: a dynamic parent never collapses
+const OfDynamic = /*YAK Extracted CSS:
+.ym7uBBuD {
+  color: teal;
+}
+*/ /*#__PURE__*/ styled(ToggleBase)("ym7uBBuD");
+// folds to the wrapped component: an attrs parent never collapses
+const OfAttrs = /*YAK Extracted CSS:
+.ym7uBBuE {
+  color: maroon;
+}
+*/ /*#__PURE__*/ styled(WithAttrs)("ym7uBBuE");
 // bails: a lowercase name would be parsed as an intrinsic element in JSX
 const lowercaseComponent = (p: any)=><i {...p}/>;
 const ExtendedLowercase = /*YAK Extracted CSS:
-.ym7uBBu9 {
+.ym7uBBuF {
   color: gold;
 }
-*/ /*#__PURE__*/ styled(lowercaseComponent)("ym7uBBu9");
+*/ /*#__PURE__*/ styled(lowercaseComponent)("ym7uBBuF");
 // bails: the wrapped component binding can be reassigned
 let MutableTarget = (p: any)=><b {...p}/>;
 const ExtendedMutable = /*YAK Extracted CSS:
-.ym7uBBuA {
+.ym7uBBuG {
   color: ivory;
 }
-*/ /*#__PURE__*/ styled(MutableTarget)("ym7uBBuA");
+*/ /*#__PURE__*/ styled(MutableTarget)("ym7uBBuG");
 // bails: let declaration
 let Mutable = /*YAK Extracted CSS:
-.ym7uBBuB {
+.ym7uBBuH {
   color: pink;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuB");
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuH");
+// bails: a let parent keeps the whole chain on the runtime path
+const OfLet = /*YAK Extracted CSS:
+.ym7uBBuI {
+  color: khaki;
+}
+*/ /*#__PURE__*/ styled(Mutable)("ym7uBBuI");
+// bails: parent declared after the child (const temporal dead zone) - collapsing
+// would turn the guaranteed ReferenceError into silently working output
+const OfLater = /*YAK Extracted CSS:
+.ym7uBBuJ {
+  color: wheat;
+}
+*/ /*#__PURE__*/ styled(Later)("ym7uBBuJ");
+const Later = /*YAK Extracted CSS:
+.ym7uBBuK {
+  color: linen;
+}
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuK");
 // bails: var redeclaration - both declarations share a single binding
 var Redeclared = /*YAK Extracted CSS:
-.ym7uBBuC {
+.ym7uBBuL {
   color: peru;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuC");
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuL");
 var Redeclared = /*YAK Extracted CSS:
-.ym7uBBuD {
+.ym7uBBuM {
   color: plum;
 }
-*/ /*#__PURE__*/ __yak.__yak_span("ym7uBBuD");
+*/ /*#__PURE__*/ __yak.__yak_span("ym7uBBuM");
 // folds although the declaration comes after the usage
-const Early = ()=><p className="ym7uBBuE">before declaration</p>;
+const Early = ()=><p className="ym7uBBuN">before declaration</p>;
 const Late = /*YAK Extracted CSS:
-.ym7uBBuE {
+.ym7uBBuN {
   color: gray;
 }
-*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuE");
+*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuN");
 // bails: wrapped in an HOC - folding would drop the wrapper
 const Memoized = memo(/*YAK Extracted CSS:
-.ym7uBBuF {
+.ym7uBBuO {
   color: teal;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuF"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuO"));
 // folds: type casts are unwrapped
 const Cast = /*YAK Extracted CSS:
-.ym7uBBuG {
+.ym7uBBuP {
   color: brown;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuG") as unknown as typeof Card;
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuP") as unknown as typeof Card;
 const BoxWithMixin = /*YAK Extracted CSS:
-.ym7uBBuH {
+.ym7uBBuQ {
   background: white;
   color: red;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuH");
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuQ");
 const Optimizable = ({ active }: {
     active?: boolean;
 })=><>
@@ -125,38 +173,43 @@ const Optimizable = ({ active }: {
     <div className={__yak_mergeClassNames("ym7uBBu1", active && "active")}>runtime class name merge</div>
     <div $foo="forwarded" className="ym7uBBu1">$props are not filtered</div>
     <div className={/*YAK Extracted CSS:
-.ym7uBBuI {
+.ym7uBBuR {
   color: orange;
 }
-*/ /*#__PURE__*/ "ym7uBBu1 ym7uBBuI"}>
+*/ /*#__PURE__*/ "ym7uBBu1 ym7uBBuR"}>
       css prop merge
     </div>
     <div className="ym7uBBu1">
       <section className="ym7uBBu2"/>
     </div>
     <h1 className="ym7uBBu3">folds</h1>
-    <div className="ym7uBBuG">folds through the type cast</div>
-    <Card className="ym7uBBu7">folds to the wrapped component</Card>
-    <Card className="ym7uBBu7 user">merges into the wrapped component</Card>
-    <ImportedCard className="ym7uBBu8">folds to the imported component</ImportedCard>
-    <div className="ym7uBBuH">folds with mixin</div>
+    <div className="ym7uBBuP">folds through the type cast</div>
+    <div className="ym7uBBu1 ym7uBBu7">collapses to a plain div</div>
+    <div className="ym7uBBu1 ym7uBBu7 user">collapses and merges the className</div>
+    <div className="ym7uBBu1 ym7uBBu7 ym7uBBu8">collapses the whole three-level chain</div>
+    <h1 className="ym7uBBu3 ym7uBBu9">collapses the exported chain</h1>
+    <ToggleBase className="ym7uBBuD">folds to the dynamic parent, chain not collapsed</ToggleBase>
+    <WithAttrs className="ym7uBBuE">folds to the attrs parent, chain not collapsed</WithAttrs>
+    <Later className="ym7uBBuJ">folds to the later-declared parent, chain not collapsed</Later>
+    <ImportedCard className="ym7uBBuA">folds to the imported component</ImportedCard>
+    <div className="ym7uBBuQ">folds with mixin</div>
   </>;
 // bails: wrapped in React.memo - the HOC result must not fold to a bare DOM element
 const ReactMemoized = React.memo(/*YAK Extracted CSS:
-.ym7uBBuJ {
+.ym7uBBuS {
   color: olive;
 }
-*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuJ"));
+*/ /*#__PURE__*/ __yak.__yak_div("ym7uBBuS"));
 // bails: conditional initializer - the branch is only known at runtime
 const Conditional = props.flag ? /*YAK Extracted CSS:
-.ym7uBBuK {
+.ym7uBBuT {
   color: crimson;
 }
-*/ /*#__PURE__*/ __yak.__yak_a("ym7uBBuK") : /*YAK Extracted CSS:
-.ym7uBBuL {
+*/ /*#__PURE__*/ __yak.__yak_a("ym7uBBuT") : /*YAK Extracted CSS:
+.ym7uBBuU {
   color: navy;
 }
-*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBuL");
+*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBuU");
 const NotOptimizable = ()=><>
     <Card {...props}>bails: spread</Card>
     <Card theme={props.theme}>bails: theme</Card>
@@ -165,6 +218,7 @@ const NotOptimizable = ()=><>
     <ExtendedLowercase>bails: lowercase wrapped component</ExtendedLowercase>
     <ExtendedMutable>bails: reassignable wrapped component</ExtendedMutable>
     <Mutable>bails</Mutable>
+    <OfLet>bails: reassignable parent keeps the runtime chain</OfLet>
     <Redeclared>bails: var redeclaration</Redeclared>
     <Memoized>bails: HOC wrapper</Memoized>
     <ReactMemoized>bails: HOC wrapper</ReactMemoized>


### PR DESCRIPTION
Replaces #613, which GitHub's stack tooling closed when its merged base branch was deleted. Same branch, same content.

A fully static `styled(Card)` chain kept one runtime wrapper per authored level even when everything is known at build time. This collapses the declaration itself — `Fancy = styled(Card)`…`` becomes the base element with parent-first merged classes — so same-file usages fold to plain elements and every consumer of an exported chain gets a single wrapper; unused base components become dead code the minifier drops.

```tsx
const Button = styled.button`
  padding: 8px;
`;
export const FullWidthButton = styled(Button)`
  width: 100%;
`;
const App = () => <FullWidthButton>Save</FullWidthButton>;

// compiles to
export const FullWidthButton = /*#__PURE__*/ __yak.__yak_button("yak-button yak-full");
const App = () => <button className="yak-button yak-full">Save</button>;
```

The folding code is restructured into `utils/fold/` (registry + register/resolve/rewrite phases, usage rewrite, shared css-to-className primitive) so the whole feature reads as one design; the collapse is a step in the resolve phase. A skipped collapse is never incorrect: dynamic, `.attrs`, cross-file, mutable, and out-of-declaration-order parents keep today's behavior.

Compile-time cost: the collapse adds no full AST traversal. Chain resolution is registry-only hashmap work; the two new scans touch only top-level `module.body` items, and only a collapsed declarator's init expression gets visited. The one full-depth pass predates this change and moved verbatim. With `foldStatic: false` or no registered components, `fold_module` returns before touching the AST.

🤖 Co-authored-by **Claude Code**