### PR TITLE
Use the full component path for CSS variable names

### DIFF
--- a/.changeset/proud-names-shine.md
+++ b/.changeset/proud-names-shine.md
@@ -1,0 +1,5 @@
+---
+"yak-swc": patch
+---
+
+CSS variables of styled components declared in object literals now carry the full path in development, e.g. `--buttons_primary__color` instead of `--buttons__color-01`.

--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -696,13 +696,10 @@ ${{() => {var}}};\n",
             let css_variable_name = reused_name.unwrap_or_else(|| {
               let readable_name = format!(
                 "{}__{}",
-                // Current variable name of the StyledComponent or Mixin
-                // e.g. Button for const Button = styled.button`color: red;`
-                self
-                  // TODO: check if parts should also be used for the name:
-                  .get_current_component_id()
-                  .id
-                  .0,
+                // Full path of the StyledComponent or Mixin, matching the
+                // class name, e.g. buttons.primary for
+                // const buttons = { primary: styled.button`color: red;` }
+                self.get_current_component_id().to_readable_string(),
                 // Current property name
                 // e.g. color for styled.button`color: red;`
                 css_state.as_ref().unwrap().current_declaration.property

--- a/packages/yak-swc/yak_swc/tests/fixture/object-literal-variable-names/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/object-literal-variable-names/input.tsx
@@ -1,0 +1,10 @@
+import { styled } from "next-yak";
+
+const buttons = {
+  primary: styled.button<{ $c: string }>`
+    color: ${({ $c }) => $c};
+  `,
+  danger: styled.button<{ $c: string }>`
+    color: ${({ $c }) => $c};
+  `,
+};

--- a/packages/yak-swc/yak_swc/tests/fixture/object-literal-variable-names/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/object-literal-variable-names/output.dev.tsx
@@ -1,0 +1,27 @@
+import { styled } from "next-yak/internal";
+import * as __yak from "next-yak/internal";
+import "./input.yak.module.css!=!./input?./input.yak.module.css";
+const buttons = {
+    primary: /*YAK Extracted CSS:
+:global(.input_buttons_primary_m7uBBu) {
+  color: var(--input_buttons_primary__color_m7uBBu);
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button("input_buttons_primary_m7uBBu", {
+        "style": {
+            "--input_buttons_primary__color_m7uBBu": ({ $c })=>$c
+        }
+    }), {
+        "displayName": "primary"
+    }),
+    danger: /*YAK Extracted CSS:
+:global(.input_buttons_danger_m7uBBu) {
+  color: var(--input_buttons_danger__color_m7uBBu);
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button("input_buttons_danger_m7uBBu", {
+        "style": {
+            "--input_buttons_danger__color_m7uBBu": ({ $c })=>$c
+        }
+    }), {
+        "displayName": "danger"
+    })
+};

--- a/packages/yak-swc/yak_swc/tests/fixture/object-literal-variable-names/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/object-literal-variable-names/output.prod.tsx
@@ -1,0 +1,23 @@
+import { styled } from "next-yak/internal";
+import * as __yak from "next-yak/internal";
+import "./input.yak.module.css!=!./input?./input.yak.module.css";
+const buttons = {
+    primary: /*YAK Extracted CSS:
+:global(.ym7uBBu) {
+  color: var(--ym7uBBu1);
+}
+*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBu", {
+        "style": {
+            "--ym7uBBu1": ({ $c })=>$c
+        }
+    }),
+    danger: /*YAK Extracted CSS:
+:global(.ym7uBBu2) {
+  color: var(--ym7uBBu3);
+}
+*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBu2", {
+        "style": {
+            "--ym7uBBu3": ({ $c })=>$c
+        }
+    })
+};

--- a/packages/yak-swc/yak_swc/tests/fixture/object-literal-variable-names/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/object-literal-variable-names/output.turbo.dev.tsx
@@ -1,0 +1,27 @@
+import { styled } from "next-yak/internal";
+import * as __yak from "next-yak/internal";
+import "data:text/css;base64,LmlucHV0X2J1dHRvbnNfcHJpbWFyeV9tN3VCQnUgewogIGNvbG9yOiB2YXIoLS1pbnB1dF9idXR0b25zX3ByaW1hcnlfX2NvbG9yX203dUJCdSk7Cn0uaW5wdXRfYnV0dG9uc19kYW5nZXJfbTd1QkJ1IHsKICBjb2xvcjogdmFyKC0taW5wdXRfYnV0dG9uc19kYW5nZXJfX2NvbG9yX203dUJCdSk7Cn0=";
+const buttons = {
+    primary: /*YAK Extracted CSS:
+.input_buttons_primary_m7uBBu {
+  color: var(--input_buttons_primary__color_m7uBBu);
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button("input_buttons_primary_m7uBBu", {
+        "style": {
+            "--input_buttons_primary__color_m7uBBu": ({ $c })=>$c
+        }
+    }), {
+        "displayName": "primary"
+    }),
+    danger: /*YAK Extracted CSS:
+.input_buttons_danger_m7uBBu {
+  color: var(--input_buttons_danger__color_m7uBBu);
+}
+*/ /*#__PURE__*/ Object.assign(/*#__PURE__*/ __yak.__yak_button("input_buttons_danger_m7uBBu", {
+        "style": {
+            "--input_buttons_danger__color_m7uBBu": ({ $c })=>$c
+        }
+    }), {
+        "displayName": "danger"
+    })
+};

--- a/packages/yak-swc/yak_swc/tests/fixture/object-literal-variable-names/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/object-literal-variable-names/output.turbo.prod.tsx
@@ -1,0 +1,23 @@
+import { styled } from "next-yak/internal";
+import * as __yak from "next-yak/internal";
+import "data:text/css;base64,LnltN3VCQnUgewogIGNvbG9yOiB2YXIoLS15bTd1QkJ1MSk7Cn0ueW03dUJCdTIgewogIGNvbG9yOiB2YXIoLS15bTd1QkJ1Myk7Cn0=";
+const buttons = {
+    primary: /*YAK Extracted CSS:
+.ym7uBBu {
+  color: var(--ym7uBBu1);
+}
+*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBu", {
+        "style": {
+            "--ym7uBBu1": ({ $c })=>$c
+        }
+    }),
+    danger: /*YAK Extracted CSS:
+.ym7uBBu2 {
+  color: var(--ym7uBBu3);
+}
+*/ /*#__PURE__*/ __yak.__yak_button("ym7uBBu2", {
+        "style": {
+            "--ym7uBBu3": ({ $c })=>$c
+        }
+    })
+};


### PR DESCRIPTION
Resolves the TODO from https://github.com/DigitecGalaxus/next-yak/pull/626#discussion_r3795844361

A styled component declared in an object literal named its dev CSS variables after the base object only:

```tsx
const buttons = {
  primary: styled.button`color: ${({ $c }) => $c};`,
  danger: styled.button`color: ${({ $c }) => $c};`,
};
```

gave `--input_buttons__color` and `--input_buttons__color-01` - in devtools you can't tell which is which. The variable name now uses the same path as the class name: `--input_buttons_primary__color` and `--input_buttons_danger__color`.

Dev mode only, prod names stay pure hashes. No existing fixture changed; the new object-literal fixture locks the behavior in.