### PR TITLE
Strip $-prefixed props when folding to a plain element

### DIFF
--- a/.changeset/fold-drop-transient-props.md
+++ b/.changeset/fold-drop-transient-props.md
@@ -1,0 +1,5 @@
+---
+"yak-swc": patch
+---
+
+Folding a static styled component into a plain element now drops its `$`-prefixed props, like the runtime does. They no longer reach the DOM, so React stops warning about unknown attributes. A fold to a wrapped component still forwards them - that component may read them for its own class names.

--- a/.changeset/fold-drop-transient-props.md
+++ b/.changeset/fold-drop-transient-props.md
@@ -2,4 +2,4 @@
 "yak-swc": patch
 ---
 
-Folding a static styled component into a plain element now drops its `$`-prefixed props, like the runtime does. They no longer reach the DOM, so React stops warning about unknown attributes. A fold to a wrapped component still forwards them - that component may read them for its own class names.
+Folding a static styled component into a plain element now removes all `$`-prefixed props

--- a/docs/content/docs/folding.mdx
+++ b/docs/content/docs/folding.mdx
@@ -385,7 +385,7 @@ A folded usage is no longer a component, and that has a few visible effects.
 
 - **It does not show in React DevTools or component stacks.** The wrapper is gone, so there is nothing named to display. This holds in development too, so development and production behave the same, and `displayName` has no effect on a folded usage.
 - **`child.type === Card` no longer matches it.** A folded usage is a plain element, so code that compares against the styled component finds a `div`, not `Card`.
-- **Foreign `$`-prefixed props reach the DOM on a fully static fold.** The runtime filters unknown `$props`; a fully static folded usage forwards them to the element instead. A class-toggling fold drops all `$props`, exactly as the runtime does.
+- **`$`-prefixed props are dropped when the fold produces a plain element**, exactly as the runtime drops them before the DOM. A fold to a wrapped component keeps them, because that component may still read them for its own class names.
 - **Prop expressions run the same number of times, in the same order, as the original JSX.** The two exceptions are cases React's own purity rule already forbids: an unread `$prop` is dropped without running, and a getter behind a member read (`$a={obj.x}`) fires each time a condition reads it.
 
 <Callout type="warn">

--- a/packages/next-yak/CHANGELOG.md
+++ b/packages/next-yak/CHANGELOG.md
@@ -31,9 +31,7 @@
   const App = () => <Icon $active={on} />;
 
   // compiles to
-  const App = () => (
-    <span className={"yak-icon" + (on ? " yak-icon--active" : "")} />
-  );
+  const App = () => <span className={"yak-icon" + (on ? " yak-icon--active" : "")} />;
   ```
 
   What folds:

--- a/packages/yak-swc/CHANGELOG.md
+++ b/packages/yak-swc/CHANGELOG.md
@@ -30,9 +30,7 @@
   const App = () => <Icon $active={on} />;
 
   // compiles to
-  const App = () => (
-    <span className={"yak-icon" + (on ? " yak-icon--active" : "")} />
-  );
+  const App = () => <span className={"yak-icon" + (on ? " yak-icon--active" : "")} />;
   ```
 
   What folds:
@@ -50,7 +48,7 @@
 ### Patch Changes
 
 - 011ace5: A `className` string next to a `css` prop kept its JSX encoding: `className="Food &amp; Drink"` rendered the entity into the DOM class, and a backslash class like `before:content-['\2713']` broke the build with a SyntaxError. The value now reaches the DOM exactly as written.
-- eebca6f: Drop empty css props at build time instead of emitting a dead class name, e.g. ` <div css={css``} /> ` becomes `<div />` and an empty ternary arm folds to `""`. A nested empty ` css` `` also folds to an empty class name instead of keeping the whole css prop on the runtime merge path.
+- eebca6f: Drop empty css props at build time instead of emitting a dead class name, e.g. `<div css={css``} />` becomes `<div />` and an empty ternary arm folds to `""`. A nested empty ` css` `` also folds to an empty class name instead of keeping the whole css prop on the runtime merge path.
 - 06a6c95: A folded `className` merge keeps the user's class name exactly as written: backslashes, HTML entities and emoji reach the DOM byte for byte.
 
 ## 9.6.0

--- a/packages/yak-swc/yak_swc/src/utils/fold/usage.rs
+++ b/packages/yak-swc/yak_swc/src/utils/fold/usage.rs
@@ -131,9 +131,11 @@ impl FoldVisitor<'_> {
         attr.value = Some(value);
       }
     }
-    // the class-toggling expressions consumed the $props at compile time -
-    // drop them all like the runtime does before the DOM
-    if !component.runtime_expressions.is_empty() {
+    // the runtime strips every $prop before the element, so a fold to a plain
+    // element has to as well - the class-toggling expressions already consumed
+    // the ones they read at compile time. A component target keeps them: it may
+    // be a yak component which still has to read them for its own classes
+    if matches!(component.target, FoldTarget::Native(_)) {
       n.opening.attrs.retain(|attr| !is_transient_prop(attr));
     }
     plan.bindings
@@ -396,10 +398,10 @@ impl FoldVisitor<'_> {
   /// Checks all attributes and computes the folded className value
   /// Returns `None` if the usage is not foldable
   ///
-  /// All other attributes (style, ref, event handlers, $props of fully
-  /// static components) are forwarded unchanged - a fully static styled
-  /// component passes them through to the DOM element or the wrapped
-  /// component. Foreign $props are treated as user error and not filtered out
+  /// All other attributes (style, ref, event handlers) are forwarded
+  /// unchanged - a fully static styled component passes them through to the
+  /// DOM element or the wrapped component. $props are dropped from a fold to a
+  /// plain element, like the runtime drops them before the DOM
   fn fold_attrs(
     &mut self,
     attrs: &[JSXAttrOrSpread],

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/input.tsx
@@ -97,6 +97,12 @@ const Cases = () => (
     {/* static component: a string className merges at compile time */}
     <Card className="user">static merge</Card>
 
+    {/* a static component reads no prop, so its $props are dropped with their
+        values - an unread $prop never evaluates, like on a dynamic component */}
+    <Card $unread={f()} id={g()}>
+      static component drops the unread transient prop
+    </Card>
+
     {/* the chain collapses, so the usage folds to a plain div */}
     <Fancy className="extra">wrapper fold</Fancy>
 

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.dev.tsx
@@ -107,6 +107,12 @@ const Cases = ()=><>
     { /* static component: a string className merges at compile time */ }
     <div className={"input_Card_m7uBBu user"}>static merge</div>
 
+    { /* a static component reads no prop, so its $props are dropped with their
+        values - an unread $prop never evaluates, like on a dynamic component */ }
+    <div id={g()} className="input_Card_m7uBBu">
+      static component drops the unread transient prop
+    </div>
+
     { /* the chain collapses, so the usage folds to a plain div */ }
     <div className={"input_Card_m7uBBu input_Fancy_m7uBBu extra"}>wrapper fold</div>
 

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.prod.tsx
@@ -93,6 +93,12 @@ const Cases = ()=><>
     { /* static component: a string className merges at compile time */ }
     <div className={"ym7uBBu7 user"}>static merge</div>
 
+    { /* a static component reads no prop, so its $props are dropped with their
+        values - an unread $prop never evaluates, like on a dynamic component */ }
+    <div id={g()} className="ym7uBBu7">
+      static component drops the unread transient prop
+    </div>
+
     { /* the chain collapses, so the usage folds to a plain div */ }
     <div className={"ym7uBBu7 ym7uBBu8 extra"}>wrapper fold</div>
 

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.turbo.dev.tsx
@@ -107,6 +107,12 @@ const Cases = ()=><>
     { /* static component: a string className merges at compile time */ }
     <div className={"input_Card_m7uBBu user"}>static merge</div>
 
+    { /* a static component reads no prop, so its $props are dropped with their
+        values - an unread $prop never evaluates, like on a dynamic component */ }
+    <div id={g()} className="input_Card_m7uBBu">
+      static component drops the unread transient prop
+    </div>
+
     { /* the chain collapses, so the usage folds to a plain div */ }
     <div className={"input_Card_m7uBBu input_Fancy_m7uBBu extra"}>wrapper fold</div>
 

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding-tricky/output.turbo.prod.tsx
@@ -93,6 +93,12 @@ const Cases = ()=><>
     { /* static component: a string className merges at compile time */ }
     <div className={"ym7uBBu7 user"}>static merge</div>
 
+    { /* a static component reads no prop, so its $props are dropped with their
+        values - an unread $prop never evaluates, like on a dynamic component */ }
+    <div id={g()} className="ym7uBBu7">
+      static component drops the unread transient prop
+    </div>
+
     { /* the chain collapses, so the usage folds to a plain div */ }
     <div className={"ym7uBBu7 ym7uBBu8 extra"}>wrapper fold</div>
 

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/input.tsx
@@ -140,7 +140,10 @@ const Optimizable = ({ active }: { active?: boolean }) => (
     </Card>
     <Card className="user">static class name merge</Card>
     <Card className={active && "active"}>runtime class name merge</Card>
-    <Card $foo="forwarded">$props are not filtered</Card>
+    <Card $foo="dropped">$props never reach the element</Card>
+    <Card $bare $value={active} className="user">
+      every $prop is dropped, whatever its value
+    </Card>
     <Card
       css={css`
         color: orange;
@@ -155,12 +158,20 @@ const Optimizable = ({ active }: { active?: boolean }) => (
     <Cast>folds through the type cast</Cast>
     <Extended>collapses to a plain div</Extended>
     <Extended className="user">collapses and merges the className</Extended>
-    <ExtendedTwice>collapses the whole three-level chain</ExtendedTwice>
+    <ExtendedTwice $deep>
+      collapses the whole three-level chain and drops the $prop
+    </ExtendedTwice>
     <FancyTitle>collapses the exported chain</FancyTitle>
-    <OfDynamic>folds to the dynamic parent, chain not collapsed</OfDynamic>
-    <OfAttrs>folds to the attrs parent, chain not collapsed</OfAttrs>
+    <OfDynamic $on={active}>
+      folds to the dynamic parent, which still reads the $prop
+    </OfDynamic>
+    <OfAttrs $foo="kept">
+      folds to the attrs parent, which strips the $prop at runtime
+    </OfAttrs>
     <OfLater>folds to the later-declared parent, chain not collapsed</OfLater>
-    <ExtendedImport>folds to the imported component</ExtendedImport>
+    <ExtendedImport $on={active}>
+      folds to the imported component, which may read the $prop
+    </ExtendedImport>
     <BoxWithMixin>folds with mixin</BoxWithMixin>
   </>
 );

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.dev.tsx
@@ -219,7 +219,10 @@ const Optimizable = ({ active }: {
     </div>
     <div className={"input_Card_m7uBBu user"}>static class name merge</div>
     <div className={__yak_mergeClassNames("input_Card_m7uBBu", active && "active")}>runtime class name merge</div>
-    <div $foo="forwarded" className="input_Card_m7uBBu">$props are not filtered</div>
+    <div className="input_Card_m7uBBu">$props never reach the element</div>
+    <div className={"input_Card_m7uBBu user"}>
+      every $prop is dropped, whatever its value
+    </div>
     <div className={/*YAK Extracted CSS:
 :global(.input_Optimizable_m7uBBu) {
   color: orange;
@@ -234,12 +237,20 @@ const Optimizable = ({ active }: {
     <div className="input_Cast_m7uBBu">folds through the type cast</div>
     <div className="input_Card_m7uBBu input_Extended_m7uBBu">collapses to a plain div</div>
     <div className={"input_Card_m7uBBu input_Extended_m7uBBu user"}>collapses and merges the className</div>
-    <div className="input_Card_m7uBBu input_Extended_m7uBBu input_ExtendedTwice_m7uBBu">collapses the whole three-level chain</div>
+    <div className="input_Card_m7uBBu input_Extended_m7uBBu input_ExtendedTwice_m7uBBu">
+      collapses the whole three-level chain and drops the $prop
+    </div>
     <h1 className="input_Title_m7uBBu input_FancyTitle_m7uBBu">collapses the exported chain</h1>
-    <ToggleBase className="input_OfDynamic_m7uBBu">folds to the dynamic parent, chain not collapsed</ToggleBase>
-    <WithAttrs className="input_OfAttrs_m7uBBu">folds to the attrs parent, chain not collapsed</WithAttrs>
+    <ToggleBase $on={active} className="input_OfDynamic_m7uBBu">
+      folds to the dynamic parent, which still reads the $prop
+    </ToggleBase>
+    <WithAttrs $foo="kept" className="input_OfAttrs_m7uBBu">
+      folds to the attrs parent, which strips the $prop at runtime
+    </WithAttrs>
     <Later className="input_OfLater_m7uBBu">folds to the later-declared parent, chain not collapsed</Later>
-    <ImportedCard className="input_ExtendedImport_m7uBBu">folds to the imported component</ImportedCard>
+    <ImportedCard $on={active} className="input_ExtendedImport_m7uBBu">
+      folds to the imported component, which may read the $prop
+    </ImportedCard>
     <div className="input_BoxWithMixin_m7uBBu">folds with mixin</div>
   </>;
 // bails: wrapped in React.memo - the HOC result must not fold to a bare DOM element

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.prod.tsx
@@ -171,7 +171,10 @@ const Optimizable = ({ active }: {
     </div>
     <div className={"ym7uBBu1 user"}>static class name merge</div>
     <div className={__yak_mergeClassNames("ym7uBBu1", active && "active")}>runtime class name merge</div>
-    <div $foo="forwarded" className="ym7uBBu1">$props are not filtered</div>
+    <div className="ym7uBBu1">$props never reach the element</div>
+    <div className={"ym7uBBu1 user"}>
+      every $prop is dropped, whatever its value
+    </div>
     <div className={/*YAK Extracted CSS:
 :global(.ym7uBBuR) {
   color: orange;
@@ -186,12 +189,20 @@ const Optimizable = ({ active }: {
     <div className="ym7uBBuP">folds through the type cast</div>
     <div className="ym7uBBu1 ym7uBBu7">collapses to a plain div</div>
     <div className={"ym7uBBu1 ym7uBBu7 user"}>collapses and merges the className</div>
-    <div className="ym7uBBu1 ym7uBBu7 ym7uBBu8">collapses the whole three-level chain</div>
+    <div className="ym7uBBu1 ym7uBBu7 ym7uBBu8">
+      collapses the whole three-level chain and drops the $prop
+    </div>
     <h1 className="ym7uBBu3 ym7uBBu9">collapses the exported chain</h1>
-    <ToggleBase className="ym7uBBuD">folds to the dynamic parent, chain not collapsed</ToggleBase>
-    <WithAttrs className="ym7uBBuE">folds to the attrs parent, chain not collapsed</WithAttrs>
+    <ToggleBase $on={active} className="ym7uBBuD">
+      folds to the dynamic parent, which still reads the $prop
+    </ToggleBase>
+    <WithAttrs $foo="kept" className="ym7uBBuE">
+      folds to the attrs parent, which strips the $prop at runtime
+    </WithAttrs>
     <Later className="ym7uBBuJ">folds to the later-declared parent, chain not collapsed</Later>
-    <ImportedCard className="ym7uBBuA">folds to the imported component</ImportedCard>
+    <ImportedCard $on={active} className="ym7uBBuA">
+      folds to the imported component, which may read the $prop
+    </ImportedCard>
     <div className="ym7uBBuQ">folds with mixin</div>
   </>;
 // bails: wrapped in React.memo - the HOC result must not fold to a bare DOM element

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.dev.tsx
@@ -219,7 +219,10 @@ const Optimizable = ({ active }: {
     </div>
     <div className={"input_Card_m7uBBu user"}>static class name merge</div>
     <div className={__yak_mergeClassNames("input_Card_m7uBBu", active && "active")}>runtime class name merge</div>
-    <div $foo="forwarded" className="input_Card_m7uBBu">$props are not filtered</div>
+    <div className="input_Card_m7uBBu">$props never reach the element</div>
+    <div className={"input_Card_m7uBBu user"}>
+      every $prop is dropped, whatever its value
+    </div>
     <div className={/*YAK Extracted CSS:
 .input_Optimizable_m7uBBu {
   color: orange;
@@ -234,12 +237,20 @@ const Optimizable = ({ active }: {
     <div className="input_Cast_m7uBBu">folds through the type cast</div>
     <div className="input_Card_m7uBBu input_Extended_m7uBBu">collapses to a plain div</div>
     <div className={"input_Card_m7uBBu input_Extended_m7uBBu user"}>collapses and merges the className</div>
-    <div className="input_Card_m7uBBu input_Extended_m7uBBu input_ExtendedTwice_m7uBBu">collapses the whole three-level chain</div>
+    <div className="input_Card_m7uBBu input_Extended_m7uBBu input_ExtendedTwice_m7uBBu">
+      collapses the whole three-level chain and drops the $prop
+    </div>
     <h1 className="input_Title_m7uBBu input_FancyTitle_m7uBBu">collapses the exported chain</h1>
-    <ToggleBase className="input_OfDynamic_m7uBBu">folds to the dynamic parent, chain not collapsed</ToggleBase>
-    <WithAttrs className="input_OfAttrs_m7uBBu">folds to the attrs parent, chain not collapsed</WithAttrs>
+    <ToggleBase $on={active} className="input_OfDynamic_m7uBBu">
+      folds to the dynamic parent, which still reads the $prop
+    </ToggleBase>
+    <WithAttrs $foo="kept" className="input_OfAttrs_m7uBBu">
+      folds to the attrs parent, which strips the $prop at runtime
+    </WithAttrs>
     <Later className="input_OfLater_m7uBBu">folds to the later-declared parent, chain not collapsed</Later>
-    <ImportedCard className="input_ExtendedImport_m7uBBu">folds to the imported component</ImportedCard>
+    <ImportedCard $on={active} className="input_ExtendedImport_m7uBBu">
+      folds to the imported component, which may read the $prop
+    </ImportedCard>
     <div className="input_BoxWithMixin_m7uBBu">folds with mixin</div>
   </>;
 // bails: wrapped in React.memo - the HOC result must not fold to a bare DOM element

--- a/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/styled-jsx-folding/output.turbo.prod.tsx
@@ -171,7 +171,10 @@ const Optimizable = ({ active }: {
     </div>
     <div className={"ym7uBBu1 user"}>static class name merge</div>
     <div className={__yak_mergeClassNames("ym7uBBu1", active && "active")}>runtime class name merge</div>
-    <div $foo="forwarded" className="ym7uBBu1">$props are not filtered</div>
+    <div className="ym7uBBu1">$props never reach the element</div>
+    <div className={"ym7uBBu1 user"}>
+      every $prop is dropped, whatever its value
+    </div>
     <div className={/*YAK Extracted CSS:
 .ym7uBBuR {
   color: orange;
@@ -186,12 +189,20 @@ const Optimizable = ({ active }: {
     <div className="ym7uBBuP">folds through the type cast</div>
     <div className="ym7uBBu1 ym7uBBu7">collapses to a plain div</div>
     <div className={"ym7uBBu1 ym7uBBu7 user"}>collapses and merges the className</div>
-    <div className="ym7uBBu1 ym7uBBu7 ym7uBBu8">collapses the whole three-level chain</div>
+    <div className="ym7uBBu1 ym7uBBu7 ym7uBBu8">
+      collapses the whole three-level chain and drops the $prop
+    </div>
     <h1 className="ym7uBBu3 ym7uBBu9">collapses the exported chain</h1>
-    <ToggleBase className="ym7uBBuD">folds to the dynamic parent, chain not collapsed</ToggleBase>
-    <WithAttrs className="ym7uBBuE">folds to the attrs parent, chain not collapsed</WithAttrs>
+    <ToggleBase $on={active} className="ym7uBBuD">
+      folds to the dynamic parent, which still reads the $prop
+    </ToggleBase>
+    <WithAttrs $foo="kept" className="ym7uBBuE">
+      folds to the attrs parent, which strips the $prop at runtime
+    </WithAttrs>
     <Later className="ym7uBBuJ">folds to the later-declared parent, chain not collapsed</Later>
-    <ImportedCard className="ym7uBBuA">folds to the imported component</ImportedCard>
+    <ImportedCard $on={active} className="ym7uBBuA">
+      folds to the imported component, which may read the $prop
+    </ImportedCard>
     <div className="ym7uBBuQ">folds with mixin</div>
   </>;
 // bails: wrapped in React.memo - the HOC result must not fold to a bare DOM element


### PR DESCRIPTION
Fixes #622

The strip was gated on the component being dynamic, so a fully static `styled.a` kept its `$props` on the folded DOM element and React warned about them. Gate it on the fold target instead: plain elements drop them, component targets keep forwarding them because a yak parent still reads them for its own class names.