### PR TITLE
Handle css props strict where possible

### DIFF
--- a/.changeset/clear-eels-fix.md
+++ b/.changeset/clear-eels-fix.md
@@ -1,0 +1,6 @@
+---
+"next-yak": patch
+"yak-swc": patch
+---
+
+Reject `css` prop values which can not apply styles (e.g. `css={[a, b]}` or `css={{ color: "red" }}`)

--- a/docs/content/docs/features.mdx
+++ b/docs/content/docs/features.mdx
@@ -783,6 +783,35 @@ It's meant for simple styling requirements, where you don't have to think about 
 
 The `css` prop is allowed on any element that can accept `className` and `style`.
 
+Its value has to be styles written in place: a `css` template or an `atoms()` call and logical combinations of them.
+Everything else fails the build, because next-yak only compiles the styles it sees on the element.
+To combine several styles, nest them in one template instead of passing an array:
+
+```jsx title="my-component.tsx"
+const base = css`
+  color: red;
+`;
+const highlight = css`
+  font-weight: bold;
+`;
+
+const Component = () => {
+  return (
+    <div
+      css={css`
+        ${base};
+        ${highlight};
+      `}
+    >
+      Hello there!
+    </div>
+  );
+};
+```
+
+Set the `strictCssProp` option to `false` to leave unsupported values untouched instead, for
+example when another library on the same element owns the `css` prop.
+
 If you prefer working with the utility first approach, you can use our `atoms` function in conjunction with the `css` prop.
 
 ```jsx title="my-component.tsx"

--- a/packages/next-yak/runtime/__tests__/cssProp.test.tsx
+++ b/packages/next-yak/runtime/__tests__/cssProp.test.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { it, expect } from "vitest";
+import { it, expect, describe, beforeEach, afterEach } from "vitest";
 import { mergeCssProp } from "../internals/mergeCssProp";
 import { css } from "../cssLiteral";
 import { atoms } from "../atoms";
@@ -334,5 +334,37 @@ it("keeps the relevant props when the css prop is falsy", async () => {
   expect(mergeCssProp({ className: "btn", style: { padding: "8px" } }, false)).toMatchObject({
     className: "btn",
     style: { padding: "8px" },
+  });
+});
+
+describe("a css prop which can not apply styles", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    // errors are only thrown in development mode
+    process.env.NODE_ENV = "development";
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it("throws for an array instead of calling it", () => {
+    expect(() => mergeCssProp({}, [css("yakCss1")])).toThrowError(/but received an array/);
+  });
+
+  it("throws for an object instead of calling it", () => {
+    expect(() => mergeCssProp({}, { color: "red" })).toThrowError(
+      /but received a value of type object/,
+    );
+  });
+
+  it("throws for a plain string instead of calling it", () => {
+    expect(() => mergeCssProp({}, "yakCss1")).toThrowError(/but received a value of type string/);
+  });
+
+  it("renders unstyled in production instead of taking the page down", () => {
+    process.env.NODE_ENV = "production";
+    expect(mergeCssProp({ className: "btn" }, [css("yakCss1")])).toEqual({ className: "btn" });
   });
 });

--- a/packages/next-yak/runtime/internals/mergeCssProp.ts
+++ b/packages/next-yak/runtime/internals/mergeCssProp.ts
@@ -26,9 +26,21 @@ export const mergeCssProp = (
   const existingStyle = relevantProps.style;
   const style = existingStyle ? { ...existingStyle } : {};
 
-  // a falsy css prop applies no styles, e.g. `css={on && css`...`}` with `on` false
-  if (cssProp) {
+  // only a style function applies styles. A falsy css prop applies none,
+  // e.g. `css={on && css`...`}` with `on` false
+  if (typeof cssProp === "function") {
     cssProp({}, classNames, style);
+  } else if (cssProp) {
+    // The swc plugin rejects a value which can not apply styles at build time,
+    // so this only runs where it can not see one during build time.
+    if (process.env.NODE_ENV === "development") {
+      const received: unknown = cssProp;
+      throw new Error(
+        `The css prop only applies styles written in place, but received ${
+          Array.isArray(received) ? "an array" : `a value of type ${typeof received}`
+        }.\n\nCombine several styles in one template instead of an array: css={css\`\${first} \${second}\`}\nWrite declarations in a template instead of an object: css={css\`color: red;\`}`,
+      );
+    }
   }
 
   // Forward all other props (onClick, aria-*, id, …) untouched and only

--- a/packages/next-yak/withYak/index.ts
+++ b/packages/next-yak/withYak/index.ts
@@ -37,8 +37,8 @@ export type YakConfigOptions = {
   foldStatic?: boolean;
   /**
    * Fail the build when a `css` prop has a value next-yak can't handle
-   * (e.g. a plain string). next-yak claims the `css` prop, so a malformed
-   * value is almost always a mistake worth surfacing.
+   * (e.g. an array, an object or a plain string). next-yak claims the `css`
+   * prop, so a malformed value is almost always a mistake worth surfacing.
    *
    * Set to `false` to leave such props untouched instead, e.g. when another
    * library on the same element uses its own `css` prop.

--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -91,10 +91,10 @@ pub struct Config {
   #[serde(default = "Config::fold_static_default")]
   pub fold_static: bool,
   /// Fail the build when a `css` prop has a value next-yak can't handle
-  /// (e.g. a plain string). Enabled by default: next-yak claims the `css` prop,
-  /// so a malformed value is almost always a mistake worth surfacing. Set to
-  /// false to leave such props untouched instead, e.g. when another library on
-  /// the same element uses its own `css` prop.
+  /// (e.g. an array, an object or a plain string). Enabled by default: next-yak
+  /// claims the `css` prop, so a malformed value is almost always a mistake
+  /// worth surfacing. Set to false to leave such props untouched instead, e.g.
+  /// when another library on the same element uses its own `css` prop.
   #[serde(default = "Config::strict_css_prop_default")]
   pub strict_css_prop: bool,
 }

--- a/packages/yak-swc/yak_swc/src/utils/fold/css_expr.rs
+++ b/packages/yak-swc/yak_swc/src/utils/fold/css_expr.rs
@@ -213,6 +213,23 @@ pub(super) fn is_yak_css_callee(callee: &Callee, yak_imports: &YakImports) -> bo
   }
 }
 
+/// Matches a callee that resolves to a yak style function: `css`, which an
+/// inline template compiles to, or `atoms`
+pub(super) fn is_yak_style_callee(callee: &Callee, yak_imports: &YakImports) -> bool {
+  if is_yak_css_callee(callee, yak_imports) {
+    return true;
+  }
+  match callee {
+    Callee::Expr(expr) => match unwrap_type_casts(expr) {
+      Expr::Ident(ident) => {
+        yak_imports.get_yak_library_name_for_ident(&ident.to_id()) == Some("atoms".into())
+      }
+      _ => false,
+    },
+    _ => false,
+  }
+}
+
 /// Joins two class names with a single space, e.g. `"a"` and `"b"` -> `"a b"`
 ///
 /// Concatenates at the WTF-8 level so a user class name is copied byte for byte:

--- a/packages/yak-swc/yak_swc/src/utils/fold/css_prop.rs
+++ b/packages/yak-swc/yak_swc/src/utils/fold/css_prop.rs
@@ -74,60 +74,64 @@ impl CSSProp {
     if fold_static && self.try_fold(opening_element, yak_imports) {
       return;
     }
-    let merge_ident = yak_imports.get_yak_utility_ident("mergeCssProp");
-    // Build the replacement from borrowed attributes first, without mutating the
-    // element. That way an invalid `css` prop can be left completely untouched
-    // when strict mode is off (it might belong to another library, not next-yak).
-    let merge_call: Result<Box<Expr>, TransformError> = (|| {
-      let css_expr =
-        Self::extract_css_expr(&opening_element.attrs[self.index], opening_element.span)?;
-      Self::validate_css_value(&css_expr, yak_imports)?;
-      let mapped_props = self
-        .relevant_props
-        .iter()
-        .map(|&(index, _)| match &opening_element.attrs[index] {
-          JSXAttrOrSpread::JSXAttr(attr) => Self::map_jsx_attr(attr),
-          JSXAttrOrSpread::SpreadElement(spread) => Ok(PropOrSpread::Spread(spread.clone())),
-          #[cfg(swc_ast_unknown)]
-          _ => Err(TransformError::UnsupportedJSXAttrOrSpread()),
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-      Ok(Self::create_merge_call(
-        &mapped_props,
-        css_expr,
-        &merge_ident,
-      ))
-    })();
-
-    let merge_call = match merge_call {
-      Ok(merge_call) => merge_call,
-      Err(err) => {
-        // Strict mode (default): a `css` prop next-yak can't handle is almost
-        // always a mistake in a next-yak project, so fail loudly. Otherwise leave
-        // the element untouched so unrelated `css` props keep working.
-        if strict_css_prop {
-          HANDLER.with(|handler| {
-            handler.struct_span_err(err.span(), err.message()).emit();
-          });
-        }
-        return;
+    // The parts are collected from borrowed attributes before anything is
+    // mutated, so both outcomes below start from the element as written.
+    match self.collect_merge_parts(opening_element, yak_imports) {
+      // We own this css prop and replaces it with the merge call
+      Ok((relevant_props, css_expr)) => {
+        let merge_ident = yak_imports.get_yak_utility_ident("mergeCssProp");
+        let merge_call = Self::create_merge_call(&relevant_props, css_expr, &merge_ident);
+        self.replace_with_merge_call(opening_element, merge_call);
       }
-    };
+      // We can't compile this value, so the element keeps every attribute as written
+      // and another library on it can still own the css prop.
+      // Default strict mode reports the value on top, since in a next-yak project it is almost always a mistake.
+      Err(unsupported) => {
+        if strict_css_prop {
+          unsupported.report();
+        }
+      }
+    }
+  }
 
-    // Validation succeeded — remove the consumed attributes and insert the spread.
+  fn collect_merge_parts(
+    &self,
+    opening_element: &JSXOpeningElement,
+    yak_imports: &YakImports,
+  ) -> Result<(Vec<PropOrSpread>, Box<Expr>), UnsupportedCssProp> {
+    let css_expr =
+      Self::extract_css_expr(&opening_element.attrs[self.index], opening_element.span)?;
+    Self::validate_css_value(&css_expr, yak_imports)?;
+    let relevant_props = self
+      .relevant_props
+      .iter()
+      .map(|&(index, _)| match &opening_element.attrs[index] {
+        JSXAttrOrSpread::JSXAttr(attr) => Self::map_jsx_attr(attr),
+        JSXAttrOrSpread::SpreadElement(spread) => Ok(PropOrSpread::Spread(spread.clone())),
+        #[cfg(swc_ast_unknown)]
+        _ => Err(UnsupportedCssProp::UnsupportedJSXAttrOrSpread()),
+      })
+      .collect::<Result<Vec<_>, _>>()?;
+    Ok((relevant_props, css_expr))
+  }
+
+  /// Swaps the css prop and the props merged into it for the merge call spread
+  fn replace_with_merge_call(
+    &self,
+    opening_element: &mut JSXOpeningElement,
+    merge_call: Box<Expr>,
+  ) {
     opening_element.attrs.remove(self.index);
     for &(index, _) in self.relevant_props.iter().rev() {
       let adjusted_index = if index > self.index { index - 1 } else { index };
       opening_element.attrs.remove(adjusted_index);
     }
-    let insert_index = opening_element.attrs.len();
-    opening_element.attrs.insert(
-      insert_index,
-      JSXAttrOrSpread::SpreadElement(SpreadElement {
+    opening_element
+      .attrs
+      .push(JSXAttrOrSpread::SpreadElement(SpreadElement {
         dot3_token: DUMMY_SP,
         expr: merge_call,
-      }),
-    );
+      }));
   }
 
   /// Replaces a statically known css prop with a plain className attribute
@@ -197,7 +201,7 @@ impl CSSProp {
   /// inline css template (already transformed into a `css(...)` call when this
   /// runs), an `atoms(...)` call and the falsy values, which apply no styles.
   /// Everything else is rejected here.
-  fn validate_css_value(expr: &Expr, yak_imports: &YakImports) -> Result<(), TransformError> {
+  fn validate_css_value(expr: &Expr, yak_imports: &YakImports) -> Result<(), UnsupportedCssProp> {
     match unwrap_type_casts(expr) {
       Expr::Cond(cond) => {
         Self::validate_css_value(&cond.cons, yak_imports)?;
@@ -219,53 +223,56 @@ impl CSSProp {
       Expr::Ident(ident) if ident.sym == "undefined" => Ok(()),
       // a reference to styles declared elsewhere keeps its own message. It is
       // fixed by wrapping the reference in a css template
-      Expr::Ident(ident) => Err(TransformError::StyleReference(ident.span)),
-      Expr::Member(member) => Err(TransformError::StyleReference(member.span)),
-      Expr::OptChain(opt_chain) => Err(TransformError::StyleReference(opt_chain.span)),
-      unsupported => Err(TransformError::UnsupportedCssValue(unsupported.span())),
+      Expr::Ident(ident) => Err(UnsupportedCssProp::StyleReference(ident.span)),
+      Expr::Member(member) => Err(UnsupportedCssProp::StyleReference(member.span)),
+      Expr::OptChain(opt_chain) => Err(UnsupportedCssProp::StyleReference(opt_chain.span)),
+      unsupported => Err(UnsupportedCssProp::UnsupportedValue(unsupported.span())),
     }
   }
 
   /// Extracts the CSS expression from a JSX attribute or spread element.
-  fn extract_css_expr(attr: &JSXAttrOrSpread, span: Span) -> Result<Box<Expr>, TransformError> {
+  fn extract_css_expr(attr: &JSXAttrOrSpread, span: Span) -> Result<Box<Expr>, UnsupportedCssProp> {
     match attr {
       JSXAttrOrSpread::JSXAttr(jsx_attr) => jsx_attr
         .value
         .as_ref()
-        .ok_or(TransformError::InvalidCSSAttribute(span))
+        .ok_or(UnsupportedCssProp::InvalidCSSAttribute(span))
         .and_then(|value| match value {
           JSXAttrValue::JSXExprContainer(container) => match &container.expr {
             JSXExpr::Expr(expr) => Ok(expr.clone()),
-            _ => Err(TransformError::InvalidCSSAttribute(container.span)),
+            _ => Err(UnsupportedCssProp::InvalidCSSAttribute(container.span)),
           },
-          _ => Err(TransformError::InvalidCSSAttribute(span)),
+          _ => Err(UnsupportedCssProp::InvalidCSSAttribute(span)),
         }),
-      JSXAttrOrSpread::SpreadElement(_) => Err(TransformError::UnsupportedSpreadElement(span)),
+      JSXAttrOrSpread::SpreadElement(_) => Err(UnsupportedCssProp::UnsupportedSpreadElement(span)),
       #[cfg(swc_ast_unknown)]
-      _ => Err(TransformError::UnsupportedSpreadElement(span)),
+      _ => Err(UnsupportedCssProp::UnsupportedSpreadElement(span)),
     }
   }
 
   /// Maps a single JSX attribute to a PropOrSpread element.
   /// This is used to convert a JSX attribute to an object property for the merge call.
   /// e.g. `style={{color: red}}` becomes `{style: {color: red}}`
-  fn map_jsx_attr(attr: &JSXAttr) -> Result<PropOrSpread, TransformError> {
+  fn map_jsx_attr(attr: &JSXAttr) -> Result<PropOrSpread, UnsupportedCssProp> {
     match &attr.name {
       JSXAttrName::Ident(ident) => Ok(PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
         key: PropName::Ident(ident.clone()),
         value: Self::extract_value(&attr.value, attr.span)?,
       })))),
-      _ => Err(TransformError::InvalidJSXAttribute(attr.span)),
+      _ => Err(UnsupportedCssProp::InvalidJSXAttribute(attr.span)),
     }
   }
 
   /// Extracts the value from a JSX attribute.
   /// This handles different types of attribute values and converts them to expressions.
   /// e.g. `style={{color: red}}` becomes `{color: red}`
-  fn extract_value(value: &Option<JSXAttrValue>, span: Span) -> Result<Box<Expr>, TransformError> {
+  fn extract_value(
+    value: &Option<JSXAttrValue>,
+    span: Span,
+  ) -> Result<Box<Expr>, UnsupportedCssProp> {
     value
       .as_ref()
-      .ok_or(TransformError::MissingAttributeValue(span))
+      .ok_or(UnsupportedCssProp::MissingAttributeValue(span))
       .and_then(|v| match v {
         // Drop `raw`: a JSX attribute raw is JSX-encoded text (HTML entities stay
         // encoded, backslashes are literal). Moved into JS expression position it
@@ -277,9 +284,9 @@ impl CSSProp {
         })))),
         JSXAttrValue::JSXExprContainer(container) => match &container.expr {
           JSXExpr::Expr(expr) => Ok(expr.clone()),
-          _ => Err(TransformError::InvalidJSXEmptyExpr(container.span)),
+          _ => Err(UnsupportedCssProp::InvalidJSXEmptyExpr(container.span)),
         },
-        _ => Err(TransformError::UnsupportedAttributeValue(span)),
+        _ => Err(UnsupportedCssProp::UnsupportedAttributeValue(span)),
       })
   }
 
@@ -345,7 +352,7 @@ impl HasCSSProp for JSXOpeningElement {
 }
 
 #[derive(Debug)]
-pub enum TransformError {
+pub enum UnsupportedCssProp {
   InvalidCSSAttribute(Span),
   UnsupportedSpreadElement(Span),
   InvalidJSXAttribute(Span),
@@ -353,60 +360,67 @@ pub enum TransformError {
   InvalidJSXEmptyExpr(Span),
   UnsupportedAttributeValue(Span),
   StyleReference(Span),
-  UnsupportedCssValue(Span),
+  UnsupportedValue(Span),
   #[cfg(swc_ast_unknown)]
   UnsupportedJSXAttrOrSpread(),
 }
 
-impl TransformError {
+impl UnsupportedCssProp {
+  /// Reports the value as a build error
+  fn report(&self) {
+    HANDLER.with(|handler| {
+      handler.struct_span_err(self.span(), self.message()).emit();
+    });
+  }
+
   fn span(&self) -> Span {
     match self {
-      TransformError::InvalidCSSAttribute(span)
-      | TransformError::UnsupportedSpreadElement(span)
-      | TransformError::InvalidJSXAttribute(span)
-      | TransformError::MissingAttributeValue(span)
-      | TransformError::InvalidJSXEmptyExpr(span)
-      | TransformError::UnsupportedAttributeValue(span)
-      | TransformError::StyleReference(span)
-      | TransformError::UnsupportedCssValue(span) => *span,
+      UnsupportedCssProp::InvalidCSSAttribute(span)
+      | UnsupportedCssProp::UnsupportedSpreadElement(span)
+      | UnsupportedCssProp::InvalidJSXAttribute(span)
+      | UnsupportedCssProp::MissingAttributeValue(span)
+      | UnsupportedCssProp::InvalidJSXEmptyExpr(span)
+      | UnsupportedCssProp::UnsupportedAttributeValue(span)
+      | UnsupportedCssProp::StyleReference(span)
+      | UnsupportedCssProp::UnsupportedValue(span) => *span,
       #[cfg(swc_ast_unknown)]
-      TransformError::UnsupportedJSXAttrOrSpread() => Span::default(),
+      UnsupportedCssProp::UnsupportedJSXAttrOrSpread() => Span::default(),
     }
   }
 
   fn message(&self) -> &'static str {
     match self {
-            TransformError::InvalidCSSAttribute(_) =>
+            UnsupportedCssProp::InvalidCSSAttribute(_) =>
                 "Invalid CSS attribute. The 'css' prop should contain a valid CSS-in-JS expression. \
                 Example: css={css`color: red;`}",
 
-            TransformError::UnsupportedSpreadElement(_) =>
+            UnsupportedCssProp::UnsupportedSpreadElement(_) =>
                 "Spread elements are not supported in the 'css' prop. \
                     Instead, use a css template literals for your styles. \
                     Example: css={css`color: red;`}",
 
-            TransformError::InvalidJSXAttribute(_) =>
+            UnsupportedCssProp::InvalidJSXAttribute(_) =>
                 "Invalid JSX attribute detected. Ensure all attributes have valid names and values. \
                 Example: className=\"my-class\" or style={{ color: 'red' }}",
 
-            TransformError::MissingAttributeValue(_) =>
+            UnsupportedCssProp::MissingAttributeValue(_) =>
                 "An attribute is missing its value. All attributes should have a value assigned. \
                 Example: css={styles} or className=\"my-class\"",
 
-            TransformError::InvalidJSXEmptyExpr(_) =>
+            UnsupportedCssProp::InvalidJSXEmptyExpr(_) =>
                 "Invalid empty JSX expression found. Ensure your JSX expressions are valid JavaScript expressions.",
 
-            TransformError::UnsupportedAttributeValue(_) =>
+            UnsupportedCssProp::UnsupportedAttributeValue(_) =>
                 "Unsupported attribute value type. Use string literals for className, \
                 template literals for css prop, and object literals for style prop.",
 
-            TransformError::StyleReference(_) =>
+            UnsupportedCssProp::StyleReference(_) =>
                 "References to styles declared elsewhere are not supported in the 'css' prop - \
                 the referenced styles are not compiled at this usage and would silently never apply. \
                 Wrap the reference in a css template instead. \
                 Example: css={css`${mixin}`}",
 
-            TransformError::UnsupportedCssValue(_) =>
+            UnsupportedCssProp::UnsupportedValue(_) =>
                 "Unsupported value for the 'css' prop. Only styles written in place apply: \
                 a css template, an atoms() call, those combined with ?:, && or ||, \
                 and the falsy values false, null and undefined.\n\
@@ -416,7 +430,7 @@ impl TransformError {
                 Example: css={css`color: red;`}",
 
             #[cfg(swc_ast_unknown)]
-            TransformError::UnsupportedJSXAttrOrSpread() =>
+            UnsupportedCssProp::UnsupportedJSXAttrOrSpread() =>
                 "Unsupported JSX attribute or spread element detected. Ensure all attributes have valid names and values. \
                 Example: className=\"my-class\" or style={{ color: 'red' }}",
         }

--- a/packages/yak-swc/yak_swc/src/utils/fold/css_prop.rs
+++ b/packages/yak-swc/yak_swc/src/utils/fold/css_prop.rs
@@ -3,7 +3,7 @@
 
 use crate::utils::ast_helper::unwrap_type_casts;
 use crate::utils::fold::css_expr::{
-  class_name_attr, expr_attr_value, fold_css_expr, is_yak_css_callee,
+  class_name_attr, expr_attr_value, fold_css_expr, is_yak_css_callee, is_yak_style_callee,
 };
 use crate::yak_imports::YakImports;
 use swc_core::{
@@ -81,9 +81,7 @@ impl CSSProp {
     let merge_call: Result<Box<Expr>, TransformError> = (|| {
       let css_expr =
         Self::extract_css_expr(&opening_element.attrs[self.index], opening_element.span)?;
-      if let Some(span) = Self::find_style_reference(&css_expr) {
-        return Err(TransformError::StyleReference(span));
-      }
+      Self::validate_css_value(&css_expr, yak_imports)?;
       let mapped_props = self
         .relevant_props
         .iter()
@@ -192,28 +190,39 @@ impl CSSProp {
     )
   }
 
-  /// Finds a reference to styles declared elsewhere (`css={mixin}`,
-  /// `css={styles.padding}`) in a css value position - at the top level or in
+  /// Checks that a css value can apply styles, both at the top level and in
   /// the value arms of ternaries and logical expressions
   ///
-  /// Such a reference renders unstyled because the css prop only compiles
-  /// styles in place, so it is rejected via `TransformError::StyleReference`
-  fn find_style_reference(expr: &Expr) -> Option<Span> {
+  /// The css prop only compiles styles written in place, so it accepts an
+  /// inline css template (already transformed into a `css(...)` call when this
+  /// runs), an `atoms(...)` call and the falsy values, which apply no styles.
+  /// Everything else is rejected here.
+  fn validate_css_value(expr: &Expr, yak_imports: &YakImports) -> Result<(), TransformError> {
     match unwrap_type_casts(expr) {
       Expr::Cond(cond) => {
-        Self::find_style_reference(&cond.cons).or_else(|| Self::find_style_reference(&cond.alt))
+        Self::validate_css_value(&cond.cons, yak_imports)?;
+        Self::validate_css_value(&cond.alt, yak_imports)
       }
       // `cond && css` - only the right hand side is a css value
-      Expr::Bin(bin) if bin.op == BinaryOp::LogicalAnd => Self::find_style_reference(&bin.right),
+      Expr::Bin(bin) if bin.op == BinaryOp::LogicalAnd => {
+        Self::validate_css_value(&bin.right, yak_imports)
+      }
       // `a || b` and `a ?? b` - both sides are css values
       Expr::Bin(bin) if matches!(bin.op, BinaryOp::LogicalOr | BinaryOp::NullishCoalescing) => {
-        Self::find_style_reference(&bin.left).or_else(|| Self::find_style_reference(&bin.right))
+        Self::validate_css_value(&bin.left, yak_imports)?;
+        Self::validate_css_value(&bin.right, yak_imports)
       }
-      // `undefined` is a valid falsy css value, any other identifier is a reference
-      Expr::Ident(ident) if ident.sym != "undefined" => Some(ident.span),
-      Expr::Member(member) => Some(member.span()),
-      Expr::OptChain(opt_chain) => Some(opt_chain.span),
-      _ => None,
+      Expr::Call(call) if is_yak_style_callee(&call.callee, yak_imports) => Ok(()),
+      // the falsy css values apply no styles. `true` is not one of them
+      Expr::Lit(Lit::Null(_)) => Ok(()),
+      Expr::Lit(Lit::Bool(bool_lit)) if !bool_lit.value => Ok(()),
+      Expr::Ident(ident) if ident.sym == "undefined" => Ok(()),
+      // a reference to styles declared elsewhere keeps its own message. It is
+      // fixed by wrapping the reference in a css template
+      Expr::Ident(ident) => Err(TransformError::StyleReference(ident.span)),
+      Expr::Member(member) => Err(TransformError::StyleReference(member.span)),
+      Expr::OptChain(opt_chain) => Err(TransformError::StyleReference(opt_chain.span)),
+      unsupported => Err(TransformError::UnsupportedCssValue(unsupported.span())),
     }
   }
 
@@ -344,6 +353,7 @@ pub enum TransformError {
   InvalidJSXEmptyExpr(Span),
   UnsupportedAttributeValue(Span),
   StyleReference(Span),
+  UnsupportedCssValue(Span),
   #[cfg(swc_ast_unknown)]
   UnsupportedJSXAttrOrSpread(),
 }
@@ -357,7 +367,8 @@ impl TransformError {
       | TransformError::MissingAttributeValue(span)
       | TransformError::InvalidJSXEmptyExpr(span)
       | TransformError::UnsupportedAttributeValue(span)
-      | TransformError::StyleReference(span) => *span,
+      | TransformError::StyleReference(span)
+      | TransformError::UnsupportedCssValue(span) => *span,
       #[cfg(swc_ast_unknown)]
       TransformError::UnsupportedJSXAttrOrSpread() => Span::default(),
     }
@@ -394,6 +405,15 @@ impl TransformError {
                 the referenced styles are not compiled at this usage and would silently never apply. \
                 Wrap the reference in a css template instead. \
                 Example: css={css`${mixin}`}",
+
+            TransformError::UnsupportedCssValue(_) =>
+                "Unsupported value for the 'css' prop. Only styles written in place apply: \
+                a css template, an atoms() call, those combined with ?:, && or ||, \
+                and the falsy values false, null and undefined.\n\
+                Combine several styles in one template instead of an array. \
+                Example: css={css`${first}; ${second};`}\n\
+                Write declarations in a template instead of an object. \
+                Example: css={css`color: red;`}",
 
             #[cfg(swc_ast_unknown)]
             TransformError::UnsupportedJSXAttrOrSpread() =>

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/input.tsx
@@ -1,0 +1,28 @@
+import { css } from "next-yak";
+
+const pad = css`
+  padding: 8px;
+`;
+
+// Arrays aren't supported
+const ArrayValue = () => <div css={[pad]} />;
+
+// Objects aren't supported
+const ObjectValue = () => <div css={{ color: "red" }} />;
+
+// Plain values aren't supported
+const StringValue = () => <div css={"color: red"} />;
+const NumberValue = () => <div css={42} />;
+const TemplateValue = () => <div css={`color: red`} />;
+const TrueValue = () => <div css={true} />;
+
+// Functions other than css or atoms aren't supported
+const FunctionValue = () => <div css={() => pad} />;
+
+// A call which is neither a css template nor atoms() isn't supported
+const CallValue = () => <div css={makeStyles()} />;
+
+// Invalid ternary arm is checked and not supported
+const TernaryArm = ({ on }: { on: boolean }) => <div css={on ? [pad] : undefined} />;
+
+declare function makeStyles(): any;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.dev.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.dev.stderr
@@ -1,0 +1,75 @@
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+   ,-[input.js:8:1]
+ 7 | // Arrays aren't supported
+ 8 | const ArrayValue = () => <div css={[pad]} />;
+   :                                    ^^^^^
+   `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:11:1]
+ 10 | // Objects aren't supported
+ 11 | const ObjectValue = () => <div css={{ color: "red" }} />;
+    :                                     ^^^^^^^^^^^^^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:14:1]
+ 13 | // Plain values aren't supported
+ 14 | const StringValue = () => <div css={"color: red"} />;
+    :                                     ^^^^^^^^^^^^
+ 15 | const NumberValue = () => <div css={42} />;
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:15:1]
+ 14 | const StringValue = () => <div css={"color: red"} />;
+ 15 | const NumberValue = () => <div css={42} />;
+    :                                     ^^
+ 16 | const TemplateValue = () => <div css={`color: red`} />;
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:16:1]
+ 15 | const NumberValue = () => <div css={42} />;
+ 16 | const TemplateValue = () => <div css={`color: red`} />;
+    :                                       ^^^^^^^^^^^^
+ 17 | const TrueValue = () => <div css={true} />;
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:17:1]
+ 16 | const TemplateValue = () => <div css={`color: red`} />;
+ 17 | const TrueValue = () => <div css={true} />;
+    :                                   ^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:20:1]
+ 19 | // Functions other than css or atoms aren't supported
+ 20 | const FunctionValue = () => <div css={() => pad} />;
+    :                                       ^^^^^^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:23:1]
+ 22 | // A call which is neither a css template nor atoms() isn't supported
+ 23 | const CallValue = () => <div css={makeStyles()} />;
+    :                                   ^^^^^^^^^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:26:1]
+ 25 | // Invalid ternary arm is checked and not supported
+ 26 | const TernaryArm = ({ on }: { on: boolean }) => <div css={on ? [pad] : undefined} />;
+    :                                                                ^^^^^
+    `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.dev.tsx
@@ -1,0 +1,26 @@
+import { css, __yak_mergeCssProp } from "next-yak/internal";
+const pad = /*#__PURE__*/ css();
+// Arrays aren't supported
+const ArrayValue = ()=><div css={[
+        pad
+    ]}/>;
+// Objects aren't supported
+const ObjectValue = ()=><div css={{
+        color: "red"
+    }}/>;
+// Plain values aren't supported
+const StringValue = ()=><div css={"color: red"}/>;
+const NumberValue = ()=><div css={42}/>;
+const TemplateValue = ()=><div css={`color: red`}/>;
+const TrueValue = ()=><div css={true}/>;
+// Functions other than css or atoms aren't supported
+const FunctionValue = ()=><div css={()=>pad}/>;
+// A call which is neither a css template nor atoms() isn't supported
+const CallValue = ()=><div css={makeStyles()}/>;
+// Invalid ternary arm is checked and not supported
+const TernaryArm = ({ on }: {
+    on: boolean;
+})=><div css={on ? [
+        pad
+    ] : undefined}/>;
+declare function makeStyles(): any;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.dev.tsx
@@ -1,4 +1,4 @@
-import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { css } from "next-yak/internal";
 const pad = /*#__PURE__*/ css();
 // Arrays aren't supported
 const ArrayValue = ()=><div css={[

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.prod.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.prod.stderr
@@ -1,0 +1,75 @@
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+   ,-[input.js:8:1]
+ 7 | // Arrays aren't supported
+ 8 | const ArrayValue = () => <div css={[pad]} />;
+   :                                    ^^^^^
+   `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:11:1]
+ 10 | // Objects aren't supported
+ 11 | const ObjectValue = () => <div css={{ color: "red" }} />;
+    :                                     ^^^^^^^^^^^^^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:14:1]
+ 13 | // Plain values aren't supported
+ 14 | const StringValue = () => <div css={"color: red"} />;
+    :                                     ^^^^^^^^^^^^
+ 15 | const NumberValue = () => <div css={42} />;
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:15:1]
+ 14 | const StringValue = () => <div css={"color: red"} />;
+ 15 | const NumberValue = () => <div css={42} />;
+    :                                     ^^
+ 16 | const TemplateValue = () => <div css={`color: red`} />;
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:16:1]
+ 15 | const NumberValue = () => <div css={42} />;
+ 16 | const TemplateValue = () => <div css={`color: red`} />;
+    :                                       ^^^^^^^^^^^^
+ 17 | const TrueValue = () => <div css={true} />;
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:17:1]
+ 16 | const TemplateValue = () => <div css={`color: red`} />;
+ 17 | const TrueValue = () => <div css={true} />;
+    :                                   ^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:20:1]
+ 19 | // Functions other than css or atoms aren't supported
+ 20 | const FunctionValue = () => <div css={() => pad} />;
+    :                                       ^^^^^^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:23:1]
+ 22 | // A call which is neither a css template nor atoms() isn't supported
+ 23 | const CallValue = () => <div css={makeStyles()} />;
+    :                                   ^^^^^^^^^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:26:1]
+ 25 | // Invalid ternary arm is checked and not supported
+ 26 | const TernaryArm = ({ on }: { on: boolean }) => <div css={on ? [pad] : undefined} />;
+    :                                                                ^^^^^
+    `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.prod.tsx
@@ -1,0 +1,26 @@
+import { css, __yak_mergeCssProp } from "next-yak/internal";
+const pad = /*#__PURE__*/ css();
+// Arrays aren't supported
+const ArrayValue = ()=><div css={[
+        pad
+    ]}/>;
+// Objects aren't supported
+const ObjectValue = ()=><div css={{
+        color: "red"
+    }}/>;
+// Plain values aren't supported
+const StringValue = ()=><div css={"color: red"}/>;
+const NumberValue = ()=><div css={42}/>;
+const TemplateValue = ()=><div css={`color: red`}/>;
+const TrueValue = ()=><div css={true}/>;
+// Functions other than css or atoms aren't supported
+const FunctionValue = ()=><div css={()=>pad}/>;
+// A call which is neither a css template nor atoms() isn't supported
+const CallValue = ()=><div css={makeStyles()}/>;
+// Invalid ternary arm is checked and not supported
+const TernaryArm = ({ on }: {
+    on: boolean;
+})=><div css={on ? [
+        pad
+    ] : undefined}/>;
+declare function makeStyles(): any;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.prod.tsx
@@ -1,4 +1,4 @@
-import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { css } from "next-yak/internal";
 const pad = /*#__PURE__*/ css();
 // Arrays aren't supported
 const ArrayValue = ()=><div css={[

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.turbo.dev.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.turbo.dev.stderr
@@ -1,0 +1,75 @@
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+   ,-[input.js:8:1]
+ 7 | // Arrays aren't supported
+ 8 | const ArrayValue = () => <div css={[pad]} />;
+   :                                    ^^^^^
+   `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:11:1]
+ 10 | // Objects aren't supported
+ 11 | const ObjectValue = () => <div css={{ color: "red" }} />;
+    :                                     ^^^^^^^^^^^^^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:14:1]
+ 13 | // Plain values aren't supported
+ 14 | const StringValue = () => <div css={"color: red"} />;
+    :                                     ^^^^^^^^^^^^
+ 15 | const NumberValue = () => <div css={42} />;
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:15:1]
+ 14 | const StringValue = () => <div css={"color: red"} />;
+ 15 | const NumberValue = () => <div css={42} />;
+    :                                     ^^
+ 16 | const TemplateValue = () => <div css={`color: red`} />;
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:16:1]
+ 15 | const NumberValue = () => <div css={42} />;
+ 16 | const TemplateValue = () => <div css={`color: red`} />;
+    :                                       ^^^^^^^^^^^^
+ 17 | const TrueValue = () => <div css={true} />;
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:17:1]
+ 16 | const TemplateValue = () => <div css={`color: red`} />;
+ 17 | const TrueValue = () => <div css={true} />;
+    :                                   ^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:20:1]
+ 19 | // Functions other than css or atoms aren't supported
+ 20 | const FunctionValue = () => <div css={() => pad} />;
+    :                                       ^^^^^^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:23:1]
+ 22 | // A call which is neither a css template nor atoms() isn't supported
+ 23 | const CallValue = () => <div css={makeStyles()} />;
+    :                                   ^^^^^^^^^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:26:1]
+ 25 | // Invalid ternary arm is checked and not supported
+ 26 | const TernaryArm = ({ on }: { on: boolean }) => <div css={on ? [pad] : undefined} />;
+    :                                                                ^^^^^
+    `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.turbo.dev.tsx
@@ -1,0 +1,26 @@
+import { css, __yak_mergeCssProp } from "next-yak/internal";
+const pad = /*#__PURE__*/ css();
+// Arrays aren't supported
+const ArrayValue = ()=><div css={[
+        pad
+    ]}/>;
+// Objects aren't supported
+const ObjectValue = ()=><div css={{
+        color: "red"
+    }}/>;
+// Plain values aren't supported
+const StringValue = ()=><div css={"color: red"}/>;
+const NumberValue = ()=><div css={42}/>;
+const TemplateValue = ()=><div css={`color: red`}/>;
+const TrueValue = ()=><div css={true}/>;
+// Functions other than css or atoms aren't supported
+const FunctionValue = ()=><div css={()=>pad}/>;
+// A call which is neither a css template nor atoms() isn't supported
+const CallValue = ()=><div css={makeStyles()}/>;
+// Invalid ternary arm is checked and not supported
+const TernaryArm = ({ on }: {
+    on: boolean;
+})=><div css={on ? [
+        pad
+    ] : undefined}/>;
+declare function makeStyles(): any;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.turbo.dev.tsx
@@ -1,4 +1,4 @@
-import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { css } from "next-yak/internal";
 const pad = /*#__PURE__*/ css();
 // Arrays aren't supported
 const ArrayValue = ()=><div css={[

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.turbo.prod.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.turbo.prod.stderr
@@ -1,0 +1,75 @@
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+   ,-[input.js:8:1]
+ 7 | // Arrays aren't supported
+ 8 | const ArrayValue = () => <div css={[pad]} />;
+   :                                    ^^^^^
+   `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:11:1]
+ 10 | // Objects aren't supported
+ 11 | const ObjectValue = () => <div css={{ color: "red" }} />;
+    :                                     ^^^^^^^^^^^^^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:14:1]
+ 13 | // Plain values aren't supported
+ 14 | const StringValue = () => <div css={"color: red"} />;
+    :                                     ^^^^^^^^^^^^
+ 15 | const NumberValue = () => <div css={42} />;
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:15:1]
+ 14 | const StringValue = () => <div css={"color: red"} />;
+ 15 | const NumberValue = () => <div css={42} />;
+    :                                     ^^
+ 16 | const TemplateValue = () => <div css={`color: red`} />;
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:16:1]
+ 15 | const NumberValue = () => <div css={42} />;
+ 16 | const TemplateValue = () => <div css={`color: red`} />;
+    :                                       ^^^^^^^^^^^^
+ 17 | const TrueValue = () => <div css={true} />;
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:17:1]
+ 16 | const TemplateValue = () => <div css={`color: red`} />;
+ 17 | const TrueValue = () => <div css={true} />;
+    :                                   ^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:20:1]
+ 19 | // Functions other than css or atoms aren't supported
+ 20 | const FunctionValue = () => <div css={() => pad} />;
+    :                                       ^^^^^^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:23:1]
+ 22 | // A call which is neither a css template nor atoms() isn't supported
+ 23 | const CallValue = () => <div css={makeStyles()} />;
+    :                                   ^^^^^^^^^^^^
+    `----
+  x Unsupported value for the 'css' prop. Only styles written in place apply: a css template, an atoms() call, those combined with ?:, && or ||, and the falsy values false, null and undefined.
+  | Combine several styles in one template instead of an array. Example: css={css`${first}; ${second};`}
+  | Write declarations in a template instead of an object. Example: css={css`color: red;`}
+    ,-[input.js:26:1]
+ 25 | // Invalid ternary arm is checked and not supported
+ 26 | const TernaryArm = ({ on }: { on: boolean }) => <div css={on ? [pad] : undefined} />;
+    :                                                                ^^^^^
+    `----

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.turbo.prod.tsx
@@ -1,0 +1,26 @@
+import { css, __yak_mergeCssProp } from "next-yak/internal";
+const pad = /*#__PURE__*/ css();
+// Arrays aren't supported
+const ArrayValue = ()=><div css={[
+        pad
+    ]}/>;
+// Objects aren't supported
+const ObjectValue = ()=><div css={{
+        color: "red"
+    }}/>;
+// Plain values aren't supported
+const StringValue = ()=><div css={"color: red"}/>;
+const NumberValue = ()=><div css={42}/>;
+const TemplateValue = ()=><div css={`color: red`}/>;
+const TrueValue = ()=><div css={true}/>;
+// Functions other than css or atoms aren't supported
+const FunctionValue = ()=><div css={()=>pad}/>;
+// A call which is neither a css template nor atoms() isn't supported
+const CallValue = ()=><div css={makeStyles()}/>;
+// Invalid ternary arm is checked and not supported
+const TernaryArm = ({ on }: {
+    on: boolean;
+})=><div css={on ? [
+        pad
+    ] : undefined}/>;
+declare function makeStyles(): any;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid-values/output.turbo.prod.tsx
@@ -1,4 +1,4 @@
-import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { css } from "next-yak/internal";
 const pad = /*#__PURE__*/ css();
 // Arrays aren't supported
 const ArrayValue = ()=><div css={[

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.dev.tsx
@@ -1,4 +1,4 @@
-import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { css } from "next-yak/internal";
 const styles = /*#__PURE__*/ css();
 const Elem = ()=><div css="invalid"/>;
 const Elem2 = (props: any)=><div css={props}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.prod.tsx
@@ -1,4 +1,4 @@
-import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { css } from "next-yak/internal";
 const styles = /*#__PURE__*/ css();
 const Elem = ()=><div css="invalid"/>;
 const Elem2 = (props: any)=><div css={props}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.dev.tsx
@@ -1,4 +1,4 @@
-import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { css } from "next-yak/internal";
 const styles = /*#__PURE__*/ css();
 const Elem = ()=><div css="invalid"/>;
 const Elem2 = (props: any)=><div css={props}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-invalid/output.turbo.prod.tsx
@@ -1,4 +1,4 @@
-import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { css } from "next-yak/internal";
 const styles = /*#__PURE__*/ css();
 const Elem = ()=><div css="invalid"/>;
 const Elem2 = (props: any)=><div css={props}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/input.tsx
@@ -12,3 +12,5 @@ const yakClass = css`
 // (see the css-prop-invalid fixture).
 const StringValue = () => <div css="their-class" />;
 const Reference = (props: { styles?: unknown }) => <div css={props.styles} />;
+const ArrayValue = (props: { styles?: unknown }) => <div css={[props.styles]} />;
+const ObjectValue = () => <div css={{ color: "red" }} />;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/input.tsx
@@ -6,6 +6,18 @@ const yakClass = css`
   color: blue;
 `;
 
+// A css prop next-yak owns is still compiled and merged with className and
+// style. Non-strict only changes what happens to a value it can not compile.
+const Merged = () => (
+  <div
+    css={css`
+      color: red;
+    `}
+    className="theirs"
+    style={{ padding: "5px" }}
+  />
+);
+
 // With strictCssProp off, a css prop value next-yak can't handle is left
 // untouched instead of failing the build - useful when another library on the
 // same element owns the css prop. Under the default strict mode these error

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.dev.tsx
@@ -10,3 +10,11 @@ const StringValue = ()=><div css="their-class"/>;
 const Reference = (props: {
     styles?: unknown;
 })=><div css={props.styles}/>;
+const ArrayValue = (props: {
+    styles?: unknown;
+})=><div css={[
+        props.styles
+    ]}/>;
+const ObjectValue = ()=><div css={{
+        color: "red"
+    }}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.dev.tsx
@@ -1,7 +1,20 @@
 import { css, __yak_mergeCssProp } from "next-yak/internal";
+import "./input.yak.module.css!=!./input?./input.yak.module.css";
 // A real yak style keeps the module recognized as using next-yak, so the css
 // prop below is still processed by the plugin.
 const yakClass = /*#__PURE__*/ css();
+// A css prop next-yak owns is still compiled and merged with className and
+// style. Non-strict only changes what happens to a value it can not compile.
+const Merged = ()=><div {...__yak_mergeCssProp({
+        className: "theirs",
+        style: {
+            padding: "5px"
+        }
+    }, /*YAK Extracted CSS:
+:global(.input_Merged_m7uBBu) {
+  color: red;
+}
+*/ /*#__PURE__*/ css("input_Merged_m7uBBu"))}/>;
 // With strictCssProp off, a css prop value next-yak can't handle is left
 // untouched instead of failing the build - useful when another library on the
 // same element owns the css prop. Under the default strict mode these error

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.prod.tsx
@@ -10,3 +10,11 @@ const StringValue = ()=><div css="their-class"/>;
 const Reference = (props: {
     styles?: unknown;
 })=><div css={props.styles}/>;
+const ArrayValue = (props: {
+    styles?: unknown;
+})=><div css={[
+        props.styles
+    ]}/>;
+const ObjectValue = ()=><div css={{
+        color: "red"
+    }}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.prod.tsx
@@ -1,7 +1,20 @@
 import { css, __yak_mergeCssProp } from "next-yak/internal";
+import "./input.yak.module.css!=!./input?./input.yak.module.css";
 // A real yak style keeps the module recognized as using next-yak, so the css
 // prop below is still processed by the plugin.
 const yakClass = /*#__PURE__*/ css();
+// A css prop next-yak owns is still compiled and merged with className and
+// style. Non-strict only changes what happens to a value it can not compile.
+const Merged = ()=><div {...__yak_mergeCssProp({
+        className: "theirs",
+        style: {
+            padding: "5px"
+        }
+    }, /*YAK Extracted CSS:
+:global(.ym7uBBu1) {
+  color: red;
+}
+*/ /*#__PURE__*/ css("ym7uBBu1"))}/>;
 // With strictCssProp off, a css prop value next-yak can't handle is left
 // untouched instead of failing the build - useful when another library on the
 // same element owns the css prop. Under the default strict mode these error

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.turbo.dev.tsx
@@ -10,3 +10,11 @@ const StringValue = ()=><div css="their-class"/>;
 const Reference = (props: {
     styles?: unknown;
 })=><div css={props.styles}/>;
+const ArrayValue = (props: {
+    styles?: unknown;
+})=><div css={[
+        props.styles
+    ]}/>;
+const ObjectValue = ()=><div css={{
+        color: "red"
+    }}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.turbo.dev.tsx
@@ -1,7 +1,20 @@
 import { css, __yak_mergeCssProp } from "next-yak/internal";
+import "data:text/css;base64,LmlucHV0X01lcmdlZF9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0=";
 // A real yak style keeps the module recognized as using next-yak, so the css
 // prop below is still processed by the plugin.
 const yakClass = /*#__PURE__*/ css();
+// A css prop next-yak owns is still compiled and merged with className and
+// style. Non-strict only changes what happens to a value it can not compile.
+const Merged = ()=><div {...__yak_mergeCssProp({
+        className: "theirs",
+        style: {
+            padding: "5px"
+        }
+    }, /*YAK Extracted CSS:
+.input_Merged_m7uBBu {
+  color: red;
+}
+*/ /*#__PURE__*/ css("input_Merged_m7uBBu"))}/>;
 // With strictCssProp off, a css prop value next-yak can't handle is left
 // untouched instead of failing the build - useful when another library on the
 // same element owns the css prop. Under the default strict mode these error

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.turbo.prod.tsx
@@ -10,3 +10,11 @@ const StringValue = ()=><div css="their-class"/>;
 const Reference = (props: {
     styles?: unknown;
 })=><div css={props.styles}/>;
+const ArrayValue = (props: {
+    styles?: unknown;
+})=><div css={[
+        props.styles
+    ]}/>;
+const ObjectValue = ()=><div css={{
+        color: "red"
+    }}/>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-non-strict/output.turbo.prod.tsx
@@ -1,7 +1,20 @@
 import { css, __yak_mergeCssProp } from "next-yak/internal";
+import "data:text/css;base64,LnltN3VCQnUxIHsKICBjb2xvcjogcmVkOwp9";
 // A real yak style keeps the module recognized as using next-yak, so the css
 // prop below is still processed by the plugin.
 const yakClass = /*#__PURE__*/ css();
+// A css prop next-yak owns is still compiled and merged with className and
+// style. Non-strict only changes what happens to a value it can not compile.
+const Merged = ()=><div {...__yak_mergeCssProp({
+        className: "theirs",
+        style: {
+            padding: "5px"
+        }
+    }, /*YAK Extracted CSS:
+.ym7uBBu1 {
+  color: red;
+}
+*/ /*#__PURE__*/ css("ym7uBBu1"))}/>;
 // With strictCssProp off, a css prop value next-yak can't handle is left
 // untouched instead of failing the build - useful when another library on the
 // same element owns the css prop. Under the default strict mode these error

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.dev.tsx
@@ -4,7 +4,7 @@
 // reference would render unstyled without any signal. Only the reference arm
 // errors - inline templates in ternary and logical arms keep working, covered
 // by css-prop-ternary and css-prop-fold-bailouts.
-import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { css } from "next-yak/internal";
 import { ellipsis } from "./typography";
 import * as tokens from "./tokens";
 import "./input.yak.module.css!=!./input?./input.yak.module.css";

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.prod.tsx
@@ -4,7 +4,7 @@
 // reference would render unstyled without any signal. Only the reference arm
 // errors - inline templates in ternary and logical arms keep working, covered
 // by css-prop-ternary and css-prop-fold-bailouts.
-import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { css } from "next-yak/internal";
 import { ellipsis } from "./typography";
 import * as tokens from "./tokens";
 import "./input.yak.module.css!=!./input?./input.yak.module.css";

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.turbo.dev.tsx
@@ -4,7 +4,7 @@
 // reference would render unstyled without any signal. Only the reference arm
 // errors - inline templates in ternary and logical arms keep working, covered
 // by css-prop-ternary and css-prop-fold-bailouts.
-import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { css } from "next-yak/internal";
 import { ellipsis } from "./typography";
 import * as tokens from "./tokens";
 import "data:text/css;base64,LmlucHV0X1Rlcm5hcnlBcm1fbTd1QkJ1IHsKICBjb2xvcjogYmx1ZTsKfQ==";

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-style-reference/output.turbo.prod.tsx
@@ -4,7 +4,7 @@
 // reference would render unstyled without any signal. Only the reference arm
 // errors - inline templates in ternary and logical arms keep working, covered
 // by css-prop-ternary and css-prop-fold-bailouts.
-import { css, __yak_mergeCssProp } from "next-yak/internal";
+import { css } from "next-yak/internal";
 import { ellipsis } from "./typography";
 import * as tokens from "./tokens";
 import "data:text/css;base64,LnltN3VCQnUxIHsKICBjb2xvcjogYmx1ZTsKfQ==";

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-with-atoms/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-with-atoms/input.tsx
@@ -24,6 +24,10 @@ const Elem7 = () => <div className="no-css" />;
 
 const Elem8 = () => <div css={atoms("empty-css")} className="empty-css" />;
 
+const Elem9 = ({ on }: { on: boolean }) => (
+  <div css={on ? atoms("orange") : undefined} />
+);
+
 const Text = styled.p`
   font-size: 20px;
 `;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-with-atoms/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-with-atoms/output.dev.tsx
@@ -27,6 +27,9 @@ const Elem7 = ()=><div className="no-css"/>;
 const Elem8 = ()=><div {...__yak_mergeCssProp({
         className: "empty-css"
     }, atoms("empty-css"))}/>;
+const Elem9 = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on ? atoms("orange") : undefined)}/>;
 const Text = /*YAK Extracted CSS:
 :global(.input_Text_m7uBBu) {
   font-size: 20px;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-with-atoms/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-with-atoms/output.prod.tsx
@@ -27,6 +27,9 @@ const Elem7 = ()=><div className="no-css"/>;
 const Elem8 = ()=><div {...__yak_mergeCssProp({
         className: "empty-css"
     }, atoms("empty-css"))}/>;
+const Elem9 = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on ? atoms("orange") : undefined)}/>;
 const Text = /*YAK Extracted CSS:
 :global(.ym7uBBu) {
   font-size: 20px;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-with-atoms/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-with-atoms/output.turbo.dev.tsx
@@ -27,6 +27,9 @@ const Elem7 = ()=><div className="no-css"/>;
 const Elem8 = ()=><div {...__yak_mergeCssProp({
         className: "empty-css"
     }, atoms("empty-css"))}/>;
+const Elem9 = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on ? atoms("orange") : undefined)}/>;
 const Text = /*YAK Extracted CSS:
 .input_Text_m7uBBu {
   font-size: 20px;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop-with-atoms/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop-with-atoms/output.turbo.prod.tsx
@@ -27,6 +27,9 @@ const Elem7 = ()=><div className="no-css"/>;
 const Elem8 = ()=><div {...__yak_mergeCssProp({
         className: "empty-css"
     }, atoms("empty-css"))}/>;
+const Elem9 = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on ? atoms("orange") : undefined)}/>;
 const Text = /*YAK Extracted CSS:
 .ym7uBBu {
   font-size: 20px;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/input.tsx
@@ -117,6 +117,29 @@ const Elem11 = ({ on }: { on: boolean }) => (
   />
 );
 
+const Elem12 = ({ on }: { on: boolean }) => (
+  <div
+    css={
+      on &&
+      css`
+        color: brown;
+      `
+    }
+  />
+);
+
+const Elem13 = ({ on }: { on: boolean }) => (
+  <div
+    css={
+      on
+        ? css`
+            color: teal;
+          `
+        : null
+    }
+  />
+);
+
 const Text = styled.p`
   font-size: 20px;
 `;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.dev.tsx
@@ -92,6 +92,20 @@ const Elem11 = ({ on }: {
   color: blue;
 }
 */ /*#__PURE__*/ css("input_Elem11_m7uBBu-01"))}/>;
+const Elem12 = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on && /*YAK Extracted CSS:
+:global(.input_Elem12_m7uBBu) {
+  color: brown;
+}
+*/ /*#__PURE__*/ css("input_Elem12_m7uBBu"))}/>;
+const Elem13 = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on ? /*YAK Extracted CSS:
+:global(.input_Elem13_m7uBBu) {
+  color: teal;
+}
+*/ /*#__PURE__*/ css("input_Elem13_m7uBBu") : null)}/>;
 const Text = /*YAK Extracted CSS:
 :global(.input_Text_m7uBBu) {
   font-size: 20px;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.prod.tsx
@@ -92,15 +92,29 @@ const Elem11 = ({ on }: {
   color: blue;
 }
 */ /*#__PURE__*/ css("ym7uBBuF"))}/>;
-const Text = /*YAK Extracted CSS:
+const Elem12 = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on && /*YAK Extracted CSS:
 :global(.ym7uBBuG) {
+  color: brown;
+}
+*/ /*#__PURE__*/ css("ym7uBBuG"))}/>;
+const Elem13 = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on ? /*YAK Extracted CSS:
+:global(.ym7uBBuH) {
+  color: teal;
+}
+*/ /*#__PURE__*/ css("ym7uBBuH") : null)}/>;
+const Text = /*YAK Extracted CSS:
+:global(.ym7uBBuI) {
   font-size: 20px;
 }
-*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuG");
+*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuI");
 const StyledComponentWithCSSProp = ()=><Text {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
-:global(.ym7uBBuH) {
+:global(.ym7uBBuJ) {
   color: red;
 }
-*/ /*#__PURE__*/ css("ym7uBBuH"))}>
+*/ /*#__PURE__*/ css("ym7uBBuJ"))}>
     test
   </Text>;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.turbo.dev.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.turbo.dev.tsx
@@ -1,6 +1,6 @@
 import { css, styled, __yak_mergeCssProp } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LmlucHV0X0VsZW1fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0VsZW0yX203dUJCdSB7CiAgY29sb3I6IGJsdWU7Cn0uaW5wdXRfRWxlbTNfbTd1QkJ1IHsKICBwYWRkaW5nOiAxMHB4Owp9LmlucHV0X0VsZW00X203dUJCdSB7CiAgY29sb3I6IGdyZWVuOwp9LmlucHV0X0VsZW01X203dUJCdSB7CiAgY29sb3I6IHB1cnBsZTsKfS5pbnB1dF9FbGVtNl9tN3VCQnUgewogIGZvbnQtc2l6ZTogMTZweDsKfS5pbnB1dF9FbGVtRW50aXR5X203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9FbGVtQmFja3NsYXNoX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9FbGVtRW1vamlfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0VsZW0xMF9fb25fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9Ci5pbnB1dF9FbGVtMTBfX25vdF9vbl9tN3VCQnUgewogIGNvbG9yOiBibHVlOwp9LmlucHV0X0VsZW0xMV9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfRWxlbTExX203dUJCdS0wMSB7CiAgY29sb3I6IGJsdWU7Cn0uaW5wdXRfVGV4dF9tN3VCQnUgewogIGZvbnQtc2l6ZTogMjBweDsKfS5pbnB1dF9TdHlsZWRDb21wb25lbnRXaXRoQ1NTUHJvcF9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0=";
+import "data:text/css;base64,LmlucHV0X0VsZW1fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0VsZW0yX203dUJCdSB7CiAgY29sb3I6IGJsdWU7Cn0uaW5wdXRfRWxlbTNfbTd1QkJ1IHsKICBwYWRkaW5nOiAxMHB4Owp9LmlucHV0X0VsZW00X203dUJCdSB7CiAgY29sb3I6IGdyZWVuOwp9LmlucHV0X0VsZW01X203dUJCdSB7CiAgY29sb3I6IHB1cnBsZTsKfS5pbnB1dF9FbGVtNl9tN3VCQnUgewogIGZvbnQtc2l6ZTogMTZweDsKfS5pbnB1dF9FbGVtRW50aXR5X203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9FbGVtQmFja3NsYXNoX203dUJCdSB7CiAgY29sb3I6IHJlZDsKfS5pbnB1dF9FbGVtRW1vamlfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9LmlucHV0X0VsZW0xMF9fb25fbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9Ci5pbnB1dF9FbGVtMTBfX25vdF9vbl9tN3VCQnUgewogIGNvbG9yOiBibHVlOwp9LmlucHV0X0VsZW0xMV9tN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0uaW5wdXRfRWxlbTExX203dUJCdS0wMSB7CiAgY29sb3I6IGJsdWU7Cn0uaW5wdXRfRWxlbTEyX203dUJCdSB7CiAgY29sb3I6IGJyb3duOwp9LmlucHV0X0VsZW0xM19tN3VCQnUgewogIGNvbG9yOiB0ZWFsOwp9LmlucHV0X1RleHRfbTd1QkJ1IHsKICBmb250LXNpemU6IDIwcHg7Cn0uaW5wdXRfU3R5bGVkQ29tcG9uZW50V2l0aENTU1Byb3BfbTd1QkJ1IHsKICBjb2xvcjogcmVkOwp9";
 const Elem = ()=><div {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
 .input_Elem_m7uBBu {
   color: red;
@@ -92,6 +92,20 @@ const Elem11 = ({ on }: {
   color: blue;
 }
 */ /*#__PURE__*/ css("input_Elem11_m7uBBu-01"))}/>;
+const Elem12 = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on && /*YAK Extracted CSS:
+.input_Elem12_m7uBBu {
+  color: brown;
+}
+*/ /*#__PURE__*/ css("input_Elem12_m7uBBu"))}/>;
+const Elem13 = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on ? /*YAK Extracted CSS:
+.input_Elem13_m7uBBu {
+  color: teal;
+}
+*/ /*#__PURE__*/ css("input_Elem13_m7uBBu") : null)}/>;
 const Text = /*YAK Extracted CSS:
 .input_Text_m7uBBu {
   font-size: 20px;

--- a/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.turbo.prod.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-prop/output.turbo.prod.tsx
@@ -1,6 +1,6 @@
 import { css, styled, __yak_mergeCssProp } from "next-yak/internal";
 import * as __yak from "next-yak/internal";
-import "data:text/css;base64,LnltN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdTEgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnUyIHsKICBwYWRkaW5nOiAxMHB4Owp9LnltN3VCQnUzIHsKICBjb2xvcjogZ3JlZW47Cn0ueW03dUJCdTQgewogIGNvbG9yOiBwdXJwbGU7Cn0ueW03dUJCdTUgewogIGZvbnQtc2l6ZTogMTZweDsKfS55bTd1QkJ1NiB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1NyB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1OCB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1QyB7CiAgY29sb3I6IHJlZDsKfQoueW03dUJCdUQgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnVFIHsKICBjb2xvcjogcmVkOwp9LnltN3VCQnVGIHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1RyB7CiAgZm9udC1zaXplOiAyMHB4Owp9LnltN3VCQnVIIHsKICBjb2xvcjogcmVkOwp9";
+import "data:text/css;base64,LnltN3VCQnUgewogIGNvbG9yOiByZWQ7Cn0ueW03dUJCdTEgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnUyIHsKICBwYWRkaW5nOiAxMHB4Owp9LnltN3VCQnUzIHsKICBjb2xvcjogZ3JlZW47Cn0ueW03dUJCdTQgewogIGNvbG9yOiBwdXJwbGU7Cn0ueW03dUJCdTUgewogIGZvbnQtc2l6ZTogMTZweDsKfS55bTd1QkJ1NiB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1NyB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1OCB7CiAgY29sb3I6IHJlZDsKfS55bTd1QkJ1QyB7CiAgY29sb3I6IHJlZDsKfQoueW03dUJCdUQgewogIGNvbG9yOiBibHVlOwp9LnltN3VCQnVFIHsKICBjb2xvcjogcmVkOwp9LnltN3VCQnVGIHsKICBjb2xvcjogYmx1ZTsKfS55bTd1QkJ1RyB7CiAgY29sb3I6IGJyb3duOwp9LnltN3VCQnVIIHsKICBjb2xvcjogdGVhbDsKfS55bTd1QkJ1SSB7CiAgZm9udC1zaXplOiAyMHB4Owp9LnltN3VCQnVKIHsKICBjb2xvcjogcmVkOwp9";
 const Elem = ()=><div {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
 .ym7uBBu {
   color: red;
@@ -92,15 +92,29 @@ const Elem11 = ({ on }: {
   color: blue;
 }
 */ /*#__PURE__*/ css("ym7uBBuF"))}/>;
-const Text = /*YAK Extracted CSS:
+const Elem12 = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on && /*YAK Extracted CSS:
 .ym7uBBuG {
+  color: brown;
+}
+*/ /*#__PURE__*/ css("ym7uBBuG"))}/>;
+const Elem13 = ({ on }: {
+    on: boolean;
+})=><div {...__yak_mergeCssProp({}, on ? /*YAK Extracted CSS:
+.ym7uBBuH {
+  color: teal;
+}
+*/ /*#__PURE__*/ css("ym7uBBuH") : null)}/>;
+const Text = /*YAK Extracted CSS:
+.ym7uBBuI {
   font-size: 20px;
 }
-*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuG");
+*/ /*#__PURE__*/ __yak.__yak_p("ym7uBBuI");
 const StyledComponentWithCSSProp = ()=><Text {...__yak_mergeCssProp({}, /*YAK Extracted CSS:
-.ym7uBBuH {
+.ym7uBBuJ {
   color: red;
 }
-*/ /*#__PURE__*/ css("ym7uBBuH"))}>
+*/ /*#__PURE__*/ css("ym7uBBuJ"))}>
     test
   </Text>;


### PR DESCRIPTION
Closes: #635

When `strictCssProp` (default: `true`) is enabled, we check the values that are passed now more thoroughly. The SWC plugin checks if only a valid function e.g. `css` or `atoms` or a logical combination thereof is used.

For cases where static analysis can't reach (e.g. spreading) we throw an error during runtime in DEV if we encounter any wrongly passed values.