### PR TITLE
Fix JSX parsing in turbopack

### DIFF
--- a/.changeset/early-ducks-create.md
+++ b/.changeset/early-ducks-create.md
@@ -1,0 +1,5 @@
+---
+"next-yak": patch
+---
+
+Fix parsing of `.jsx`, `.js`, `.mjs` and `.cjs` files with Turbopack and Rsbuild

--- a/packages/next-yak/loaders/lib/__tests__/swcParserOptions.test.ts
+++ b/packages/next-yak/loaders/lib/__tests__/swcParserOptions.test.ts
@@ -1,0 +1,53 @@
+import { transform } from "@swc/core";
+import { describe, expect, it } from "vitest";
+import { getSwcParserOptions } from "../swcParserOptions.js";
+
+describe("swc parses every extension of the yak loader rule", () => {
+  const jsxSource = `import { styled } from "next-yak";
+const Container = styled.div\`display: flex;\`;
+export default function Component() {
+  return <Container>Hello</Container>;
+}`;
+  const typeScriptSource = `import { styled } from "next-yak";
+export const gap: Array<number> = [1];
+export const Container = styled.div\`gap: \${gap[0]}px;\`;`;
+
+  it.each(
+    Object.entries({
+      "a.js": jsxSource,
+      "a.jsx": jsxSource,
+      "a.mjs": jsxSource,
+      "a.cjs": jsxSource,
+      "a.tsx": typeScriptSource + jsxSource.replace(/^import .*\n/, ""),
+      "a.ts": typeScriptSource,
+      "a.mts": typeScriptSource,
+      "a.cts": typeScriptSource,
+    }),
+  )("parses %s", async (file, code) => {
+    const filename = `/app/${file}`;
+    const result = await transform(code, {
+      filename,
+      jsc: {
+        parser: getSwcParserOptions(filename),
+        target: "es2022",
+        transform: { react: { runtime: "preserve" } },
+      },
+      isModule: true,
+    });
+    expect(result.code).toContain("styled.div");
+  });
+
+  it("keeps import attributes", async () => {
+    const source = `import data from "./data.json" with { type: "json" };\nexport default data;`;
+    const result = await transform(source, {
+      filename: "/app/a.ts",
+      jsc: {
+        parser: getSwcParserOptions("/app/a.ts"),
+        target: "es2022",
+        experimental: { keepImportAttributes: true },
+      },
+      isModule: true,
+    });
+    expect(result.code).toContain(`type: "json"`);
+  });
+});

--- a/packages/next-yak/loaders/lib/swcParserOptions.ts
+++ b/packages/next-yak/loaders/lib/swcParserOptions.ts
@@ -6,8 +6,8 @@ const typeScriptWithJsx = /\.tsx$/;
 /**
  * Derive the SWC parser configuration for a single file.
  *
- * JSX is enabled everywhere except in `.ts`, `.mts` and `.cts`,
- * where angle brackets are type assertions and generics rather than elements.
+ * JSX is not allowed in `.ts`, `.mts` and `.cts`
+ * therefore we must parse these as pure TS/JS and must not return JSX
  *
  * This is inspired by next.js own handling.
  */

--- a/packages/next-yak/loaders/lib/swcParserOptions.ts
+++ b/packages/next-yak/loaders/lib/swcParserOptions.ts
@@ -1,0 +1,24 @@
+import type { ParserConfig } from "@swc/core";
+
+const typeScriptWithoutJsx = /\.[mc]?ts$/;
+const typeScriptWithJsx = /\.tsx$/;
+
+/**
+ * Derive the SWC parser configuration for a single file.
+ *
+ * JSX is enabled everywhere except in `.ts`, `.mts` and `.cts`,
+ * where angle brackets are type assertions and generics rather than elements.
+ *
+ * This is inspired by next.js own handling.
+ */
+export function getSwcParserOptions(filename: string): ParserConfig {
+  // module ids may carry a query string (`/a/b.ts?v=1`)
+  const [path] = filename.split("?");
+  if (typeScriptWithoutJsx.test(path)) {
+    return { syntax: "typescript", tsx: false, dynamicImport: true };
+  }
+  if (typeScriptWithJsx.test(path)) {
+    return { syntax: "typescript", tsx: true, dynamicImport: true };
+  }
+  return { syntax: "ecmascript", jsx: true, dynamicImport: true };
+}

--- a/packages/next-yak/loaders/turbo-loader.ts
+++ b/packages/next-yak/loaders/turbo-loader.ts
@@ -8,6 +8,7 @@ import type { YakConfigOptions } from "../withYak/index.js";
 import { createDebugLogger } from "./lib/debugLogger.js";
 import { extractCss } from "./lib/extractCss.js";
 import { parseExports } from "./lib/resolveCrossFileSelectors.js";
+import { getSwcParserOptions } from "./lib/swcParserOptions.js";
 
 const universalRequire = typeof require === "undefined" ? createRequire(import.meta.url) : require;
 const yakSwcPluginPath = universalRequire.resolve("yak-swc");
@@ -140,7 +141,11 @@ function createTransform(yakPluginOptions: any, yakSwcPluginPath: string) {
       sourceFileName: modulePath,
       sourceRoot: rootPath,
       jsc: {
+        // Derive the parser from the file name the same way Next.js does
+        parser: getSwcParserOptions(modulePath),
         experimental: {
+          // Keep `import data from "./data.json" with { type: "json" }` intact
+          keepImportAttributes: true,
           plugins: [[yakSwcPluginPath, yakPluginOptions]],
         },
         transform: {

--- a/packages/next-yak/loaders/vite-plugin.ts
+++ b/packages/next-yak/loaders/vite-plugin.ts
@@ -1,4 +1,4 @@
-import { Options, transform as swcTransform } from "@swc/core";
+import { type JscConfig, Options, transform as swcTransform } from "@swc/core";
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, relative, resolve } from "node:path";
@@ -10,6 +10,7 @@ import { resolveYakContext, YakConfigOptions } from "../withYak/index.js";
 import { createDebugLogger } from "./lib/debugLogger.js";
 import { extractCss } from "./lib/extractCss.js";
 import { parseExports } from "./lib/resolveCrossFileSelectors.js";
+import { getSwcParserOptions } from "./lib/swcParserOptions.js";
 const require = createRequire(import.meta.url);
 
 type ViteYakPluginOptions = YakConfigOptions & {
@@ -21,20 +22,27 @@ type ViteYakPluginOptions = YakConfigOptions & {
    * @defaultValue Vite's resolved `root`
    */
   basePath?: string;
-  swcOptions?: Omit<
-    Options,
-    "filename" | "sourceFileName" | "inputSourceMap" | "sourceMaps" | "sourceRoot"
-  >;
+  /**
+   * Overrides for the SWC pass which runs the yak transform.
+   */
+  swcOptions?: SwcOverrides;
+};
+
+/**
+ * Everything of the SWC options which is not owned by the yak transform
+ * (current file being compiled and plugins can't be overridden)
+ */
+type SwcOverrides = Omit<
+  Options,
+  "filename" | "sourceFileName" | "inputSourceMap" | "sourceMaps" | "sourceRoot" | "jsc"
+> & {
+  jsc?: Omit<JscConfig, "experimental"> & {
+    experimental?: Omit<NonNullable<JscConfig["experimental"]>, "plugins">;
+  };
 };
 
 const defaultSwcOptions: ViteYakPluginOptions["swcOptions"] = {
   jsc: {
-    parser: {
-      syntax: "typescript",
-      tsx: true,
-      decorators: false,
-      dynamicImport: true,
-    },
     transform: {
       react: {
         runtime: "preserve",
@@ -290,8 +298,13 @@ function transform(
     sourceRoot: rootPath,
     ...yakOptions.swcOptions,
     jsc: {
+      // Derive the parser from the file name, unless the user configured one
+      parser: getSwcParserOptions(modulePath),
       ...yakOptions.swcOptions?.jsc,
       experimental: {
+        // Keep `import data from "./data.json" with { type: "json" }` intact
+        keepImportAttributes: true,
+        ...yakOptions.swcOptions?.jsc?.experimental,
         plugins: [
           [
             yakSwcPath,


### PR DESCRIPTION
Closes: #638

The Turbopack loader ran SWC without a parser config, so `.js`, `.jsx`, `.mjs` and `.cjs` files containing JSX failed to parse. The Vite plugin had the opposite problem and always parsed as TSX regardless of the extension.

This adds a small shared helper that derives the SWC parser options from the file extension, mirroring how `next.js` handles it, and wires it into both loaders. Import attributes (`with { type: "json" }`) are now preserved through the transform as well.