### PR TITLE
Check the e2e case layout

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -106,8 +106,9 @@ file. Variants therefore import siblings by their unmarked names, and the
 shared `index.test.ts` needs no changes. Tests can branch on
 `testEnv.framework` when the frameworks behave differently.
 
-A case without an `index.tsx` is exclusive to the framework of its variants:
-React bundlers skip it. Helper files in such a case need no `.solid.` marker.
+Every case has an `index.tsx`, an `index.test.ts`, and a React twin for each
+`.solid.` variant; `checkCaseLayout.ts` checks that layout when the runner
+starts, so a case cannot run on one framework only by accident.
 
 ## Adding a test case
 

--- a/e2e/checkCaseLayout.ts
+++ b/e2e/checkCaseLayout.ts
@@ -1,0 +1,55 @@
+/**
+ * Every e2e case follows one layout, so the runner's file discovery
+ * (copyCase in e2eEnvironment.ts, which only knows the `.solid.` marker) sees
+ * what the author meant:
+ *
+ *   cases/<case>/index.tsx          the React case, required
+ *   cases/<case>/index.test.ts      the shared test, required
+ *   cases/<case>/<name>.solid.<ext> a Solid variant of <name>.<ext>, which must exist
+ *
+ * A Solid variant replaces its React twin during assembly, so a variant
+ * without a twin would run on Solid only and never on React. Any other
+ * framework marker in a file name is a typo the runner would silently ship
+ * to every bundler.
+ */
+
+import { existsSync, globSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+const casesDir = join(import.meta.dirname, "cases");
+
+/** Exits with one line per problem; silent when the layout is right */
+export function checkCaseLayout(): void {
+  const problems: string[] = [];
+
+  for (const dir of globSync("*/", { cwd: casesDir })) {
+    for (const required of ["index.tsx", "index.test.ts"]) {
+      if (!existsSync(join(casesDir, dir, required))) problems.push(`${dir}: missing ${required}`);
+    }
+  }
+
+  for (const file of globSync("**/*.*.*", { cwd: casesDir })) {
+    const name = basename(file);
+    const markers = name
+      .split(".")
+      .slice(1, -1)
+      .filter((part) => /^[a-z]+$/.test(part));
+    for (const marker of markers) {
+      if (marker === "solid") {
+        const twin = join(dirname(file), name.replace(".solid.", "."));
+        if (!existsSync(join(casesDir, twin))) {
+          problems.push(`${file}: no React twin ${basename(twin)}`);
+        }
+      } else if (marker !== "test" && marker !== "yak") {
+        problems.push(
+          `${file}: unknown marker ".${marker}." (only ".solid." is a framework variant)`,
+        );
+      }
+    }
+  }
+
+  if (problems.length > 0) {
+    console.error("e2e case layout:\n" + problems.map((line) => `  ${line}`).join("\n"));
+    process.exit(1);
+  }
+}

--- a/e2e/runBuildTests.ts
+++ b/e2e/runBuildTests.ts
@@ -14,7 +14,9 @@ import {
   runBundlerCases,
   printSummary,
 } from "./e2eEnvironment.ts";
+import { checkCaseLayout } from "./checkCaseLayout.ts";
 
+checkCaseLayout();
 const discoveredBundlers = await discoverBundlers();
 const allCases = await discoverCases();
 const { bundlers, cases } = parseCLIArgs(discoveredBundlers, allCases);

--- a/e2e/runDevTests.ts
+++ b/e2e/runDevTests.ts
@@ -11,7 +11,9 @@ import {
   runBundlerCases,
   printSummary,
 } from "./e2eEnvironment.ts";
+import { checkCaseLayout } from "./checkCaseLayout.ts";
 
+checkCaseLayout();
 const discoveredBundlers = await discoverBundlers();
 const allCases = await discoverCases();
 const { bundlers, cases } = parseCLIArgs(discoveredBundlers, allCases);


### PR DESCRIPTION
Stacked on #645. One script, `scripts/e2e-exists.mjs`, pins the layout every e2e case follows:

```
e2e/cases/<case>/index.tsx          the React case, required
e2e/cases/<case>/index.test.ts      the shared test, required
e2e/cases/<case>/<name>.solid.<ext> a Solid variant of <name>.<ext>, which must exist
```

A Solid variant replaces its React twin during assembly, so a variant without a twin would run on Solid only and never on React. Any other framework marker in a file name (`index.react.tsx`) is a typo the runner would silently ship to every bundler; the script rejects it. It uses Node's own `fs.globSync`, runs before `runDevTests.ts` and `runBuildTests.ts` start and as part of `pnpm lint`, and prints one line per problem. Changing the layout on purpose means changing this script, so it does not drift by accident.

The runtime PR #644 is rebased on top of this and gains the React twins its `reactive-props` case was missing.
